### PR TITLE
[ADD] add module to force currency rate on account invoice

### DIFF
--- a/account_invoice_currency_rate/__init__.py
+++ b/account_invoice_currency_rate/__init__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+###############################################################################
+#
+#   Module for OpenERP
+#   Copyright (C) 2015 Akretion (http://www.akretion.com). All Rights Reserved
+#   @author Benoît GUILLOT <benoit.guillot@akretion.com>
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as
+#   published by the Free Software Foundation, either version 3 of the
+#   License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+
+from . import invoice
+from . import currency
+from . import wizard

--- a/account_invoice_currency_rate/__openerp__.py
+++ b/account_invoice_currency_rate/__openerp__.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+###############################################################################
+#
+#   Module for OpenERP
+#   Copyright (C) 2015 Akretion (http://www.akretion.com). All Rights Reserved
+#   @author Benoît GUILLOT <benoit.guillot@akretion.com>
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as
+#   published by the Free Software Foundation, either version 3 of the
+#   License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+
+{
+    'name': 'account_invoice_currency_rate',
+    'version': '0.1',
+    'category': 'Accounting & Finance',
+    'license': 'AGPL-3',
+    'description': """
+    This module adds the field currency_rate on account invoice in order to
+    force the currency rate on an invoice.
+    """,
+    'author': 'Akretion',
+    'website': 'http://www.akretion.com/',
+    'depends': ['account'],
+    'data': [
+        'wizard/force_currency_rate_view.xml',
+        'invoice_view.xml',
+    ],
+    'demo': [],
+    'installable': True,
+}

--- a/account_invoice_currency_rate/currency.py
+++ b/account_invoice_currency_rate/currency.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+###############################################################################
+#
+#   Module for OpenERP
+#   Copyright (C) 2015 Akretion (http://www.akretion.com). All Rights Reserved
+#   @author Benoît GUILLOT <benoit.guillot@akretion.com>
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as
+#   published by the Free Software Foundation, either version 3 of the
+#   License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+
+from openerp.osv import orm
+
+
+class res_currency(orm.Model):
+    _inherit = "res.currency"
+
+    def _get_conversion_rate(
+            self, cr, uid, from_currency, to_currency, context=None):
+        if context is None:
+            context = {}
+        if context.get('force_currency_rate', False):
+            return context['force_currency_rate']
+        return super(res_currency, self)._get_conversion_rate(
+            cr, uid, from_currency, to_currency, context=context)

--- a/account_invoice_currency_rate/i18n/account_invoice_currency_rate.pot
+++ b/account_invoice_currency_rate/i18n/account_invoice_currency_rate.pot
@@ -1,0 +1,62 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#	* account_invoice_currency_rate
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-04-07 14:23+0000\n"
+"PO-Revision-Date: 2015-04-07 14:23+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_invoice_currency_rate
+#: view:invoice.force.currency.rate:0
+msgid "Set the currency rate you want to force on this invoice."
+msgstr ""
+
+#. module: account_invoice_currency_rate
+#: help:account.invoice,currency_rate:0
+#: help:invoice.force.currency.rate,currency_rate:0
+msgid "You can force the currency rate on the invoice with this field."
+msgstr ""
+
+#. module: account_invoice_currency_rate
+#: field:account.invoice,currency_rate:0
+#: field:invoice.force.currency.rate,currency_rate:0
+msgid "Forced currency rate"
+msgstr ""
+
+#. module: account_invoice_currency_rate
+#: model:ir.model,name:account_invoice_currency_rate.model_res_currency
+msgid "Currency"
+msgstr ""
+
+#. module: account_invoice_currency_rate
+#: model:ir.model,name:account_invoice_currency_rate.model_account_invoice
+msgid "Invoice"
+msgstr ""
+
+#. module: account_invoice_currency_rate
+#: view:invoice.force.currency.rate:0
+msgid "Cancel"
+msgstr ""
+
+#. module: account_invoice_currency_rate
+#: view:invoice.force.currency.rate:0
+msgid "or"
+msgstr ""
+
+#. module: account_invoice_currency_rate
+#: view:account.invoice:0
+#: view:invoice.force.currency.rate:0
+#: model:ir.actions.act_window,name:account_invoice_currency_rate.action_force_currency_rate
+#: model:ir.model,name:account_invoice_currency_rate.model_invoice_force_currency_rate
+msgid "Force currency rate"
+msgstr ""
+

