### PR TITLE
sale_order_partial_invoice - Some fixes and enhancements:

### DIFF
--- a/sale_order_partial_invoice/i18n/es.po
+++ b/sale_order_partial_invoice/i18n/es.po
@@ -6,108 +6,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 7.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-02-08 14:15+0000\n"
-"PO-Revision-Date: 2014-03-07 14:21+0000\n"
-"Last-Translator: Pedro Manuel Baeza <pedro.baeza@gmail.com>\n"
+"POT-Creation-Date: 2014-08-16 11:10+0000\n"
+"PO-Revision-Date: 2014-08-16 11:10+0000\n"
+"Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2014-03-21 06:54+0000\n"
-"X-Generator: Launchpad (build 16967)\n"
-
-#. module: sale_order_partial_invoice
-#: model:ir.model,name:sale_order_partial_invoice.model_sale_order_line_invoice_partially_line
-msgid "sale.order.line.invoice.partially.line"
-msgstr "Línea de pedido de venta para facturaración parcial"
-
-#. module: sale_order_partial_invoice
-#: field:sale.order.line.invoice.partially.line,wizard_id:0
-msgid "Wizard"
-msgstr "Asistente"
-
-#. module: sale_order_partial_invoice
-#: view:sale.order.line.invoice.partially:0
-msgid "Create Invoice"
-msgstr "Crear factura"
-
-#. module: sale_order_partial_invoice
-#: model:ir.model,name:sale_order_partial_invoice.model_sale_advance_payment_inv
-msgid "Sales Advance Payment Invoice"
-msgstr "Factura de pago adelantado de ventas"
-
-#. module: sale_order_partial_invoice
-#: field:sale.order.line,qty_delivered:0
-#: field:sale.order.line,qty_invoiced:0
-msgid "Invoiced Quantity"
-msgstr "Cantidad facturada"
-
-#. module: sale_order_partial_invoice
-#: field:sale.order.line.invoice.partially.line,order_qty:0
-msgid "Sold"
-msgstr "Vendido"
-
-#. module: sale_order_partial_invoice
-#: field:sale.order.line.invoice.partially.line,name:0
-msgid "Line"
-msgstr "Líneas"
-
-#. module: sale_order_partial_invoice
-#: field:sale.order.line.invoice.partially.line,quantity:0
-msgid "To invoice"
-msgstr "A facturar"
-
-#. module: sale_order_partial_invoice
-#: view:sale.order.line.invoice.partially:0
-msgid "Invoice lines"
-msgstr "Líneas de factura"
-
-#. module: sale_order_partial_invoice
-#: view:sale.order.line:0
-msgid "Inv. Qty"
-msgstr "Cant. facturada"
-
-#. module: sale_order_partial_invoice
-#: view:sale.order.line:0
-msgid "Shipped Qty"
-msgstr "Cant. enviada"
-
-#. module: sale_order_partial_invoice
-#: field:sale.order.line.invoice.partially,name:0
-msgid "Name"
-msgstr "Nombre"
-
-#. module: sale_order_partial_invoice
-#: model:ir.model,name:sale_order_partial_invoice.model_sale_order_line_invoice_partially
-msgid "sale.order.line.invoice.partially"
-msgstr "Pedido de venta para facturación parcial"
-
-#. module: sale_order_partial_invoice
-#: view:sale.order.line.invoice.partially:0
-#: field:sale.order.line.invoice.partially,line_ids:0
-msgid "Lines"
-msgstr "Líneas"
-
-#. module: sale_order_partial_invoice
-#: field:sale.order.line.invoice.partially.line,qty_delivered:0
-msgid "Shipped"
-msgstr "Enviada"
-
-#. module: sale_order_partial_invoice
-#: help:sale.order.line,qty_delivered:0
-#: help:sale.order.line,qty_invoiced:0
-msgid "the quantity of product from this line already invoiced"
-msgstr "la cantidad de producto de esta línea ya facturada"
-
-#. module: sale_order_partial_invoice
-#: view:sale.order.line.invoice.partially:0
-msgid "Invoice Sale Order Lines"
-msgstr "Facturar líneas de pedido de ventas"
-
-#. module: sale_order_partial_invoice
-#: field:sale.order.line.invoice.partially.line,sale_order_line_id:0
-msgid "sale.order.line"
-msgstr "Línea de pedido de venta"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
 
 #. module: sale_order_partial_invoice
 #: view:sale.order.line.invoice.partially:0
