### PR TITLE
[FIX] account_invoice_merge: Don't lose invoice line data

### DIFF
--- a/account_invoice_merge/README.rst
+++ b/account_invoice_merge/README.rst
@@ -25,13 +25,10 @@ Usage
 Bug Tracker
 ===========
 
-Bugs are tracked on `GitHub Issues <https://github.com/OCA/account-invoicing/issues>`_.
-In case of trouble, please check there if your issue has already been reported.
-If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
-`here <https://github.com/OCA/
-account-invoicing/issues/new?body=module:%20
-account_invoice_merge%0Aversion:%20
-8.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/account-invoicing/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
 
 
 Credits
@@ -42,7 +39,7 @@ Contributors
 
 * Ian Li <ian.li@elico-corp.com>
 * Cédric Pigeon <cedric.pigeon@acsone.eu>
-* Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+* Pedro M. Baeza <pedro.baeza@tecnativa.com>
 
 Maintainer
 ----------

--- a/account_invoice_merge/README.rst
+++ b/account_invoice_merge/README.rst
@@ -1,3 +1,8 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==============
 Merge invoices
 ==============
 
@@ -10,6 +15,12 @@ the conditions to allow merging:
 * Currency should be the same
 * Account receivable account should be the same
 
+Usage
+=====
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/95/8,0
 
 Bug Tracker
 ===========
@@ -17,7 +28,10 @@ Bug Tracker
 Bugs are tracked on `GitHub Issues <https://github.com/OCA/account-invoicing/issues>`_.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
-`here <https://github.com/OCA/account-invoicing/issues/new?body=module:%20account_invoice_merge%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+`here <https://github.com/OCA/
+account-invoicing/issues/new?body=module:%20
+account_invoice_merge%0Aversion:%20
+8.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 
 Credits
@@ -28,16 +42,19 @@ Contributors
 
 * Ian Li <ian.li@elico-corp.com>
 * Cédric Pigeon <cedric.pigeon@acsone.eu>
+* Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
 
 Maintainer
 ----------
 
 .. image:: http://odoo-community.org/logo.png
    :alt: Odoo Community Association
-   :target: http://odoo-community.org
+   :target: https://odoo-community.org
 
 This module is maintained by the OCA.
 
-OCA, or the Odoo Community Association, is a nonprofit organization whose mission is to support the collaborative development of Odoo features and promote its widespread use.
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
 
-To contribute to this module, please visit http://odoo-community.org.
+To contribute to this module, please visit https://odoo-community.org.

--- a/account_invoice_merge/__openerp__.py
+++ b/account_invoice_merge/__openerp__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # © 2010-2011 Ian Li <ian.li@elico-corp.com>
 # © 2015 Cédric Pigeon <cedric.pigeon@acsone.eu>
-# © 2016 Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+# © 2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {
@@ -10,7 +10,7 @@
     'category': 'Finance',
     'author': "Elico Corp, "
               "ACSONE A/V, "
-              "Serv. Tecnol. Avanzados - Pedro M. Baeza, "
+              "Tecnativa, "
               "Odoo Community Association (OCA)",
     'website': 'http://www.openerp.net.cn',
     'license': 'AGPL-3',

--- a/account_invoice_merge/__openerp__.py
+++ b/account_invoice_merge/__openerp__.py
@@ -1,40 +1,22 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    OpenERP, Open Source Management Solution
-#    Copyright (c) 2010-2011 Elico Corp. All Rights Reserved.
-#    Author: Ian Li <ian.li@elico-corp.com>
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2010-2011 Ian Li <ian.li@elico-corp.com>
+# © 2015 Cédric Pigeon <cedric.pigeon@acsone.eu>
+# © 2016 Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {
     'name': 'Account Invoice Merge Wizard',
-    'version': '8.0.1.1.1',
+    'version': '8.0.2.0.0',
     'category': 'Finance',
