### PR TITLE
[8.0] Add accout invoice merge payment module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ virtualenv:
 
 install:
   - git clone https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
+  - git clone https://github.com/OCA/bank-payment.git -b ${VERSION} ${HOME}/bank-payment
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - travis_install_nightly
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ install:
   - git clone https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
   - git clone https://github.com/OCA/bank-payment.git -b ${VERSION} ${HOME}/bank-payment
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
+  - sudo pip install unidecode
   - travis_install_nightly
 
 script:

--- a/account_invoice_merge_payment/README.rst
+++ b/account_invoice_merge_payment/README.rst
@@ -7,7 +7,7 @@ module to support fields added in Account Payment Partner from OCA/bank-payment
 Installation
 ============
 
-* the module is automatically installed when account_invoice_merge and account_payment_partner are installed
+* The module is automatically installed when account_invoice_merge and account_payment_partner are installed
 
 Credits
 =======

--- a/account_invoice_merge_payment/README.rst
+++ b/account_invoice_merge_payment/README.rst
@@ -7,13 +7,7 @@ module to support fields added in Account Payment Partner from OCA/bank-payment
 Installation
 ============
 
-To install this module, you need to:
-
- * Click on install button
-
-For further information, please visit:
-
- * https://www.odoo.com/forum/help-1
+* the module is automatically installed when account_invoice_merge and account_payment_partner are installed
 
 Credits
 =======

--- a/account_invoice_merge_payment/README.rst
+++ b/account_invoice_merge_payment/README.rst
@@ -1,3 +1,6 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License AGPL-3
+
 Account Invoice Merge Payment
 =============================
 

--- a/account_invoice_merge_payment/README.rst
+++ b/account_invoice_merge_payment/README.rst
@@ -1,0 +1,38 @@
+Account Invoice Merge Payment
+=============================
+
+This module was written to extend the functionality of Account Invoice Merge
+module to support fields added in Account Payment Partner from OCA/bank-payment
+
+Installation
+============
+
+To install this module, you need to:
+
+ * Click on install button
+
+For further information, please visit:
+
+ * https://www.odoo.com/forum/help-1
+
+Credits
+=======
+
+Contributors
+------------
+
+* Stéphane Bidoul <stephane.bidoul@acsone.eu>
+* Adrien Peiffer <adrien.peiffer@acsone.eu>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose mission is to support the collaborative development of Odoo features and promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/account_invoice_merge_payment/__init__.py
+++ b/account_invoice_merge_payment/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import models

--- a/account_invoice_merge_payment/__openerp__.py
+++ b/account_invoice_merge_payment/__openerp__.py
@@ -26,7 +26,7 @@
     'name': "account_invoice_merge_payment",
     'summary': """
         Use invoice merge regarding fields on Account Payment Partner""",
-    'author': "ACSONE SA/NV",
+    'author': "ACSONE SA/NV,Odoo Community Association (OCA)",
     'website': "http://acsone.eu",
     'category': 'Invoicing & Payments',
     'version': '0.1',

--- a/account_invoice_merge_payment/__openerp__.py
+++ b/account_invoice_merge_payment/__openerp__.py
@@ -35,6 +35,5 @@
         'account_invoice_merge',
         'account_payment_partner',
     ],
-    'data': [],
     'auto_install': True
 }

--- a/account_invoice_merge_payment/__openerp__.py
+++ b/account_invoice_merge_payment/__openerp__.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#     This file is part of account_invoice_merge_payment,
+#     an Odoo module.
+#
+#     Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
+#
+#     account_invoice_merge_payment is free software:
+#     you can redistribute it and/or modify it under the terms of the GNU
+#     Affero General Public License as published by the Free Software
+#     Foundation,either version 3 of the License, or (at your option) any
+#     later version.
+#
+#     account_invoice_merge_payment is distributed
+#     in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+#     even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#     PURPOSE.  See the GNU Affero General Public License for more details.
+#
+#     You should have received a copy of the GNU Affero General Public License
+#     along with account_invoice_merge_payment.
+#     If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': "account_invoice_merge_payment",
+    'summary': """
+        Use invoice merge regarding fields on Account Payment Partner""",
+    'author': "ACSONE SA/NV",
+    'website': "http://acsone.eu",
+    'category': 'Invoicing & Payments',
+    'version': '0.1',
+    'license': 'AGPL-3',
+    'depends': [
+        'account_invoice_merge',
+        'account_payment_partner',
+    ],
+    'data': [],
+    'auto_install': True
+}

--- a/account_invoice_merge_payment/models/__init__.py
+++ b/account_invoice_merge_payment/models/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import account_invoice

--- a/account_invoice_merge_payment/models/account_invoice.py
+++ b/account_invoice_merge_payment/models/account_invoice.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#     This file is part of account_invoice_merge_payment,
+#     an Odoo module.
+#
+#     Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
+#
+#     account_invoice_merge_payment is free software:
+#     you can redistribute it and/or modify it under the terms of the GNU
+#     Affero General Public License as published by the Free Software
+#     Foundation,either version 3 of the License, or (at your option) any
+#     later version.
+#
+#     account_invoice_merge_payment is distributed
+#     in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+#     even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#     PURPOSE.  See the GNU Affero General Public License for more details.
+#
+#     You should have received a copy of the GNU Affero General Public License
+#     along with account_invoice_merge_payment.
+#     If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models, api
+from openerp.addons.account_invoice_merge.invoice import INVOICE_KEY_COLS
+
+
+INVOICE_KEY_COLS.append('payment_mode_id')
+
+
+class AccountInvoice(models.Model):
+    _inherit = 'account.invoice'
+
+    @api.model
+    def _get_first_invoice_fields(self, invoice):
+        res = super(AccountInvoice, self)._get_first_invoice_fields(invoice)
+        res.update({'payment_mode_id': invoice.payment_mode_id.id})
+        return res


### PR DESCRIPTION
Add accout invoice merge payment module that was written to extend the functionality of Account Invoice Merge module to support fields added in Account Payment Partner from OCA/bank-payment.