@@ -116,15 +22,128 @@ msgstr "Cancelar"
 
 #. module: sale_order_partial_invoice
 #: view:sale.order.line.invoice.partially:0
-msgid "or"
-msgstr "o"
+msgid "Create Invoice"
+msgstr "Crear factura"
 
 #. module: sale_order_partial_invoice
-#: model:ir.model,name:sale_order_partial_invoice.model_sale_order_line
-msgid "Sales Order Line"
-msgstr "Línea de pedido de venta"
+#: code:addons/sale_order_partial_invoice/sale.py:242
+#, python-format
+msgid "Created invoice %d"
+msgstr "Factura %d creada"
+
+#. module: sale_order_partial_invoice
+#: view:sale.order.line:0
+msgid "Inv. Qty"
+msgstr "Cant. facturada"
+
+#. module: sale_order_partial_invoice
+#: view:sale.order.line.invoice.partially:0
+msgid "Invoice Sale Order Lines"
+msgstr "Facturar líneas de pedido de ventas"
+
+#. module: sale_order_partial_invoice
+#: view:sale.order.line.invoice.partially:0
+msgid "Invoice lines"
+msgstr "Líneas de factura"
 
 #. module: sale_order_partial_invoice
 #: field:sale.order.line.invoice.partially.line,qty_invoiced:0
 msgid "Invoiced"
-msgstr "Facturada"
+msgstr "Facturado"
+
+#. module: sale_order_partial_invoice
+#: field:sale.order.line,qty_delivered:0
+#: field:sale.order.line,qty_invoiced:0
+msgid "Invoiced Quantity"
+msgstr "Cantidad facturada"
+
+#. module: sale_order_partial_invoice
+#: field:sale.order.line.invoice.partially.line,name:0
+msgid "Line"
+msgstr "Líneas"
+
+#. module: sale_order_partial_invoice
+#: view:sale.order.line.invoice.partially:0
+#: field:sale.order.line.invoice.partially,line_ids:0
+msgid "Lines"
+msgstr "Líneas"
+
+#. module: sale_order_partial_invoice
+#: field:sale.order.line.invoice.partially,name:0
+msgid "Name"
+msgstr "Nombre"
+
+#. module: sale_order_partial_invoice
+#: constraint:sale.order.line.invoice.partially.line:0
+msgid "Quantity to invoice couldn't be greater than remaining quantity"
+msgstr "La cantidad a facturar no puede ser mayor que la cantidad restante"
+
+#. module: sale_order_partial_invoice
+#: code:_description:0
+#: model:ir.model,name:sale_order_partial_invoice.model_sale_advance_payment_inv
+#, python-format
+msgid "Sales Advance Payment Invoice"
+msgstr "Ventas. Anticipo pago factura"
+
+#. module: sale_order_partial_invoice
+#: code:_description:0
+#: model:ir.model,name:sale_order_partial_invoice.model_sale_order_line
+#, python-format
+msgid "Sales Order Line"
+msgstr "Línea de pedido de venta"
+
+#. module: sale_order_partial_invoice
+#: field:sale.order.line.invoice.partially.line,qty_delivered:0
+msgid "Shipped"
+msgstr "Enviado"
+
+#. module: sale_order_partial_invoice
+#: view:sale.order.line:0
+msgid "Shipped Qty"
+msgstr "Cant. enviada"
+
+#. module: sale_order_partial_invoice
+#: field:sale.order.line.invoice.partially.line,order_qty:0
+msgid "Sold"
+msgstr "Vendido"
+
+#. module: sale_order_partial_invoice
+#: field:sale.order.line.invoice.partially.line,quantity:0
+msgid "To invoice"
+msgstr "A facturar"
+
+#. module: sale_order_partial_invoice
+#: field:sale.order.line.invoice.partially.line,wizard_id:0
+msgid "Wizard"
+msgstr "Asistente"
+
+#. module: sale_order_partial_invoice
+#: view:sale.order.line.invoice.partially:0
+msgid "or"
+msgstr "o"
+
+#. module: sale_order_partial_invoice
+#: field:sale.order.line.invoice.partially.line,sale_order_line_id:0
+msgid "sale.order.line"
+msgstr "Línea de pedido de venta"
+
+#. module: sale_order_partial_invoice
+#: code:_description:0
+#: model:ir.model,name:sale_order_partial_invoice.model_sale_order_line_invoice_partially
+#, python-format
+msgid "sale.order.line.invoice.partially"
+msgstr "Pedido de venta para facturación parcial"
+
+#. module: sale_order_partial_invoice
+#: code:_description:0
+#: model:ir.model,name:sale_order_partial_invoice.model_sale_order_line_invoice_partially_line
+#, python-format
+msgid "sale.order.line.invoice.partially.line"
+msgstr "Línea de pedido de venta para facturaración parcial"
+
+#. module: sale_order_partial_invoice
+#: help:sale.order.line,qty_delivered:0
+#: help:sale.order.line,qty_invoiced:0
+msgid "the quantity of product from this line already invoiced"
+msgstr "la cantidad de producto de esta línea ya facturada"
+