-    'author': "Elico Corp,Odoo Community Association (OCA)",
+    'author': "Elico Corp, "
+              "ACSONE A/V, "
+              "Serv. Tecnol. Avanzados - Pedro M. Baeza, "
+              "Odoo Community Association (OCA)",
     'website': 'http://www.openerp.net.cn',
     'license': 'AGPL-3',
     'depends': ['account'],
     'data': [
         'wizard/invoice_merge_view.xml',
     ],
-    'test': [
-    ],
-    'demo': [],
     'installable': True,
-    'active': False,
-    'certificate': False,
 }

--- a/account_invoice_merge/models/__init__.py
+++ b/account_invoice_merge/models/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from . import models
-from . import wizard
+from . import account_invoice

--- a/account_invoice_merge/models/account_invoice.py
+++ b/account_invoice_merge/models/account_invoice.py
@@ -179,14 +179,12 @@ class AccountInvoice(models.Model):
                 workflow.trg_validate(
                     self.env.uid, 'account.invoice', old_id, 'invoice_cancel',
                     self.env.cr)
-        # make link between original sale order or purchase order
-        # None if sale is not installed
-        so_obj = self.env['sale.order']\
-            if 'sale.order' in self.env.registry else False
-        invoice_line_obj = self.env['account.invoice.line']
+        # make link between original sale order if sale is not installed
         # None if purchase is not installed
-        for new_invoice_id in invoices_info:
-            if so_obj:
+        if 'sale.order' in self.env.registry:
+            so_obj = self.env['sale.order']
+            invoice_line_obj = self.env['account.invoice.line']
+            for new_invoice_id in invoices_info:
                 todos = so_obj.search(
                     [('invoice_ids', 'in', invoices_info[new_invoice_id])])
                 todos.write({'invoice_ids': [(4, new_invoice_id)]})

--- a/account_invoice_merge/models/account_invoice.py
+++ b/account_invoice_merge/models/account_invoice.py
@@ -53,14 +53,13 @@ class AccountInvoice(models.Model):
 
     @api.model
     def _merge_invoice_line_values(self, vals, new_invoice_line):
