### PR TITLE
8.0 account_invoice_merge fixes

### DIFF
--- a/account_invoice_merge/__openerp__.py
+++ b/account_invoice_merge/__openerp__.py
@@ -6,11 +6,12 @@
 
 {
     'name': 'Account Invoice Merge Wizard',
-    'version': '8.0.2.0.0',
+    'version': '8.0.2.0.1',
     'category': 'Finance',
     'author': "Elico Corp, "
               "ACSONE A/V, "
               "Tecnativa, "
+              "Noviat, "
               "Odoo Community Association (OCA)",
     'website': 'http://www.openerp.net.cn',
     'license': 'AGPL-3',

--- a/account_invoice_merge/tests/__init__.py
+++ b/account_invoice_merge/tests/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import test_account_invoice_merge

--- a/account_invoice_merge/tests/test_account_invoice_merge.py
+++ b/account_invoice_merge/tests/test_account_invoice_merge.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+# Copyright 2009-2017 Noviat.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from openerp.tests.common import TransactionCase
+from openerp.exceptions import Warning as UserError
+
+
+class TestAccountInvoiceMerge(TransactionCase):
+
+    def setUp(self):
+        super(TestAccountInvoiceMerge, self).setUp()
+
+        self.wiz_model = self.env['invoice.merge']
+        self.wiz_context = {'active_model': 'account.invoice'}
+        self.invoice_model = self.env['account.invoice']
+        self.account_payable = self.env.ref('account.a_pay')
+        self.partner_1 = self.env.ref('base.res_partner_1')
+        self.partner_2 = self.env.ref('base.res_partner_2')
+
+        self.supplier_invoice_1 = self.invoice_model.create(
+            {'journal_id': self.env.ref('account.expenses_journal').id,
+             'type': 'in_invoice',
+             'partner_id': self.partner_1.id,
+             'account_id': self.account_payable.id,
+             'invoice_line': [(0, 0, {'name': 'Inv 1 - Line 1',
+                                      'price_unit': 100.0})],
+             })
+
+        self.supplier_invoice_2 = self.invoice_model.create(
+            {'journal_id': self.env.ref('account.expenses_journal').id,
+             'type': 'in_invoice',
+             'partner_id': self.partner_1.id,
+             'account_id': self.account_payable.id,
+             'invoice_line': [(0, 0, {'name': 'Inv 2 - Line 1',
+                                      'price_unit': 150.0})],
+             })
+
+        self.supplier_invoice_3 = self.invoice_model.create(
+            {'journal_id': self.env.ref('account.expenses_journal').id,
+             'type': 'in_invoice',
+             'partner_id': self.partner_2.id,
+             'account_id': self.account_payable.id,
+             'invoice_line': [(0, 0, {'name': 'Inv 3 - Line 1',
+                                      'price_unit': 50.0})],
+             })
+
+    def test_invoice_merge(self):
+        invoices = self.supplier_invoice_1 + self.supplier_invoice_2
+        invoices_info, invoice_lines_info = invoices.do_merge()
+        for k in invoices_info:
+            new_inv = self.invoice_model.browse(k)
+            self.assertEqual(new_inv.amount_total, 250.0)
+            new_inv_line_ids = invoice_lines_info[k].values()
+            self.assertEqual(
+                len(new_inv_line_ids), len(new_inv.invoice_line._ids),
+                "Incorrect Invoice Line Mapping")
+
+    def test_invoice_merge_wizard(self):
+        invoices = self.supplier_invoice_1 + self.supplier_invoice_2
+        ctx = dict(self.wiz_context, active_ids=invoices._ids)
+        wiz = self.wiz_model.with_context(ctx).create({})
+        act = wiz.merge_invoices()
+        self.assertEqual(
+            len(act['domain'][0][2]), 3, "Error in invoice.merge wizard")
+
+    def test_dirty_check(self):
+        invoices = self.supplier_invoice_1 + self.supplier_invoice_3
+        ctx = dict(self.wiz_context, active_ids=invoices._ids)
+        wiz = self.wiz_model.with_context(ctx).create({})
+        with self.assertRaises(UserError):
+            wiz._dirty_check()

--- a/account_invoice_merge/wizard/invoice_merge.py
+++ b/account_invoice_merge/wizard/invoice_merge.py
@@ -2,8 +2,8 @@
 # © 2010-2011 Ian Li <ian.li@elico-corp.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from openerp import models, fields, api, exceptions
-from openerp.tools.translate import _
+from openerp import api, fields, models, _
+from openerp.exceptions import Warning as UserError
 
 
 class InvoiceMerge(models.TransientModel):
@@ -16,39 +16,42 @@ class InvoiceMerge(models.TransientModel):
 
     @api.model
     def _dirty_check(self):
-        if self.env.context.get('active_model', '') == 'account.invoice':
-            ids = self.env.context['active_ids']
+        if self._context.get('active_model') == 'account.invoice':
+            ids = self._context['active_ids']
             if len(ids) < 2:
-                raise exceptions.UserError(
+                raise UserError(
                     _('Please select multiple invoice to merge in the list '
                       'view.'))
-            inv_obj = self.env['account.invoice']
-            invs = inv_obj.read(ids,
-                                ['account_id', 'state', 'type', 'company_id',
-                                 'partner_id', 'currency_id', 'journal_id'])
-            for d in invs:
-                if d['state'] != 'draft':
-                    raise exceptions.UserError(
+            invs = self.env['account.invoice'].browse(ids)
+            for i, inv in enumerate(invs):
+                if inv.state != 'draft':
+                    raise UserError(
                         _('At least one of the selected invoices is %s!') %
-                        d['state'])
-                if d['account_id'] != invs[0]['account_id']:
-                    raise exceptions.UserError(
-                        _('Not all invoices use the same account!'))
-                if d['company_id'] != invs[0]['company_id']:
-                    raise exceptions.UserError(
-                        _('Not all invoices are at the same company!'))
-                if d['partner_id'] != invs[0]['partner_id']:
-                    raise exceptions.UserError(
-                        _('Not all invoices are for the same partner!'))
-                if d['type'] != invs[0]['type']:
-                    raise exceptions.UserError(
-                        _('Not all invoices are of the same type!'))
-                if d['currency_id'] != invs[0]['currency_id']:
-                    raise exceptions.UserError(
-                        _('Not all invoices are at the same currency!'))
-                if d['journal_id'] != invs[0]['journal_id']:
-                    raise exceptions.UserError(
-                        _('Not all invoices are at the same journal!'))
+                        inv.state)
+                if i > 0:
+                    if inv.account_id != invs[0].account_id:
+                        raise UserError(
+                            _('Not all invoices use the same account!'))
+                    if inv.company_id != invs[0].company_id:
+                        raise UserError(
+                            _('Not all invoices are at the same company!'))
+                    if inv.partner_id != invs[0].partner_id:
+                        raise UserError(
+                            _('Not all invoices are for the same partner!'))
+                    if inv.type != invs[0].type:
+                        raise UserError(
+                            _('Not all invoices are of the same type!'))
+                    if inv.currency_id != invs[0].currency_id:
+                        raise UserError(
+                            _('Not all invoices are at the same currency!'))
+                    if inv.journal_id != invs[0].journal_id:
+                        raise UserError(
+                            _('Not all invoices are at the same journal!'))
+                    if inv.partner_bank_id != invs[0].partner_bank_id:
+                        raise UserError(
+                            _('Not all invoices have the same '
+                              'Partner Bank Account!'))
+
         return {}
 
     @api.model
@@ -79,14 +82,11 @@ class InvoiceMerge(models.TransientModel):
 
              @return: account invoice action
         """
-        inv_obj = self.env['account.invoice']
         aw_obj = self.env['ir.actions.act_window']
-        ids = self.env.context.get('active_ids', [])
-        invoices = inv_obj.browse(ids)
-        invoices_info, invoice_lines_info = invoices.do_merge(
-            keep_references=self.keep_references,
-            date_invoice=self.date_invoice
-        )
+        ids = self._context.get('active_ids', [])
+        invoices = self.env['account.invoice'].browse(ids)
+        allinvoices = invoices.do_merge(keep_references=self.keep_references,
+                                        date_invoice=self.date_invoice)[0]
         xid = {
             'out_invoice': 'action_invoice_tree1',
             'out_refund': 'action_invoice_tree3',
@@ -95,6 +95,6 @@ class InvoiceMerge(models.TransientModel):
         }[invoices[0].type]
         action = aw_obj.for_xml_id('account', xid)
         action.update({
-            'domain': [('id', 'in', ids + invoices_info.keys())],
+            'domain': [('id', 'in', list(ids) + allinvoices.keys())],
         })
         return action

--- a/account_invoice_merge_payment/__init__.py
+++ b/account_invoice_merge_payment/__init__.py
@@ -1,2 +1,3 @@
 # -*- coding: utf-8 -*-
 from . import models
+from . import wizard

--- a/account_invoice_merge_payment/__openerp__.py
+++ b/account_invoice_merge_payment/__openerp__.py
@@ -29,7 +29,7 @@
     'author': "ACSONE SA/NV,Odoo Community Association (OCA)",
     'website': "http://acsone.eu",
     'category': 'Invoicing & Payments',
-    'version': '8.0.0.1.0',
+    'version': '8.0.0.1.1',
     'license': 'AGPL-3',
     'depends': [
         'account_invoice_merge',

--- a/account_invoice_merge_payment/wizard/__init__.py
+++ b/account_invoice_merge_payment/wizard/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import invoice_merge

--- a/account_invoice_merge_payment/wizard/invoice_merge.py
+++ b/account_invoice_merge_payment/wizard/invoice_merge.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Copyright 2009-2017 Noviat
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import api, models, _
+from openerp.exceptions import Warning as UserError
+
+
+class InvoiceMerge(models.TransientModel):
+    _inherit = 'invoice.merge'
+
+    @api.model
+    def _dirty_check(self):
+        res = super(InvoiceMerge, self)._dirty_check()
+        ids = self._context['active_ids']
+        invs = self.env['account.invoice'].browse(ids)
+        for i, inv in enumerate(invs):
+            if i > 0:
+                if inv.payment_mode_id != invs[0].payment_mode_id:
+                    raise UserError(
+                        _('Not all invoices have the same Payment Mode!'))
+        return res

--- a/account_invoice_merge_purchase/__openerp__.py
+++ b/account_invoice_merge_purchase/__openerp__.py
@@ -9,7 +9,7 @@
     'author': "ACSONE SA/NV,Noviat,Odoo Community Association (OCA)",
     'website': "http://acsone.eu",
     'category': 'Finance',
-    'version': '8.0.2.0.0',
+    'version': '8.0.2.0.1',
     'license': 'AGPL-3',
     'depends': [
         'account_invoice_merge',

--- a/account_invoice_merge_purchase/models/account_invoice.py
+++ b/account_invoice_merge_purchase/models/account_invoice.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
-# Copyright 2009-2016 Noviat
+# Copyright 2009-2017 Noviat
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from openerp import api, models
 
@@ -26,7 +26,9 @@ class AccountInvoice(models.Model):
             todos.write({'invoice_ids': [(4, new_invoice_id)]})
             for org_po in todos:
                 for po_line in org_po.order_line:
-                    org_ilines = po_line.mapped('invoice_lines')
+                    org_ilines = po_line.mapped('invoice_lines').filtered(
+                        lambda l: l.invoice_id.id
+                        in invoices_info[new_invoice_id])
                     invoice_line_ids = []
                     for org_iline in org_ilines:
                         invoice_line_ids.append(

--- a/account_invoice_merge_purchase/tests/test_account_invoice_merge_purchase.py
+++ b/account_invoice_merge_purchase/tests/test_account_invoice_merge_purchase.py
@@ -96,10 +96,16 @@ class TestAccountInvoiceMergePurchase(common.TransactionCase):
                          "Purchase order's state isn't correct")
         invoice_ids.extend(purchase_order02.invoice_ids.ids)
         invoices = self.inv_obj.browse(invoice_ids)
-        invoices_info, inv_lines_info = invoices.do_merge()
+        invoices_info, invoice_lines_info = invoices.do_merge()
         new_invoice_ids = invoices_info.keys()
         # Ensure there is only one new invoice
         self.assertEqual(len(new_invoice_ids), 1)
+        # Check invoice_lines_info
+        invoice_lines = invoices.mapped('invoice_line')
+        for v in invoice_lines_info:
+            for k in invoice_lines_info[v]:
+                self.assertIn(k, invoice_lines._ids,
+                              "Incorrect Invoice Line Mapping")
         # I post the created invoice
         workflow.trg_validate(self.uid, 'account.invoice', new_invoice_ids[0],
                               'invoice_open', self.cr)
@@ -150,7 +156,7 @@ class TestAccountInvoiceMergePurchase(common.TransactionCase):
         picking02.do_transfer()
         invoice_ids.extend(invoice_picking(self, picking02))
         invoices = self.inv_obj.browse(invoice_ids)
-        invoices_info, inv_lines_info = invoices.do_merge()
+        invoices_info = invoices.do_merge()[0]
         new_invoice_ids = invoices_info.keys()
         # Ensure there is only one new invoice
         self.assertEqual(len(new_invoice_ids), 1)


### PR DESCRIPTION
This PR contains a couple of fixes and extra units tests for the account_invoice_merge modules:
- fix python dump when running account_invoice_merge without account_invoice_merge_purchase
- fix _dirty_check method
- addition of unit tests to the account_invoice_merge module.
- fix python dump in case 'sale_order_line_invoice_rel' points to an invoice line that is not present in Sale Order invoices
- remove obsolete code in do_merge (the population of allinvoices list doesn't make any sense)
- maintain invoice line sequence in merged invoice
- extra unit tests in account_invoice_merge_purchase module