### PR TITLE
[8.0][ADD] add new module to manage order of invoice lines

### DIFF
--- a/account_invoice_line_sort/README.rst
+++ b/account_invoice_line_sort/README.rst
@@ -1,0 +1,32 @@
+Sort Customer Invoice Lines
+============================
+
+This module was written to extend the functionality of customer invoice and allow you to manage sort of lines.
+
+An attribute is added on the customer form to select the sort of invoice lines.
+When selecting the customer on an invoice, the sort options are automatically inherited.
+If needed, the user can always change it on the invoice without impacting the customer data.
+When saving the invoice, all lines are sorted given the sort options selected.
+
+In any cases, the default sort is by sequence ascending.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Cédric Pigeon <cedric.pigeon@acsone.eu>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose mission is to support the collaborative development of Odoo features and promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/account_invoice_line_sort/__init__.py
+++ b/account_invoice_line_sort/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import models

--- a/account_invoice_line_sort/__openerp__.py
+++ b/account_invoice_line_sort/__openerp__.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+
+#     This file is part of account_invoice_line_sort, an Odoo module.
+#
+#     Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
+#
+#     account_invoice_line_sort is free software: you can redistribute it
+#     and/or modify it under the terms of the GNU Affero General Public License
+#     as published by the Free Software Foundation, either version 3 of
+#     the License, or (at your option) any later version.
+#
+#     account_invoice_line_sort is distributed in the hope that it will
+#     be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU Affero General Public License for more details.
+#
+#     You should have received a copy of the
+#     GNU Affero General Public License
+#     along with account_invoice_line_sort.
+#     If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': "Sort Customer Invoice Lines",
+
+    'summary': """
+        Manage sort of customer invoice lines by customers""",
+
+    'author': "ACSONE SA/NV",
+    'website': "http://acsone.eu",
+
+    'category': 'Finance',
+    'version': '0.1',
+    'license': 'AGPL-3',
+
+    'depends': [
+        'account',
+    ],
+
+    'data': [
+        'views/account_invoice_view.xml',
+        'views/res_partner_view.xml'
+    ],
+
+    'demo': [
+    ],
+}

--- a/account_invoice_line_sort/models/__init__.py
+++ b/account_invoice_line_sort/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+from . import account_invoice
+from . import res_partner

--- a/account_invoice_line_sort/models/account_invoice.py
+++ b/account_invoice_line_sort/models/account_invoice.py
@@ -23,7 +23,7 @@
 ##############################################################################
 
 from openerp import models, fields, api