--- a/sale_order_partial_invoice/i18n/sale_order_partial_invoice.pot
+++ b/sale_order_partial_invoice/i18n/sale_order_partial_invoice.pot
@@ -6,23 +6,18 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 7.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-02-08 14:15+0000\n"
-"PO-Revision-Date: 2014-02-08 15:16+0100\n"
-"Last-Translator: Pedro Manuel Baeza <pedro.baeza@serviciosbaeza.com>\n"
+"POT-Creation-Date: 2014-08-16 11:09+0000\n"
+"PO-Revision-Date: 2014-08-16 11:09+0000\n"
+"Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
 
 #. module: sale_order_partial_invoice
-#: model:ir.model,name:sale_order_partial_invoice.model_sale_order_line_invoice_partially_line
-msgid "sale.order.line.invoice.partially.line"
-msgstr ""
-
-#. module: sale_order_partial_invoice
-#: field:sale.order.line.invoice.partially.line,wizard_id:0
-msgid "Wizard"
+#: view:sale.order.line.invoice.partially:0
+msgid "Cancel"
 msgstr ""
 
 #. module: sale_order_partial_invoice
@@ -31,8 +26,29 @@ msgid "Create Invoice"
 msgstr ""
 
 #. module: sale_order_partial_invoice
-#: model:ir.model,name:sale_order_partial_invoice.model_sale_advance_payment_inv
-msgid "Sales Advance Payment Invoice"
+#: code:addons/sale_order_partial_invoice/sale.py:242
+#, python-format
+msgid "Created invoice %d"
+msgstr ""
+
+#. module: sale_order_partial_invoice
+#: view:sale.order.line:0
+msgid "Inv. Qty"
+msgstr ""
+
+#. module: sale_order_partial_invoice
+#: view:sale.order.line.invoice.partially:0
+msgid "Invoice Sale Order Lines"
+msgstr ""
+
+#. module: sale_order_partial_invoice
+#: view:sale.order.line.invoice.partially:0
+msgid "Invoice lines"
+msgstr ""
+
+#. module: sale_order_partial_invoice
+#: field:sale.order.line.invoice.partially.line,qty_invoiced:0
+msgid "Invoiced"
 msgstr ""
 
 #. module: sale_order_partial_invoice
@@ -42,43 +58,8 @@ msgid "Invoiced Quantity"
 msgstr ""
 
 #. module: sale_order_partial_invoice
-#: field:sale.order.line.invoice.partially.line,order_qty:0
-msgid "Sold"
-msgstr ""
-
-#. module: sale_order_partial_invoice
 #: field:sale.order.line.invoice.partially.line,name:0
 msgid "Line"
