### PR TITLE
8.0 Add support for payment terms such as 'End of month 45 days'

### DIFF
--- a/account_payment_term_extension/README.rst
+++ b/account_payment_term_extension/README.rst
@@ -5,6 +5,8 @@ This module was written to extend the functionality of payment terms to support 
 
 By default in Odoo, if you have a payment term of *30 days end of months* and you invoice on January 30, you will have a due date on March 31st. With this module, if you configure the payment term line with months = 1, days = 0 and days2 = -1, you will have a due date on February 28th.
 
+This module also adds support for payment terms such as *End of month 45 days* (which is not the same as *45 days end of month* !).
+
 Configuration
 =============
 

--- a/account_payment_term_extension/account_view.xml
+++ b/account_payment_term_extension/account_view.xml
@@ -15,6 +15,9 @@
                     <field name="weeks"/>
                     <field name="months"/>
                 </field>
+                <field name="days" position="before">
+                    <field name="start_with_end_month"/>
+                </field>
             </field>
         </record>
 
@@ -29,6 +32,9 @@
                 <field name="days" position="after">
                     <field name="weeks"/>
                     <field name="months"/>
+                </field>
+                <field name="days" position="before">
+                    <field name="start_with_end_month"/>
                 </field>
             </field>
         </record>


### PR DESCRIPTION
Add support for payment terms such as 'End of month 45 days'... which is not the same as '45 days end of month' !!!