--- a/account_invoice_currency_rate/i18n/fr.po
+++ b/account_invoice_currency_rate/i18n/fr.po
@@ -1,0 +1,62 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#	* account_invoice_currency_rate
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-04-07 14:23+0000\n"
+"PO-Revision-Date: 2015-04-07 14:23+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_invoice_currency_rate
+#: view:invoice.force.currency.rate:0
+msgid "Set the currency rate you want to force on this invoice."
+msgstr "Entrer le taux de change à forcer sur cette facture."
+
+#. module: account_invoice_currency_rate
+#: help:account.invoice,currency_rate:0
+#: help:invoice.force.currency.rate,currency_rate:0
+msgid "You can force the currency rate on the invoice with this field."
+msgstr "Vous pouvez forcer le taux de change sur la facture à l'aide de ce champ."
+
+#. module: account_invoice_currency_rate
+#: field:account.invoice,currency_rate:0
+#: field:invoice.force.currency.rate,currency_rate:0
+msgid "Forced currency rate"
+msgstr "Taux de change forcé"
+
+#. module: account_invoice_currency_rate
+#: model:ir.model,name:account_invoice_currency_rate.model_res_currency
+msgid "Currency"
+msgstr "Devise"
+
+#. module: account_invoice_currency_rate
+#: model:ir.model,name:account_invoice_currency_rate.model_account_invoice
+msgid "Invoice"
+msgstr "Facture"
+
+#. module: account_invoice_currency_rate
+#: view:invoice.force.currency.rate:0
+msgid "Cancel"
+msgstr "Annuler"
+
+#. module: account_invoice_currency_rate
+#: view:invoice.force.currency.rate:0
+msgid "or"
+msgstr "ou"
+
+#. module: account_invoice_currency_rate
+#: view:account.invoice:0
+#: view:invoice.force.currency.rate:0
+#: model:ir.actions.act_window,name:account_invoice_currency_rate.action_force_currency_rate
+#: model:ir.model,name:account_invoice_currency_rate.model_invoice_force_currency_rate
+msgid "Force currency rate"
+msgstr "Forcer le taux de change"
+

--- a/account_invoice_currency_rate/invoice.py
+++ b/account_invoice_currency_rate/invoice.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+###############################################################################
+#
+#   Module for OpenERP
+#   Copyright (C) 2015 Akretion (http://www.akretion.com). All Rights Reserved
+#   @author Benoît GUILLOT <benoit.guillot@akretion.com>
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as
+#   published by the Free Software Foundation, either version 3 of the
+#   License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+
+from openerp.osv import fields, orm
+
+
+class account_invoice(orm.Model):
+    _inherit = "account.invoice"
+
+    _columns = {
+        'currency_rate': fields.float(
+            'Forced currency rate',
+            help="You can force the currency rate on the invoice with this "
+                 "field.")
+        }
+
+    def action_move_create(self, cr, uid, ids, context=None):
+        if context is None:
+            context = {}
+        for invoice in self.browse(cr, uid, ids, context=context):
+            ctx = context.copy()
+            if invoice.currency_rate:
+                ctx['force_currency_rate'] = invoice.currency_rate
+            super(account_invoice, self).action_move_create(
+                cr, uid, [invoice.id], context=ctx)
+        return True

--- a/account_invoice_currency_rate/invoice_view.xml
+++ b/account_invoice_currency_rate/invoice_view.xml
@@ -9,12 +9,14 @@
             <field name="arch" type="xml">
                 <xpath expr="//button[@name='invoice_open']" position="before">
                     <button name="%(action_force_currency_rate)d" type="action"
-                        string="Force currency rate" states="draft"/>
+                        string="Force currency rate"
+                        attrs="{'invisible': [('show_force_currency', '=', False)]}"/>
                 </xpath>
                 <xpath expr="//field[@name='currency_id']/.." position="after">
                     <field name="currency_rate"
                            attrs="{'readonly':[('state','!=','draft')], 'invisible':[('currency_rate', '=', 0.0)]}"
                            groups="base.group_multi_currency"/>
+                    <field name="show_force_currency" invisible="1"/>
                 </xpath>
             </field>
         </record>
@@ -26,12 +28,14 @@
             <field name="arch" type="xml">
                 <xpath expr="//button[@name='invoice_open']" position="before">
                     <button name="%(action_force_currency_rate)d" type="action"
-                        string="Force currency rate" states="draft"/>
+                        string="Force currency rate"
+                        attrs="{'invisible': [('show_force_currency', '=', False)]}"/>
                 </xpath>
                 <xpath expr="//field[@name='currency_id']" position="after">
                     <field name="currency_rate"
                            attrs="{'readonly':[('state','!=','draft')], 'invisible':[('currency_rate', '=', 0.0)]}"
                            groups="base.group_multi_currency"/>
+                    <field name="show_force_currency" invisible="1"/>
                 </xpath>
             </field>
         </record>

