### PR TITLE
[FIX] typo

### DIFF
--- a/invoice_validation_wkfl/invoice.py
+++ b/invoice_validation_wkfl/invoice.py
@@ -156,7 +156,7 @@ class AccountInvoiceRefund(orm.TransientModel):
                     for line in movelines:
                         if line.account_id.id == inv.account_id.id:
                             to_reconcile_ids[line.account_id.id] = [line.id]
-                        if type(line.reconcile_id) != orm.orm.browse_null:
+                        if type(line.reconcile_id) != orm.browse_null:
                             reconcile_obj.unlink(cr, uid, line.reconcile_id.id)
                     # Specific to c2c need to trigger specific wrkf before
                     # create the refund


### PR DESCRIPTION
This is just a typo that make OpenERP crash when you try to to used "Create Refund" wizard