-msgstr ""
-
-#. module: sale_order_partial_invoice
-#: field:sale.order.line.invoice.partially.line,quantity:0
-msgid "To invoice"
-msgstr ""
-
-#. module: sale_order_partial_invoice
-#: view:sale.order.line.invoice.partially:0
-msgid "Invoice lines"
-msgstr ""
-
-#. module: sale_order_partial_invoice
-#: view:sale.order.line:0
-msgid "Inv. Qty"
-msgstr ""
-
-#. module: sale_order_partial_invoice
-#: view:sale.order.line:0
-msgid "Shipped Qty"
-msgstr ""
-
-#. module: sale_order_partial_invoice
-#: field:sale.order.line.invoice.partially,name:0
-msgid "Name"
-msgstr ""
-
-#. module: sale_order_partial_invoice
-#: model:ir.model,name:sale_order_partial_invoice.model_sale_order_line_invoice_partially
-msgid "sale.order.line.invoice.partially"
 msgstr ""
 
 #. module: sale_order_partial_invoice
@@ -88,29 +69,52 @@ msgid "Lines"
 msgstr ""
 
 #. module: sale_order_partial_invoice
+#: field:sale.order.line.invoice.partially,name:0
+msgid "Name"
+msgstr ""
+
+#. module: sale_order_partial_invoice
+#: constraint:sale.order.line.invoice.partially.line:0
+msgid "Quantity to invoice couldn't be greater than remaining quantity"
+msgstr ""
+
+#. module: sale_order_partial_invoice
+#: code:_description:0
+#: model:ir.model,name:sale_order_partial_invoice.model_sale_advance_payment_inv
+#, python-format
+msgid "Sales Advance Payment Invoice"
+msgstr ""
+
+#. module: sale_order_partial_invoice
+#: code:_description:0
+#: model:ir.model,name:sale_order_partial_invoice.model_sale_order_line
+#, python-format
+msgid "Sales Order Line"
+msgstr ""
+
+#. module: sale_order_partial_invoice
 #: field:sale.order.line.invoice.partially.line,qty_delivered:0
 msgid "Shipped"
 msgstr ""
 
 #. module: sale_order_partial_invoice
-#: help:sale.order.line,qty_delivered:0
-#: help:sale.order.line,qty_invoiced:0
-msgid "the quantity of product from this line already invoiced"
+#: view:sale.order.line:0
+msgid "Shipped Qty"
 msgstr ""
 
 #. module: sale_order_partial_invoice
-#: view:sale.order.line.invoice.partially:0
-msgid "Invoice Sale Order Lines"
+#: field:sale.order.line.invoice.partially.line,order_qty:0
+msgid "Sold"
 msgstr ""
 
 #. module: sale_order_partial_invoice
-#: field:sale.order.line.invoice.partially.line,sale_order_line_id:0
-msgid "sale.order.line"
+#: field:sale.order.line.invoice.partially.line,quantity:0
+msgid "To invoice"
 msgstr ""
 
 #. module: sale_order_partial_invoice
-#: view:sale.order.line.invoice.partially:0
-msgid "Cancel"
+#: field:sale.order.line.invoice.partially.line,wizard_id:0
+msgid "Wizard"
 msgstr ""
 
 #. module: sale_order_partial_invoice
@@ -119,12 +123,27 @@ msgid "or"
 msgstr ""
 
 #. module: sale_order_partial_invoice
-#: model:ir.model,name:sale_order_partial_invoice.model_sale_order_line
-msgid "Sales Order Line"
+#: field:sale.order.line.invoice.partially.line,sale_order_line_id:0
+msgid "sale.order.line"
 msgstr ""
 
 #. module: sale_order_partial_invoice
-#: field:sale.order.line.invoice.partially.line,qty_invoiced:0
-msgid "Invoiced"
+#: code:_description:0
+#: model:ir.model,name:sale_order_partial_invoice.model_sale_order_line_invoice_partially
+#, python-format
+msgid "sale.order.line.invoice.partially"
+msgstr ""
+
+#. module: sale_order_partial_invoice
+#: code:_description:0
+#: model:ir.model,name:sale_order_partial_invoice.model_sale_order_line_invoice_partially_line
+#, python-format
+msgid "sale.order.line.invoice.partially.line"
+msgstr ""
+
+#. module: sale_order_partial_invoice
+#: help:sale.order.line,qty_delivered:0
+#: help:sale.order.line,qty_invoiced:0
+msgid "the quantity of product from this line already invoiced"
 msgstr ""
 

