### PR TITLE
[FIX] Fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,8 @@ env:
   matrix:
   - LINT_CHECK="1"
   - TRANSIFEX="1"
-  - TESTS="1" ODOO_REPO="odoo/odoo" EXCLUDE="account_invoice_validation_workflow"
-  - TESTS="1" ODOO_REPO="OCA/OCB"   EXCLUDE="account_invoice_validation_workflow"
-  - TESTS="1" ODOO_REPO="odoo/odoo" INCLUDE="account_invoice_validation_workflow"
-  - TESTS="1" ODOO_REPO="OCA/OCB"   INCLUDE="account_invoice_validation_workflow"
+  - TESTS="1" ODOO_REPO="odoo/odoo"
+  - TESTS="1" ODOO_REPO="OCA/OCB"
 
 virtualenv:
   system_site_packages: true


### PR DESCRIPTION
Travis builds are red because tests include a module which is not
installable.
So I removed this module from INCLUDE/EXCLUDE list

https://github.com/OCA/account-invoicing/blob/9.0/account_invoice_validation_workflow/__openerp__.py#L43