--- a/account_invoice_currency_rate/invoice_view.xml
+++ b/account_invoice_currency_rate/invoice_view.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+<data>
+
+        <record model="ir.ui.view" id="account_invoice_form_currency_rate">
+            <field name="name">account.invoice.form.currency_rate</field>
+            <field name="model">account.invoice</field>
+            <field name="inherit_id" ref="account.invoice_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//button[@name='invoice_open']" position="before">
+                    <button name="%(action_force_currency_rate)d" type="action"
+                        string="Force currency rate" states="draft"/>
+                </xpath>
+                <xpath expr="//field[@name='currency_id']/.." position="after">
+                    <field name="currency_rate"
+                           attrs="{'readonly':[('state','!=','draft')], 'invisible':[('currency_rate', '=', 0.0)]}"
+                           groups="base.group_multi_currency"/>
+                </xpath>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="account_invoice_supplier_form_currency_rate">
+            <field name="name">account.invoice.supplier.form.currency_rate</field>
+            <field name="model">account.invoice</field>
+            <field name="inherit_id" ref="account.invoice_supplier_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//button[@name='invoice_open']" position="before">
+                    <button name="%(action_force_currency_rate)d" type="action"
+                        string="Force currency rate" states="draft"/>
+                </xpath>
+                <xpath expr="//field[@name='currency_id']" position="after">
+                    <field name="currency_rate"
+                           attrs="{'readonly':[('state','!=','draft')], 'invisible':[('currency_rate', '=', 0.0)]}"
+                           groups="base.group_multi_currency"/>
+                </xpath>
+            </field>
+        </record>
+
+</data>
+</openerp>

--- a/account_invoice_currency_rate/wizard/__init__.py
+++ b/account_invoice_currency_rate/wizard/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+###############################################################################
+#
+#   Module for OpenERP
+#   Copyright (C) 2015 Akretion (http://www.akretion.com). All Rights Reserved
+#   @author Benoît GUILLOT <benoit.guillot@akretion.com>
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as
+#   published by the Free Software Foundation, either version 3 of the
+#   License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+
+from . import force_currency_rate

--- a/account_invoice_currency_rate/wizard/force_currency_rate.py
+++ b/account_invoice_currency_rate/wizard/force_currency_rate.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+###############################################################################
+#
+#   Module for OpenERP
+#   Copyright (C) 2015 Akretion (http://www.akretion.com). All Rights Reserved
+#   @author Benoît GUILLOT <benoit.guillot@akretion.com>
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as
+#   published by the Free Software Foundation, either version 3 of the
+#   License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+
+from openerp.osv import fields, orm
+
+
+class invoice_force_currency_rate(orm.TransientModel):
+    _name = "invoice.force.currency.rate"
+    _description = "Force currency rate"
+
+    _columns = {
+        'currency_rate': fields.float(
+            'Forced currency rate',
+            help="You can force the currency rate on the invoice with this "
+                 "field.")
+        }
+
+    def _get_currency_rate(self, cr, uid, context=None):
+        if context is None:
+            context = {}
+        rate = 1
+        if context.get('active_id'):
+            invoice = self.pool['account.invoice'].browse(
+                cr, uid, context['active_id'], context=context)
+            rate = invoice.currency_id.rate
+        return rate
+
+    _defaults = {
+        'currency_rate': _get_currency_rate,
+        }
+
+    def force_currency_rate(self, cr, uid, ids, context=None):
+        if context is None:
+            context = {}
+        if context.get('active_id'):
+            wizard = self.browse(cr, uid, ids[0], context=context)
+            self.pool['account.invoice'].write(
+                cr, uid, context['active_id'],
+                {'currency_rate': wizard.currency_rate},
+                context=context)
+        return {'type': 'ir.actions.act_window_close'}

--- a/account_invoice_currency_rate/wizard/force_currency_rate_view.xml
+++ b/account_invoice_currency_rate/wizard/force_currency_rate_view.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Module for OpenERP
+  Copyright (C) 2015 Akretion (http://www.akretion.com). All Rights Reserved
+  @author Benoît GUILLOT <benoit.guillot@akretion.com>
+  The licence is in the file __openerp__.py
+-->
+
+<openerp>
+    <data>
+        <record id="invoice_force_currency_rate_view" model="ir.ui.view">
+            <field name="name">Force currency rate</field>
+            <field name="model">invoice.force.currency.rate</field>
+            <field name="arch" type="xml">
+                <form string="Force currency rate" version="7.0">
+                    <p class="oe_grey">
+                        Set the currency rate you want to force on this invoice.
+                    </p>
+                    <group>
+                        <field name="currency_rate" class="oe_inline"/>
+                    </group>
+                    <footer>
+                        <button name="force_currency_rate" type="object"
+                            string="Force currency rate" class="oe_highlight"/>
+                        or
+                        <button string="Cancel" class="oe_link" special="cancel"/>
+                    </footer>
+                </form>
+            </field>
+        </record>
+
+         <record id="action_force_currency_rate" model="ir.actions.act_window">
+            <field name="name">Force currency rate</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">invoice.force.currency.rate</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">form</field>
+            <field name="target">new</field>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
Hello, 

This PR adds a module : account_invoice_currency_rate. 
It allows to manually set the currency rate on account invoice and it will be used on the move creation.

Thanks for reviews
