### PR TITLE
[8.0]Let the choice to the user to keep or not the reference from original invoices

### DIFF
--- a/account_invoice_merge/invoice.py
+++ b/account_invoice_merge/invoice.py
@@ -56,7 +56,7 @@ class account_invoice(models.Model):
         }
 
     @api.multi
-    def do_merge(self):
+    def do_merge(self, keep_references=True):
         """
         To merge similar type of account invoices.
         Invoices will only be merged if:
@@ -68,10 +68,7 @@ class account_invoice(models.Model):
         * Invoice lines are exactly the same except for the quantity and unit
 
          @param self: The object pointer.
-         @param cr: A database cursor
-         @param uid: ID of the user currently logged in
-         @param ids: the ID or list of IDs
-         @param context: A standard dictionary
+         @param keep_references: If True, keep reference of original invoices
 
          @return: new account invoice id
 
@@ -117,8 +114,10 @@ class account_invoice(models.Model):
                     self._get_first_invoice_fields(account_invoice))
                 origins.add(account_invoice.origin)
                 client_refs.add(account_invoice.reference)
+                if not keep_references:
+                    invoice_infos.pop('name')
             else:
-                if account_invoice.name:
+                if account_invoice.name and keep_references:
                     invoice_infos['name'] = \
                         (invoice_infos['name'] or '') + \
                         (' %s' % (account_invoice.name,))

--- a/account_invoice_merge/wizard/invoice_merge.py
+++ b/account_invoice_merge/wizard/invoice_merge.py
@@ -111,4 +111,3 @@ class invoice_merge(models.TransientModel):
             'domain': [('id', 'in', ids + allinvoices.keys())],
         })
         return action
-

--- a/account_invoice_merge/wizard/invoice_merge.py
+++ b/account_invoice_merge/wizard/invoice_merge.py
@@ -18,13 +18,17 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-from openerp import models, api, exceptions
+from openerp import models, fields, api, exceptions
 from openerp.tools.translate import _
 
 
 class invoice_merge(models.TransientModel):
     _name = "invoice.merge"
     _description = "Merge Partner Invoice"
+
+    keep_references = fields.Boolean('Keep references'
+                                     ' from original invoices',
+                                     default=True)
 
     @api.model
     def _dirty_check(self):
@@ -95,7 +99,7 @@ class invoice_merge(models.TransientModel):
         aw_obj = self.env['ir.actions.act_window']
         ids = self.env.context.get('active_ids', [])
         invoices = inv_obj.browse(ids)
-        allinvoices = invoices.do_merge()
+        allinvoices = invoices.do_merge(keep_references=self.keep_references)
         xid = {
             'out_invoice': 'action_invoice_tree1',
             'out_refund': 'action_invoice_tree3',
@@ -107,3 +111,4 @@ class invoice_merge(models.TransientModel):
             'domain': [('id', 'in', ids + allinvoices.keys())],
         })
         return action
+

--- a/account_invoice_merge/wizard/invoice_merge_view.xml
+++ b/account_invoice_merge/wizard/invoice_merge_view.xml
@@ -20,6 +20,9 @@ Lines will only be merged if:<br/>
 * Invoice lines are exactly the same except for the product,quantity and unit<br/>
                             </p>
                     </group>
+                    <group name="options">
+                        <field name="keep_references"/>
+                    </group>
                     <footer>
                         <button name="merge_invoices" string="Merge Invoices"
                             type="object" class="oe_highlight" />


### PR DESCRIPTION
By default the wizard aggregates all values from the field name of all original invoices in the field name of the new invoice.
Depending of the number of invoices to merge, this name could be very long and difficult to print on report.

So this PR add a new field on wizard to let the use choose to keep or not this reference.