--- a/sale_order_partial_invoice/sale.py
+++ b/sale_order_partial_invoice/sale.py
@@ -219,7 +219,6 @@ class SaleOrderLineInvoicePartially(orm.TransientModel):
         ctx['_partial_invoice'] = {}
         so_line_obj = self.pool['sale.order.line']
         so_obj = self.pool['sale.order']
-        invoice_obj = self.pool['account.invoice']
         order_lines = {}
         for wiz in self.browse(cr, uid, ids, context=context):
             for line in wiz.line_ids:
@@ -252,7 +251,6 @@ class SaleOrderLineInvoicePartially(orm.TransientModel):
             if all(line.invoiced for line in order.order_line):
                 wf_service.trg_validate(
                     uid, 'sale.order', order.id, 'manual_invoice', cr)
-                so_obj.write(cr, uid, [order.id], {'state': 'progress'})
         # Open invoice
         ir_model_data = self.pool['ir.model.data']
         form_res = ir_model_data.get_object_reference(cr, uid, 'account',

--- a/sale_order_partial_invoice/sale.py
+++ b/sale_order_partial_invoice/sale.py
@@ -50,6 +50,7 @@ import logging
 _logger = logging.getLogger(__name__)
 from openerp.osv import orm, fields
 from openerp import netsvc
+from openerp.tools.translate import _
 
 
 class SaleOrderLine(orm.Model):
@@ -117,19 +118,19 @@ class SaleOrderLine(orm.Model):
             _fnct_line_invoiced, string='Invoiced', type='boolean',
             store={
                 'account.invoice': (_order_lines_from_invoice2, ['state'], 10),
-                'sale.order.line': (lambda self, cr, uid, ids, ctx=None: ids,
-                                    ['invoice_lines'], 10)
+                'sale.order.line': (lambda self, cr, uid, ids, context=None:
+                                    ids, ['invoice_lines'], 10)
             }),
     }
 
 
-class sale_advance_payment_inv(orm.TransientModel):
+class SaleAdvancePaymentInv(orm.TransientModel):
     _inherit = "sale.advance.payment.inv"
 
     def create_invoices(self, cr, uid, ids, context=None):
         """override standard behavior if payment method is set to 'lines':
         """
-        res = super(sale_advance_payment_inv, self).create_invoices(
+        res = super(SaleAdvancePaymentInv, self).create_invoices(
             cr, uid, ids, context)
         wizard = self.browse(cr, uid, ids[0], context)
         if wizard.advance_payment_method != 'lines':
@@ -176,15 +177,30 @@ class SaleOrderLineInvoicePartiallyLine(orm.TransientModel):
         'sale_order_line_id': fields.many2one('sale.order.line',
                                               string='sale.order.line'),
         'name': fields.related('sale_order_line_id', 'name',
-                               type='char', string="Line"),
+                               type='text', string="Line", readonly=True),
         'order_qty': fields.related('sale_order_line_id', 'product_uom_qty',
-                                    type='float', string="Sold"),
+                                    type='float', string="Sold",
+                                    readonly=True),
         'qty_invoiced': fields.related('sale_order_line_id', 'qty_invoiced',
-                                       type='float', string="Invoiced"),
+                                       type='float', string="Invoiced",
+                                       readonly=True),
         'qty_delivered': fields.related('sale_order_line_id', 'qty_delivered',
-                                        type='float', string="Shipped"),
+                                        type='float', string="Shipped",
+                                        readonly=True),
         'quantity': fields.float('To invoice'),
     }
+
+    def _check_to_invoice_qty(self, cr, uid, ids, context=None):
+        for record in self.browse(cr, uid, ids, context=context):
+            if record.order_qty - record.qty_invoiced < record.quantity:
+                return False
+        return True
+
+    _constraints = [
+        (_check_to_invoice_qty,
+         "Quantity to invoice couldn't be greater than remaining quantity",
+         ['quantity']),
+    ]
 
 
 class SaleOrderLineInvoicePartially(orm.TransientModel):
