### PR TITLE
[FIX] sale_order_partial_invoice pylint

### DIFF
--- a/sale_order_partial_invoice/sale.py
+++ b/sale_order_partial_invoice/sale.py
@@ -157,7 +157,6 @@ class sale_advance_payment_inv(orm.TransientModel):
                 line_values.append((0, 0, val))
         val = {'line_ids': line_values, }
         wizard_id = wizard_obj.create(cr, uid, val, context=context)
-        wiz = wizard_obj.browse(cr, uid, wizard_id, context=context)
         res = {'view_type': 'form',
                'view_mode': 'form',
                'res_model': 'sale.order.line.invoice.partially',

--- a/sale_order_partial_invoice/sale.py
+++ b/sale_order_partial_invoice/sale.py
@@ -158,7 +158,6 @@ class sale_advance_payment_inv(orm.TransientModel):
         val = {'line_ids': line_values, }
         wizard_id = wizard_obj.create(cr, uid, val, context=context)
         wiz = wizard_obj.browse(cr, uid, wizard_id, context=context)
-        print wiz.line_ids
         res = {'view_type': 'form',
                'view_mode': 'form',
                'res_model': 'sale.order.line.invoice.partially',


### PR DESCRIPTION
sale_order_partial_invoice/sale.py:161: [EO001(print-statement), sale_advance_payment_inv.create_invoices] print statement used
