### PR TITLE
[ADD] supplier invoice number info, only in supplier tree and search …

### DIFF
--- a/account_invoice_supplier_number_info/README.rst
+++ b/account_invoice_supplier_number_info/README.rst
@@ -1,0 +1,47 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+============================
+Supplier Invoice Number Info
+============================
+
+This module was written to add supplier invoice number field only to the supplier invoice tree view and to the supplier invoice search view.
+
+Usage
+===========
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/repo/github-com-oca-account-invoicing-95
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/account-invoicing/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/account-invoicing/issues/new?body=module:%20account_invoice_supplier_number_info%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Alessio Gerace <alessio.gerace@agilebg.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/account_invoice_supplier_number_info/__init__.py
+++ b/account_invoice_supplier_number_info/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Agile Business Group (<http://www.agilebg.com>)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################

--- a/account_invoice_supplier_number_info/__openerp__.py
+++ b/account_invoice_supplier_number_info/__openerp__.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Agile Business Group (<http://www.agilebg.com>)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': "Supplier Invoice Number Info",
+    'version': '8.0.1.0.0',
+    'category': 'Accounting',
+    'summary': "Allows to force invoice numbering on specific invoices",
+    'author': "Agile Business Group,Odoo Community Association (OCA)",
+    'website': 'http://www.agilebg.com',
+    'license': 'AGPL-3',
+    "depends": [
+        'account'
+    ],
+    "data": [
+        'view/invoice_view.xml'
+    ],
+    "installable": True,
+}

--- a/account_invoice_supplier_number_info/i18n/it.po
+++ b/account_invoice_supplier_number_info/i18n/it.po
@@ -1,0 +1,26 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#   * account_invoice_force_number
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 6.0.3\n"
+"Report-Msgid-Bugs-To: support@openerp.com\n"
+"POT-Creation-Date: 2011-11-16 16:44+0000\n"
+"PO-Revision-Date: 2014-01-17 18:31+0000\n"
+"Last-Translator: Lorenzo Battistini - Agile BG "
+"<lorenzo.battistini@agilebg.com>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2014-03-21 06:54+0000\n"
+"X-Generator: Launchpad (build 16967)\n"
+
+
+#. module: account_invoice_force_number
+#: model:ir.module.module,shortdesc:account_invoice_force_number.module_meta_information
+msgid "Supplier Invoice Number Info"
+msgstr "Info numero fattura fornitore"
+
+

--- a/account_invoice_supplier_number_info/view/invoice_view.xml
+++ b/account_invoice_supplier_number_info/view/invoice_view.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+<data>
+
+        <record id="account.invoice_tree" model="ir.ui.view">
+            <field name="mode">primary</field>
+        </record>
+
+        <record id="account.view_account_invoice_filter" model="ir.ui.view">
+            <field name="mode">primary</field>
+        </record>
+
+
+        <record model="ir.ui.view" id="view_account_invoice_supplier_tree">
+            <field name="name">view.account_invoice.supplier.tree</field>
+            <field name="model">account.invoice</field>
+            <field name="inherit_id" ref="account.invoice_tree" />
+            <field name="mode">primary</field>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='date_invoice']" position="before">
+                    <field name="supplier_invoice_number"/>
+                </xpath>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="view_account_invoice_supplier_search">
+            <field name="name">view.account.invoice.supplier.search</field>
+            <field name="model">account.invoice</field>
+            <field name="inherit_id" ref="account.view_account_invoice_filter" />
+            <field name="mode">primary</field>
+            <field name="arch" type="xml">
+                <xpath expr="/search/field[@name='number']" position="before">
+                    <field name="supplier_invoice_number"/>
+                </xpath>
+            </field>
+        </record>
+
+        <record id="account.action_invoice_tree2" model="ir.actions.act_window">
+            <field name="search_view_id" ref="view_account_invoice_supplier_search"/>
+        </record>
+
+        <record id="action_invoice_tree2_view1" model="ir.actions.act_window.view">
+            <field eval="1" name="sequence"/>
+            <field name="view_mode">tree</field>
+            <field name="view_id" ref="view_account_invoice_supplier_tree"/>
+            <field name="act_window_id" ref="account.action_invoice_tree2"/>
+        </record>
+
+        <record id="action_invoice_tree2_view2" model="ir.actions.act_window.view">
+            <field eval="2" name="sequence"/>
+            <field name="view_mode">form</field>
+            <field name="act_window_id" ref="account.action_invoice_tree2"/>
+        </record>
+
+        <record id="action_invoice_tree4_view1" model="ir.actions.act_window.view">
+            <field eval="1" name="sequence"/>
+            <field name="view_mode">tree</field>
+            <field name="view_id" ref="view_account_invoice_supplier_tree"/>
+            <field name="act_window_id" ref="account.action_invoice_tree4"/>
+        </record>
+
+        <record id="action_invoice_tree4_view2" model="ir.actions.act_window.view">
+            <field eval="2" name="sequence"/>
+            <field name="view_mode">form</field>
+            <field name="act_window_id" ref="account.action_invoice_tree4"/>
+        </record>
+
+</data>
+</openerp>


### PR DESCRIPTION
…view
consider:

https://github.com/OCA/account-invoicing/pull/90#issuecomment-121628283
I've proposed a module , because is not a simple adding a field in a view, but implements a way to create and open your own inherited invoice view ,without modify the existing view, via the "mode=priority".
