### PR TITLE
[FIX] add payment term rounding issue if balance

### DIFF
--- a/payment_term_rounding/account.py
+++ b/payment_term_rounding/account.py
@@ -65,7 +65,7 @@ class AccountPaymentTermLine(orm.Model):
                 amt = float_round(amt, precision_rounding=line.amount_round)
             return float_round(amt, precision_digits=prec)
         elif line.value == 'balance':
-            amt = float_round(remaining_amount, precision_digits=prec)
+            return float_round(remaining_amount,  precision_digits=prec)
         return None
 
 

--- a/payment_term_rounding/account.py
+++ b/payment_term_rounding/account.py
@@ -65,7 +65,7 @@ class AccountPaymentTermLine(orm.Model):
                 amt = float_round(amt, precision_rounding=line.amount_round)
             return float_round(amt, precision_digits=prec)
         elif line.value == 'balance':
-            return float_round(remaining_amount,  precision_digits=prec)
+            return float_round(remaining_amount, precision_digits=prec)
         return None
 
 


### PR DESCRIPTION
In case of a line of payment term set to balance none is return instead of the rounded value amount