@@ -203,6 +219,7 @@ class SaleOrderLineInvoicePartially(orm.TransientModel):
         ctx['_partial_invoice'] = {}
         so_line_obj = self.pool['sale.order.line']
         so_obj = self.pool['sale.order']
+        invoice_obj = self.pool['account.invoice']
         order_lines = {}
         for wiz in self.browse(cr, uid, ids, context=context):
             for line in wiz.line_ids:
@@ -212,16 +229,21 @@ class SaleOrderLineInvoicePartially(orm.TransientModel):
                 if sale_order.id not in order_lines:
                     order_lines[sale_order.id] = []
                 order_lines[sale_order.id].append(line.sale_order_line_id.id)
-                ctx['_partial_invoice'][
-                    line.sale_order_line_id.id] = line.quantity
+                ctx['_partial_invoice'][line.sale_order_line_id.id] = \
+                    line.quantity
         for order_id in order_lines:
-            line_ids = order_lines[order_id]
+            so_line_ids = order_lines[order_id]
             invoice_line_ids = so_line_obj.invoice_line_create(
-                cr, uid, line_ids, context=ctx)
+                cr, uid, so_line_ids, context=ctx)
             order = so_obj.browse(cr, uid, order_id, context=context)
-            invoice_id = so_obj._make_invoice(
-                cr, uid, order, invoice_line_ids, context=ctx)
-            _logger.info('created invoice %d', invoice_id)
+            # HACK: Avoid the creation of counterpart lines for compensating
+            # false "anticipated" invoice lines (which is the standard
+            # behaviour)
+            order.invoice_ids = []
+            # Call invoice creation
+            invoice_id = so_obj._make_invoice(cr, uid, order, invoice_line_ids,
+                                              context=ctx)
+            _logger.info(_('Created invoice %d'), invoice_id)
             # the following is copied from many places around
             # (actually sale_line_invoice.py)
             cr.execute('INSERT INTO sale_order_invoice_rel (order_id, '
@@ -230,4 +252,18 @@ class SaleOrderLineInvoicePartially(orm.TransientModel):
             if all(line.invoiced for line in order.order_line):
                 wf_service.trg_validate(
                     uid, 'sale.order', order.id, 'manual_invoice', cr)
-        return {'type': 'ir.actions.act_window_close'}
+                so_obj.write(cr, uid, [order.id], {'state': 'progress'})
+        # Open invoice
+        ir_model_data = self.pool['ir.model.data']
+        form_res = ir_model_data.get_object_reference(cr, uid, 'account',
+                                                      'invoice_form')
+        form_id = form_res and form_res[1] or False
+        return {
+            'view_type': 'form',
+            'view_mode': 'form',
+            'res_model': 'account.invoice',
+            'res_id': invoice_id,
+            'view_id': form_id,
+            'context': {'type': 'out_invoice'},
+            'type': 'ir.actions.act_window',
+        }

--- a/sale_order_partial_invoice/test/partial_so_invoice.yml
+++ b/sale_order_partial_invoice/test/partial_so_invoice.yml
@@ -167,7 +167,10 @@
                             ],
                 }
     id = self.create(cr, uid, wiz_data, context=context)
-    self.create_invoice(cr, uid, [id], context=context)
+    second_invoice_id = self.create_invoice(cr, uid, [id], context=context)['res_id']
+    invoice_obj = self.pool['account.invoice']
+    invoice = invoice_obj.browse(cr, uid, second_invoice_id)
+    assert len(invoice.invoice_line) == 3, "Wrong number of lines in second invoice"
 -
  Check the 2nd invoice is created
 -


### PR DESCRIPTION
[IMP] Make readonly wizard non-modifiable fields.
[FIX] Check if the quantity to invoice is greater than the remaining one.
[FIX] Made a little hack to avoid the creation of counterpart invoice lines in subsequent invoices.
[FIX] Write 'progress' state manually when order is fully invoiced, because workflow doesn't do it.
[IMP] Open the resulting invoice after the wizard.
[FIX] Change type of name field to text to avoid format loosing.