-from operator import attrgetter 
+from operator import attrgetter
 
 AVAILABLE_SORT_OPTIONS = [
     ('sequence', 'Sequence'),

--- a/account_invoice_line_sort/models/account_invoice.py
+++ b/account_invoice_line_sort/models/account_invoice.py
@@ -74,12 +74,11 @@ class account_invoice(models.Model):
 
     @api.one
     def _sort_account_invoice_line(self):
-        line_model = self.env['account.invoice.line']
         if self.invoice_line:
-            order = "%s %s" % (self.line_order, self.line_order_direction)
-            domain = [('id', 'in', self.invoice_line.ids)]
             sequence = 0
-            for line in line_model.search(domain, order=order):
+            key = attrgetter(self.line_order)
+            reverse = self.line_order_direction == 'desc'
+            for line in self.invoice_line.sorted(key=key, reverse=reverse):
                 sequence += 10
                 line.sequence = sequence
 

--- a/account_invoice_line_sort/models/account_invoice.py
+++ b/account_invoice_line_sort/models/account_invoice.py
@@ -23,6 +23,7 @@
 ##############################################################################
 
 from openerp import models, fields, api
+from operator import attrgetter 
 
 AVAILABLE_SORT_OPTIONS = [
     ('sequence', 'Sequence'),

--- a/account_invoice_line_sort/models/account_invoice.py
+++ b/account_invoice_line_sort/models/account_invoice.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+
+#     This file is part of account_invoice_line_sort, an Odoo module.
+#
+#     Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
+#
+#     account_invoice_line_sort is free software: you can redistribute it
+#     and/or modify it under the terms of the GNU Affero General Public License
+#     as published by the Free Software Foundation, either version 3 of
+#     the License, or (at your option) any later version.
+#
+#     account_invoice_line_sort is distributed in the hope that it will
+#     be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU Affero General Public License for more details.
+#
+#     You should have received a copy of the
+#     GNU Affero General Public License
+#     along with account_invoice_line_sort.
+#     If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models, fields, api
+
+AVAILABLE_SORT_OPTIONS = [
+    ('sequence', 'Sequence'),
+    ('name', 'Description'),
+    ('price_unit', 'Unit Price'),
+    ('price_subtotal', 'Amount'),
+]
+AVAILABLE_ORDER_OPTIONS = [
+    ('asc', 'Ascending'),
+    ('desc', 'Descending')
+]
+
+
+class account_invoice(models.Model):
+    _inherit = "account.invoice"
+    _sort_trigger_fields = ('line_order',
+                            'line_order_direction')
+
+    line_order = fields.Selection(AVAILABLE_SORT_OPTIONS,
+                                  "Sort Lines By",
+                                  default='sequence')
+    line_order_direction = fields.Selection(AVAILABLE_ORDER_OPTIONS,
+                                            "Sort Direction",
+                                            default='asc')
+
+    @api.model
+    def get_partner_sort_options(self, partner_id):
+        res = {}
+        if partner_id:
+            p = self.env['res.partner'].browse(partner_id)
+            res['line_order'] = p.line_order
+            res['line_order_direction'] = p.line_order_direction
+        return res
+
+    @api.multi
+    def onchange_partner_id(self, type, partner_id, date_invoice=False,
+                            payment_term=False, partner_bank_id=False,
+                            company_id=False):
+        res = super(account_invoice,
+                    self).onchange_partner_id(type,
+                                              partner_id,
+                                              date_invoice=date_invoice,
+                                              payment_term=payment_term,
+                                              partner_bank_id=partner_bank_id,
+                                              company_id=company_id)
+        if partner_id:
+            res['value'].update(self.get_partner_sort_options(partner_id))
+        return res
+
+    @api.one
+    def _sort_account_invoice_line(self):
+        line_model = self.env['account.invoice.line']
+        if self.invoice_line:
+            order = "%s %s" % (self.line_order, self.line_order_direction)
+            domain = [('id', 'in', self.invoice_line.ids)]
+            sequence = 0
+            for line in line_model.search(domain, order=order):
+                sequence += 10
+                line.sequence = sequence
+
+    @api.multi
+    def write(self, vals):
+        sort = False
+        fields = [key for key in vals if key in self._sort_trigger_fields]
+        if fields:
+            if [key for key in fields if vals[key] != self[key]]:
+                sort = True
+        res = super(account_invoice, self).write(vals)
+        if sort or 'invoice_line' in vals:
+            self._sort_account_invoice_line()
+        return res
+
+    @api.model
+    @api.returns('self', lambda value: value.id)
+    def create(self, vals):
+        if not [key for key in vals if key in self._sort_trigger_fields]:
+            partner_id = vals.get('partner_id', False)
+            vals.update(self.get_partner_sort_options(partner_id))
+        invoice = super(account_invoice, self).create(vals)
+        invoice._sort_account_invoice_line()
+        return invoice
+
+
+class account_invoice_line(models.Model):
+    _inherit = "account.invoice.line"
+    _sort_trigger_fields = ('name', 'quantity', 'price_unit', 'discount')
+
+    @api.multi
+    def write(self, vals):
+        sort = False
+        fields = [key for key in vals if key in self._sort_trigger_fields]
+        if fields:
+            if [key for key in fields if vals[key] != self[key]]:
+                sort = True
+        res = super(account_invoice_line, self).write(vals)
+        if sort:
+            self.invoice_id._sort_account_invoice_line()
+        return res
+
+    @api.model
+    @api.returns('self', lambda value: value.id)
+    def create(self, vals):
+        line = super(account_invoice_line, self).create(vals)
+        self.invoice_id._sort_account_invoice_line()
+        return line

--- a/account_invoice_line_sort/models/res_partner.py
+++ b/account_invoice_line_sort/models/res_partner.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+
+#     This file is part of account_invoice_line_sort, an Odoo module.
+#
+#     Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
+#
+#     account_invoice_line_sort is free software: you can redistribute it
+#     and/or modify it under the terms of the GNU Affero General Public License
+#     as published by the Free Software Foundation, either version 3 of
+#     the License, or (at your option) any later version.
+#
+#     account_invoice_line_sort is distributed in the hope that it will
+#     be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU Affero General Public License for more details.
+#
+#     You should have received a copy of the
+#     GNU Affero General Public License
+#     along with account_invoice_line_sort.
+#     If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models, fields
+from . import account_invoice
+
+
+class res_partner(models.Model):
+    _inherit = "res.partner"
+
+    line_order = fields.Selection(account_invoice.AVAILABLE_SORT_OPTIONS,
+                                  "Sort Invoice Lines By",
+                                  default='sequence')
+    line_order_direction = fields.Selection(
+        account_invoice.AVAILABLE_ORDER_OPTIONS,
+        "Sort Direction",
+        default='asc')

--- a/account_invoice_line_sort/tests/__init__.py
+++ b/account_invoice_line_sort/tests/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import test_account_invoice_line_sort

--- a/account_invoice_line_sort/tests/test_account_invoice_line_sort.py
+++ b/account_invoice_line_sort/tests/test_account_invoice_line_sort.py
@@ -1,0 +1,158 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+
+#     This file is part of account_invoice_line_sort, an Odoo module.
+#
+#     Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
+#
+#     account_invoice_line_sort is free software: you can redistribute it
+#     and/or modify it under the terms of the GNU Affero General Public License
+#     as published by the Free Software Foundation, either version 3 of
+#     the License, or (at your option) any later version.
+#
+#     account_invoice_line_sort is distributed in the hope that it will
+#     be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU Affero General Public License for more details.
+#
+#     You should have received a copy of the
+#     GNU Affero General Public License
+#     along with account_invoice_line_sort.
+#     If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from anybox.testing.openerp import SharedSetupTransactionCase
+import time
+
+
+class test_account_invoice_line_sort(object):
+
+    _module_ns = 'account_invoice_line_sort'
+
+    descriptions = ['a description', 'b description', 'c description']
+
+    def setUp(self):
+        super(test_account_invoice_line_sort, self).setUp()
+        self.invoice_model = self.env['account.invoice']
+        self.invoice_line_model = self.env['account.invoice.line']
+        self.account_rcv_id = self.ref("account.a_recv")
+        self.partner = self.browse_ref("base.res_partner_2")
+        self.lines_vals = [
+            {'quantity': 3,
+             'price_unit': 100,
+             'name': self.descriptions[0],
+             'sequence': 1},
+            {'quantity': 4,
+             'price_unit': 99,
+             'name': self.descriptions[1],
+             'sequence': 2},
+            {'quantity': 2,
+             'price_unit': 120,
+             'name': self.descriptions[2],
+             'sequence': 3}
+        ]
+        self.invoice_vals = {
+            'partner_id': self.partner.id,
+            'name': 'invoice to client',
+            'account_id': self.account_rcv_id,
+            'type': 'out_invoice',
+            'date_invoice': time.strftime('%Y') + '-07-01',
+            'invoice_line': [(0, 0, value) for value in self.lines_vals]
+        }
+
+    def test_invoice_sort_on_create(self):
+        self.partner.line_order = self.line_order
+        self.partner.line_order_direction = self.line_order_direction
+
+        invoice = self.invoice_model.create(self.invoice_vals)
+
+        for line in invoice.invoice_line:
+            self.assertEqual(line.sequence,
+                             self.expected_sequence[line.name],
+                             'Sequence should be %s and not %s !' %
+                             (self.expected_sequence[line.name],
+                              line.sequence))
+
+    def test_invoice_sort_on_write(self):
+        invoice = self.invoice_model.create(self.invoice_vals)
+        invoice.line_order = self.line_order
+        invoice.line_order_direction = self.line_order_direction
+
+        for line in invoice.invoice_line:
+            self.assertEqual(line.sequence,
+                             self.expected_sequence[line.name],
+                             'Sequence should be %s and not %s !' %
+                             (self.expected_sequence[line.name],
+                              line.sequence))
+
+
+class test_account_invoice_line_sort_name_asc(test_account_invoice_line_sort,
+                                              SharedSetupTransactionCase):
+
+        def setUp(self):
+            super(test_account_invoice_line_sort_name_asc, self).setUp()
+            self.expected_sequence = {self.descriptions[0]: 10,
+                                      self.descriptions[1]: 20,
+                                      self.descriptions[2]: 30}
+            self.line_order = 'name'
+            self.line_order_direction = 'asc'
+
+
+class test_account_invoice_line_sort_name_desc(test_account_invoice_line_sort,
+                                               SharedSetupTransactionCase):
+
+        def setUp(self):
+            super(test_account_invoice_line_sort_name_desc, self).setUp()
+            self.expected_sequence = {self.descriptions[0]: 30,
+                                      self.descriptions[1]: 20,
+                                      self.descriptions[2]: 10}
+            self.line_order = 'name'
+            self.line_order_direction = 'desc'
+
+
+class test_account_invoice_line_sort_price_unit_asc(
+        test_account_invoice_line_sort, SharedSetupTransactionCase):
+
+        def setUp(self):
+            super(test_account_invoice_line_sort_price_unit_asc, self).setUp()
+            self.expected_sequence = {self.descriptions[0]: 20,
+                                      self.descriptions[1]: 10,
+                                      self.descriptions[2]: 30}
+            self.line_order = 'price_unit'
+            self.line_order_direction = 'asc'
+
+
+class test_account_invoice_line_sort_price_unit_desc(
+        test_account_invoice_line_sort, SharedSetupTransactionCase):
+
+        def setUp(self):
+            super(test_account_invoice_line_sort_price_unit_desc, self).setUp()
+            self.expected_sequence = {self.descriptions[0]: 20,
+                                      self.descriptions[1]: 30,
+                                      self.descriptions[2]: 10}
+            self.line_order = 'price_unit'
+            self.line_order_direction = 'desc'
+
+
+class test_account_invoice_line_sort_amount_asc(
+        test_account_invoice_line_sort, SharedSetupTransactionCase):
+
+        def setUp(self):
+            super(test_account_invoice_line_sort_amount_asc, self).setUp()
+            self.expected_sequence = {self.descriptions[0]: 20,
+                                      self.descriptions[1]: 30,
+                                      self.descriptions[2]: 10}
+            self.line_order = 'price_subtotal'
+            self.line_order_direction = 'asc'
+
+
+class test_account_invoice_line_sort_amount_desc(
+        test_account_invoice_line_sort, SharedSetupTransactionCase):
+
+        def setUp(self):
+            super(test_account_invoice_line_sort_amount_desc, self).setUp()
+            self.expected_sequence = {self.descriptions[0]: 20,
+                                      self.descriptions[1]: 10,
+                                      self.descriptions[2]: 30}
+            self.line_order = 'price_subtotal'
+            self.line_order_direction = 'desc'

--- a/account_invoice_line_sort/views/account_invoice_view.xml
+++ b/account_invoice_line_sort/views/account_invoice_view.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="invoice_form" model="ir.ui.view">
+            <field name="name">account.invoice.form</field>
+            <field name="inherit_id" ref="account.invoice_form" />
+            <field name="model">account.invoice</field>
+            <field name="arch" type="xml">
+                <xpath expr="//notebook/page[@string='Other Info']/group[group[field[@name='move_id']]]" position="after">
+                    <group name = "line_sort">
+                        <label for="line_order"/>
+                        <div>
+                            <field name="line_order" class="oe_inline"/> 
+                            (<field name="line_order_direction" class="oe_inline"/>)
+                        </div>
+                    </group>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/account_invoice_line_sort/views/account_invoice_view.xml
+++ b/account_invoice_line_sort/views/account_invoice_view.xml
@@ -7,7 +7,7 @@
             <field name="model">account.invoice</field>
             <field name="arch" type="xml">
                 <xpath expr="//notebook/page[@string='Other Info']/group[group[field[@name='move_id']]]" position="after">
-                    <group name = "line_sort">
+                    <group name="line_sort">
                         <label for="line_order"/>
                         <div>
                             <field name="line_order" class="oe_inline"/> 
@@ -19,3 +19,4 @@
         </record>
     </data>
 </openerp>
+

--- a/account_invoice_line_sort/views/res_partner_view.xml
+++ b/account_invoice_line_sort/views/res_partner_view.xml
@@ -19,3 +19,4 @@
         </record>
     </data>
 </openerp>
+

--- a/account_invoice_line_sort/views/res_partner_view.xml
+++ b/account_invoice_line_sort/views/res_partner_view.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="view_partner_form" model="ir.ui.view">
+            <field name="name">res.partner.form</field>
+            <field name="inherit_id" ref="base.view_partner_form" />
+            <field name="model">res.partner</field>
+            <field name="arch" type="xml">
+                <xpath expr="//page[@name='sales_purchases']/group[group[field[@name='user_id']]]" position="after">
+                    <group name="line_sort" attrs="{'invisible': [('customer', '=', False)]}">
+                        <label for="line_order"/>
+                        <div>
+	                        <field name="line_order" class="oe_inline"/> 
+	                        (<field name="line_order_direction" class="oe_inline"/>)
+                        </div>
+                    </group>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
This PR suggest a new module to manage order of customer invoice lines.

You can sort invoice lines by sequence (default), name, price_unit or price_subtotal, either ascending or descending.

The sort options can be set on an invoice or stored customer by customer.