-        """This method merge an invoice line with the existing values from
+        """This method merges an invoice line with the existing values from
         previous line(s) that matches the merging key.
         :param vals: Dictionary of values of the previous invoice line(s)
         :param new_invoice_line: Recordset of the new line to merge.
         :return: None
         """
-        uos_factor = (new_invoice_line.uos_id and
-                      new_invoice_line.uos_id.factor or 1.0)
+        uos_factor = new_invoice_line.uos_id.factor or 1.0
         # merge the line with an existing line
         vals['quantity'] += (new_invoice_line.quantity *
                              uos_factor / vals['uom_factor'])

--- a/account_invoice_merge/models/account_invoice.py
+++ b/account_invoice_merge/models/account_invoice.py
@@ -1,29 +1,15 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    OpenERP, Open Source Management Solution
-#    Copyright (C) 2004-2010 Tiny SPRL (<http://tiny.be>).
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2010-2011 Ian Li <ian.li@elico-corp.com>
+# © 2015 Cédric Pigeon <cedric.pigeon@acsone.eu>
+# © 2016 Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from openerp import models, api
 from openerp import workflow
 from openerp.osv.orm import browse_record, browse_null
 
 
-class account_invoice(models.Model):
+class AccountInvoice(models.Model):
     _inherit = "account.invoice"
 
     @api.model
@@ -64,6 +50,20 @@ class account_invoice(models.Model):
             'invoice_line': {},
             'partner_bank_id': invoice.partner_bank_id.id,
         }
+
+    @api.model
+    def _merge_invoice_line_values(self, vals, new_invoice_line):
+        """This method merge an invoice line with the existing values from
+        previous line(s) that matches the merging key.
+        :param vals: Dictionary of values of the previous invoice line(s)
+        :param new_invoice_line: Recordset of the new line to merge.
+        :return: None
+        """
+        uos_factor = (new_invoice_line.uos_id and
+                      new_invoice_line.uos_id.factor or 1.0)
+        # merge the line with an existing line
+        vals['quantity'] += (new_invoice_line.quantity *
+                             uos_factor / vals['uom_factor'])
 
     @api.multi
     def do_merge(self, keep_references=True, date_invoice=False):
@@ -147,20 +147,13 @@ class account_invoice(models.Model):
                 line_key = make_key(
                     invoice_line, self._get_invoice_line_key_cols())
                 o_line = invoice_infos['invoice_line'].setdefault(line_key, {})
-                uos_factor = (invoice_line.uos_id and
-                              invoice_line.uos_id.factor or 1.0)
                 if o_line:
-                    # merge the line with an existing line
-                    o_line['quantity'] += invoice_line.quantity * \
-                        uos_factor / o_line['uom_factor']
+                    self._merge_invoice_line_values(o_line, invoice_line)
                 else:
                     # append a new "standalone" line
-                    for field in ('quantity', 'uos_id'):
-                        field_val = getattr(invoice_line, field)
-                        if isinstance(field_val, browse_record):
-                            field_val = field_val.id
-                        o_line[field] = field_val
-                    o_line['uom_factor'] = uos_factor
+                    o_line.update(
+                        invoice_line._convert_to_write(invoice_line._cache))
+                    del o_line['invoice_id']
         allinvoices = []
         invoices_info = {}
         for invoice_key, (invoice_data, old_ids) in new_invoices.iteritems():
@@ -168,10 +161,6 @@ class account_invoice(models.Model):
             if len(old_ids) < 2:
                 allinvoices += (old_ids or [])
                 continue
-            # cleanup invoice line data
-            for key, value in invoice_data['invoice_line'].iteritems():
-                del value['uom_factor']
-                value.update(dict(key))
             invoice_data['invoice_line'] = [
                 (0, 0, value) for value in
                 invoice_data['invoice_line'].itervalues()]

--- a/account_invoice_merge/wizard/__init__.py
+++ b/account_invoice_merge/wizard/__init__.py
@@ -1,22 +1,5 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    OpenERP, Open Source Management Solution
-#    Copyright (c) 2010-2011 Elico Corp. All Rights Reserved.
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2010-2011 Ian Li <ian.li@elico-corp.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import invoice_merge

--- a/account_invoice_merge/wizard/invoice_merge.py
+++ b/account_invoice_merge/wizard/invoice_merge.py
@@ -1,34 +1,17 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    OpenERP, Open Source Management Solution
-#    Copyright (c) 2010-2011 Elico Corp. All Rights Reserved.
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2010-2011 Ian Li <ian.li@elico-corp.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from openerp import models, fields, api, exceptions
 from openerp.tools.translate import _
 
 
-class invoice_merge(models.TransientModel):
+class InvoiceMerge(models.TransientModel):
     _name = "invoice.merge"
     _description = "Merge Partner Invoice"
 
-    keep_references = fields.Boolean('Keep references'
-                                     ' from original invoices',
-                                     default=True)
+    keep_references = fields.Boolean(
+        string='Keep references from original invoices', default=True)
     date_invoice = fields.Date('Invoice Date')
 
     @api.model
@@ -78,7 +61,7 @@ class invoice_merge(models.TransientModel):
          @param context: A standard dictionary
          @return: New arch of view.
         """
-        res = super(invoice_merge, self).fields_view_get(
+        res = super(InvoiceMerge, self).fields_view_get(
             view_id=view_id, view_type=view_type, toolbar=toolbar,
             submenu=False)
         self._dirty_check()


### PR DESCRIPTION
The module ignored all previous values of the line except the already programmed, making that you lose any value of custom fields, unless you make a glue module for adding this value. With this PR, all values are brought by default, and it also provides a hook method for treating conflicting merging values (like for example quantities), allowing to make any operation with them (in the example, sum both quantities).
