### PR TITLE
[8.0][FIX] Merge invoices from purchase order

### DIFF
--- a/account_invoice_merge/invoice.py
+++ b/account_invoice_merge/invoice.py
@@ -196,8 +196,6 @@ class account_invoice(models.Model):
             if 'sale.order' in self.env.registry else False
         invoice_line_obj = self.env['account.invoice.line']
         # None if purchase is not installed
-        po_obj = self.env['purchase.order']\
-            if 'purchase.order' in self.env.registry else False
         for new_invoice_id in invoices_info:
             if so_obj:
                 todos = so_obj.search(
@@ -211,10 +209,6 @@ class account_invoice(models.Model):
                         if invoice_line_ids:
                             so_line.write(
                                 {'invoice_lines': [(6, 0, invoice_line_ids)]})
-            if po_obj:
-                todos = po_obj.search(
-                    [('invoice_ids', 'in', invoices_info[new_invoice_id])])
-                todos.write({'invoice_ids': [(4, new_invoice_id)]})
         # recreate link (if any) between original analytic account line
         # (invoice time sheet for example) and this new invoice
         anal_line_obj = self.env['account.analytic.line']

--- a/account_invoice_merge_purchase/README.rst
+++ b/account_invoice_merge_purchase/README.rst
@@ -1,0 +1,46 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License: AGPL-3
+
+Merge invoices from purchase order
+==================================
+
+This module provides a compatibility between purchase order workflow and account invoice merge module
+
+
+Usage
+=====
+
+* Click on install button
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/95/8.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/account-invoicing/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/account-invoicing/issues/new?body=module:%20account_invoice_merge_purchase%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Adrien Peiffer <adrien.peiffer@acsone.eu>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose mission is to support the collaborative development of Odoo features and promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/account_invoice_merge_purchase/README.rst
+++ b/account_invoice_merge_purchase/README.rst
@@ -10,8 +10,6 @@ This module provides a compatibility between purchase order workflow and account
 Usage
 =====
 
-* Click on install button
-
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
    :target: https://runbot.odoo-community.org/runbot/95/8.0

--- a/account_invoice_merge_purchase/__init__.py
+++ b/account_invoice_merge_purchase/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import models

--- a/account_invoice_merge_purchase/__openerp__.py
+++ b/account_invoice_merge_purchase/__openerp__.py
@@ -29,7 +29,7 @@
     'author': "ACSONE SA/NV,Odoo Community Association (OCA)",
     'website': "http://acsone.eu",
     'category': 'Finance',
-    'version': '0.1',
+    'version': '8.0.1.0.0',
     'license': 'AGPL-3',
     'depends': [
         'account_invoice_merge',

--- a/account_invoice_merge_purchase/__openerp__.py
+++ b/account_invoice_merge_purchase/__openerp__.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#     This file is part of account_invoice_merge_purchase,
+#     an Odoo module.
+#
+#     Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
+#
+#     account_invoice_merge_purchase is free software:
+#     you can redistribute it and/or modify it under the terms of the GNU
+#     Affero General Public License as published by the Free Software
+#     Foundation,either version 3 of the License, or (at your option) any
+#     later version.
+#
+#     account_invoice_merge_purchase is distributed
+#     in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+#     even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#     PURPOSE.  See the GNU Affero General Public License for more details.
+#
+#     You should have received a copy of the GNU Affero General Public License
+#     along with account_invoice_merge_purchase.
+#     If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': "Account Invoice Merge Purchase",
+
+    'summary': """Compatibility between purchase and account invoice merge""",
+    'author': "ACSONE SA/NV,Odoo Community Association (OCA)",
+    'website': "http://acsone.eu",
+    'category': 'Finance',
+    'version': '0.1',
+    'license': 'AGPL-3',
+    'depends': [
+        'account_invoice_merge',
+        'purchase',
+    ],
+    'auto_install': True,
+}

--- a/account_invoice_merge_purchase/models/__init__.py
+++ b/account_invoice_merge_purchase/models/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import account_invoice

--- a/account_invoice_merge_purchase/models/account_invoice.py
+++ b/account_invoice_merge_purchase/models/account_invoice.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#     This file is part of account_invoice_merge_purchase,
+#     an Odoo module.
+#
+#     Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
+#
+#     account_invoice_merge_purchase is free software:
+#     you can redistribute it and/or modify it under the terms of the GNU
+#     Affero General Public License as published by the Free Software
+#     Foundation,either version 3 of the License, or (at your option) any
+#     later version.
+#
+#     account_invoice_merge_purchase is distributed
+#     in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+#     even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#     PURPOSE.  See the GNU Affero General Public License for more details.
+#
+#     You should have received a copy of the GNU Affero General Public License
+#     along with account_invoice_merge_purchase.
+#     If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models, api
+from openerp.addons.account_invoice_merge.invoice import INVOICE_LINE_KEY_COLS
+
+INVOICE_LINE_KEY_COLS.append('purchase_line_id')
+
+
+class AccountInvoice(models.Model):
+    _inherit = 'account.invoice'
+
+    @api.multi
+    def do_merge(self, keep_references=True, date_invoice=False):
+        invoices_info = super(AccountInvoice, self).do_merge(
+            keep_references=keep_references, date_invoice=date_invoice)
+        po_obj = self.env['purchase.order']
+        invoice_line_obj = self.env['account.invoice.line']
+        for new_invoice_id in invoices_info:
+            todos = po_obj.search(
+                [('invoice_ids', 'in', invoices_info[new_invoice_id])])
+            todos.write({'invoice_ids': [(4, new_invoice_id)]})
+            for org_po in todos:
+                for po_line in org_po.order_line:
+                    invoice_line_ids = invoice_line_obj.search(
+                        [('invoice_id.state', '!=', 'cancel'),
+                         ('purchase_line_id', '=', po_line.id)])
+                    if invoice_line_ids.ids:
+                        po_line.write(
+                            {'invoice_lines': [(6, 0,
+                                                invoice_line_ids.ids)]})
+        return invoices_info

--- a/account_invoice_merge_purchase/models/account_invoice.py
+++ b/account_invoice_merge_purchase/models/account_invoice.py
@@ -24,13 +24,16 @@
 ##############################################################################
 
 from openerp import models, api
-from openerp.addons.account_invoice_merge.invoice import INVOICE_LINE_KEY_COLS
-
-INVOICE_LINE_KEY_COLS.append('purchase_line_id')
 
 
 class AccountInvoice(models.Model):
     _inherit = 'account.invoice'
+
+    @api.model
+    def _get_invoice_line_key_cols(self):
+        res = super(AccountInvoice, self)._get_invoice_line_key_cols()
+        res.append('purchase_line_id')
+        return res
 
     @api.multi
     def do_merge(self, keep_references=True, date_invoice=False):

--- a/account_invoice_merge_purchase/tests/__init__.py
+++ b/account_invoice_merge_purchase/tests/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import test_account_invoice_merge_purchase

--- a/account_invoice_merge_purchase/tests/test_account_invoice_merge_purchase.py
+++ b/account_invoice_merge_purchase/tests/test_account_invoice_merge_purchase.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#     This file is part of account_invoice_merge_purchase,
+#     an Odoo module.
+#
+#     Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
+#
+#     account_invoice_merge_purchase is free software:
+#     you can redistribute it and/or modify it under the terms of the GNU
+#     Affero General Public License as published by the Free Software
+#     Foundation,either version 3 of the License, or (at your option) any
+#     later version.
+#
+#     account_invoice_merge_purchase is distributed
+#     in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+#     even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#     PURPOSE.  See the GNU Affero General Public License for more details.
+#
+#     You should have received a copy of the GNU Affero General Public License
+#     along with account_invoice_merge_purchase.
+#     If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.tests import common
+from openerp import workflow
+from datetime import datetime
+
+
+def create_simple_po(self, partner, invoice_method):
+    vals = {'partner_id': partner.id,
+            'invoice_method': invoice_method,
+            'location_id': self.ref('stock.stock_location_stock'),
+            'pricelist_id': self.ref('purchase.list0'),
+            'order_line': [(0, 0, {'name': 'test',
+                                   'date_planned': datetime.today(),
+                                   'price_unit': 10,
+                                   })]
+            }
+    return self.po_obj.create(vals)
+
+
+def pay_invoice(self, invoice):
+    aml = self.aml_obj.search(
+        [('account_id.type', 'in', ['payable', 'receivable']),
+         ('invoice.id', '=', invoice.id)])
+    ctx = self.context.copy()
+    ctx.update({'active_ids': [aml.id]})
+    writeoff = self.writeoff_obj.with_context(active_ids=[aml.id]).create(
+        {'journal_id': self.journal01.id,
+         'writeoff_acc_id': self.account01.id})
+    writeoff.trans_rec_reconcile()
+
+
+class TestAccountInvoiceMergePurchase(common.TransactionCase):
+
+    def setUp(self):
+        super(TestAccountInvoiceMergePurchase, self).setUp()
+        self.partner01 = self.env.ref('base.res_partner_1')
+        self.context = self.env['res.users'].context_get()
+        self.po_obj = self.env['purchase.order']
+        self.inv_obj = self.env['account.invoice']
+        self.aml_obj = self.env['account.move.line']
+        self.journal01 = self.env.ref('account.miscellaneous_journal')
+        self.account01 = self.env.ref('account.a_pay')
+        self.writeoff_obj = self.env['account.move.line.reconcile.writeoff']
+
+    def test_multi_purchase_order(self):
+        purchase_order01 = create_simple_po(self, self.partner01, 'order')
+        # I confirm the purchase order
+        workflow.trg_validate(self.uid, 'purchase.order',
+                              purchase_order01.id, 'purchase_confirm',
+                              self.cr)
+        # I check if the purchase order is confirmed
+        purchase_order01.invalidate_cache()
+        self.assertEqual(purchase_order01.state, 'approved',
+                         "Purchase order's state isn't correct")
+        invoice_ids = purchase_order01.invoice_ids.ids
+        purchase_order02 = purchase_order01.copy()
+        # I confirm the purchase order
+        workflow.trg_validate(self.uid, 'purchase.order',
+                              purchase_order02.id, 'purchase_confirm',
+                              self.cr)
+        # I check if the purchase order is confirmed
+        purchase_order02.invalidate_cache()
+        self.assertEqual(purchase_order02.state, 'approved',
+                         "Purchase order's state isn't correct")
+        invoice_ids.extend(purchase_order02.invoice_ids.ids)
+        invoices = self.inv_obj.browse(invoice_ids)
+        invoices_info = invoices.do_merge()
+        new_invoice_ids = invoices_info.keys()
+        # Ensure there is only one new invoice
+        self.assertEqual(len(new_invoice_ids), 1)
+        # I post the created invoice
+        workflow.trg_validate(self.uid, 'account.invoice', new_invoice_ids[0],
+                              'invoice_open', self.cr)
+        # I pay the merged invoice
+        invoice = self.inv_obj.browse(new_invoice_ids)[0]
+        pay_invoice(self, invoice)
+        # I check if merge invoice is paid
+        self.assertEqual(invoice.state, 'paid')
+        purchase_order01.invalidate_cache()
+        # I check if purchase order are done
+        self.assertEqual(purchase_order01.state, 'done')
+        self.assertEqual(purchase_order02.state, 'done')


### PR DESCRIPTION
Currently in account_invoice_merge, in case of merge of invoices genereted from the purchase order, when the new invoice is paid, the related purchase order don't go to the 'done' state.

I take this opportunity to create a new module to make the link between account_invoice_merge and purchase module.
- [x] Depends on #98 
