### PR TITLE
[CHG] Add auto_install module in install_requires of principal module's setup

### DIFF
--- a/setup/account_invoice_merge/setup.py
+++ b/setup/account_invoice_merge/setup.py
@@ -2,5 +2,9 @@ import setuptools
 
 setuptools.setup(
     setup_requires=['setuptools-odoo'],
+    install_requires=[
+        'odoo8-addon-account_invoice_merge_purchase',
+        'odoo8-addon-account_invoice_merge_payment',
+    ],
     odoo_addon=True,
 )


### PR DESCRIPTION
That allows to download auto_install module related with account_invoice_merge during installation with pip.
