### PR TITLE
[8.0] ADD account_invoice_rounding_by_currency

### DIFF
--- a/account_invoice_rounding_by_currency/README.rst
+++ b/account_invoice_rounding_by_currency/README.rst
@@ -1,0 +1,73 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+===================================================
+Unit rounded invoice (Swedish rounding) by currency
+===================================================
+
+This module extends functionality of module `Unit rounded invoice <https://github.com/OCA/account-invoicing/tree/8.0/account_invoice_rounding>`_.
+
+It allows to set, in accounting settings, a rounding precision for each currency,
+such as 0.05 CHF for Swiss invoices
+
+Configuration
+=============
+
+In Settings -> Configuration -> Accounting you will find
+Currencies Rounding Rules
+Set currency rule for each currency you need to handle.
+
+- `Swedish Round globally`
+
+  To round your invoice total amount, this option will do the adjustment in
+  the most important tax line of your invoice.
+
+- `Swedish Round by adding an invoice line`
+
+  To round your invoice total amount, this option create a invoice line without
+  taxes on it. This invoice line is tagged as `is_rounding`
+
+
+
+Usage
+=====
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/95/8.0
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/account-invoicing/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+Alessio Gerace <alessio.gerace@agilebg.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/account_invoice_rounding_by_currency/README.rst
+++ b/account_invoice_rounding_by_currency/README.rst
@@ -2,21 +2,21 @@
    :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
    :alt: License: AGPL-3
 
-===================================================
-Unit rounded invoice (Swedish rounding) by currency
-===================================================
+================================================
+Unit rounded invoice (Cash Rounding) by currency
+================================================
 
 This module extends functionality of module `Unit rounded invoice <https://github.com/OCA/account-invoicing/tree/8.0/account_invoice_rounding>`_.
 
 It allows to set, in accounting settings, a rounding precision for each currency,
-such as 0.05 CHF for Swiss invoices
+such as 0.05 CHF for Swiss invoices.
+
 
 Configuration
 =============
 
-In Settings -> Configuration -> Accounting you will find
-Currencies Rounding Rules
-Set currency rule for each currency you need to handle.
+#. in Settings > Configuration > Accounting, check Currencies Rounding Rules
+#. Set currency rule for each currency you need to handle:
 
 - `Swedish Round globally`
 
@@ -25,9 +25,9 @@ Set currency rule for each currency you need to handle.
 
 - `Swedish Round by adding an invoice line`
 
-  To round your invoice total amount, this option create a invoice line without
-  taxes on it. This invoice line is tagged as `is_rounding`
-
+  To round your invoice total amount, this option will create a invoice line without
+  taxes on it.
+  This invoice line is tagged as `is_rounding`
 
 
 Usage

--- a/account_invoice_rounding_by_currency/__init__.py
+++ b/account_invoice_rounding_by_currency/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015 Alessio Gerace <alessio.gerace@agilebg.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import models

--- a/account_invoice_rounding_by_currency/__openerp__.py
+++ b/account_invoice_rounding_by_currency/__openerp__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015 Alessio Gerace <alessio.gerace@agilebg.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{
+    'name': 'Unit rounded invoice by Currency',
+    'version': '8.0.1.0.0',
+    'category': 'Accounting',
+    'author': "Agile Business Group, Odoo Community Association (OCA)",
+    'website': 'http://www.agilebg.com/',
+    'license': 'AGPL-3',
+    'depends': ['account_invoice_rounding'],
+    'data': [
+        'views/res_config_view.xml',
+        'security/ir.model.access.csv',
+    ],
+    "demo": ['demo/data.xml'],
+    'installable': True,
+    'auto_install': False,
+    'application': False
+}

--- a/account_invoice_rounding_by_currency/demo/data.xml
+++ b/account_invoice_rounding_by_currency/demo/data.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" ?>
+<openerp>
+    <data noupdate="1">
+
+        <record id="tax_code_10" model="account.tax.code">
+            <field name="name">IVA a credito 10%</field>
+        </record>
+
+        <record id="tax_base_code_10" model="account.tax.code">
+            <field name="name">IVA a credito 10% (imponibile)</field>
+        </record>
+
+        <record id="tax_10" model="account.tax">
+            <field name="name">10% test</field>
+            <field name="description">10</field>
+            <field name="amount">0.10</field>
+            <field name="base_code_id" ref="tax_base_code_10"></field>
+            <field name="tax_code_id" ref="tax_code_10"></field>
+        </record>
+
+        <record id="base.main_company" model="res.company">
+            <field name="tax_calculation_rounding" eval="0.05"/>
+            <field name="tax_calculation_rounding_method"  eval="'swedish_round_globally'"/>
+        </record>
+
+        <record id="currency_rounding_rule" model="company.rounding">
+            <field name="currency_id" ref="base.CHF"/>
+            <field name="company_id" ref="base.main_company"/>
+            <field name="tax_calculation_rounding"  eval="0.50"/>
+            <field name="tax_calculation_rounding_method"  eval="'swedish_round_globally'"/>
+        </record>
+
+<!-- invoice 0 -->
+
+        <record id="invtest_invoice_0" model="account.invoice">
+            <field name="journal_id" ref="account.bank_journal"/>
+            <field name="currency_id" ref="base.EUR"/>
+            <field name="user_id" ref="base.user_demo"/>
+            <field name="company_id" ref="base.main_company"/>
+            <field name="type">out_invoice</field>
+            <field name="account_id" ref="account.a_pay"/>
+            <field name="date_invoice" eval="'2015-10-07'"/>
+            <field name="partner_id" ref="base.res_partner_12"/>
+        </record>
+
+        <record id="invtest_invoice_0_line_0" model="account.invoice.line">
+            <field name="invoice_id" ref="invtest_invoice_0"/>
+            <field name="account_id" ref="account.a_sale"/>
+            <field name="price_unit" eval="100.02" />
+            <field name="uos_id" ref="product.product_uom_unit"/>
+            <field name="invoice_line_tax_id" eval="[(6,0,[ref('tax_10')])]"/>
+            <field name="product_id" ref="product.product_product_3"/>
+            <field name="quantity" eval="1.0" />
+            <field name="name">[PCSC234] PC Assemble SC234-2</field>
+        </record>
+
+
+<!-- invoice 1 -->
+
+        <record id="invtest_invoice_1" model="account.invoice">
+            <field name="journal_id" ref="account.bank_journal"/>
+            <field name="currency_id" ref="base.EUR"/>
+            <field name="user_id" ref="base.user_demo"/>
+            <field name="company_id" ref="base.main_company"/>
+            <field name="type">out_invoice</field>
+            <field name="account_id" ref="account.a_pay"/>
+            <field name="date_invoice" eval="'2015-10-07'"/>
+            <field name="partner_id" ref="base.res_partner_12"/>
+        </record>
+
+        <record id="invtest_invoice_1_line_0" model="account.invoice.line">
+            <field name="invoice_id" ref="invtest_invoice_1"/>
+            <field name="account_id" ref="account.a_sale"/>
+            <field name="price_unit" eval="100.43" />
+            <field name="uos_id" ref="product.product_uom_unit"/>
+            <field name="invoice_line_tax_id" eval="[(6,0,[ref('tax_10')])]"/>
+            <field name="product_id" ref="product.product_product_3"/>
+            <field name="quantity" eval="1.0" />
+            <field name="name">[PCSC234] PC Assemble SC234-2</field>
+        </record>
+
+<!-- invoice 2 -->
+
+        <record id="invtest_invoice_2" model="account.invoice">
+            <field name="journal_id" ref="account.bank_journal"/>
+            <field name="currency_id" ref="base.CHF"/>
+            <field name="user_id" ref="base.user_demo"/>
+            <field name="company_id" ref="base.main_company"/>
+            <field name="type">out_invoice</field>
+            <field name="account_id" ref="account.a_pay"/>
+            <field name="date_invoice" eval="'2015-10-07'"/>
+            <field name="partner_id" ref="base.res_partner_12"/>
+        </record>
+
+        <record id="invtest_invoice_2_line_0" model="account.invoice.line">
+            <field name="invoice_id" ref="invtest_invoice_2"/>
+            <field name="account_id" ref="account.a_sale"/>
+            <field name="price_unit" eval="100.43" />
+            <field name="uos_id" ref="product.product_uom_unit"/>
+            <field name="invoice_line_tax_id" eval="[(6,0,[ref('tax_10')])]"/>
+            <field name="product_id" ref="product.product_product_3"/>
+            <field name="quantity" eval="1.0" />
+            <field name="name">[PCSC234] PC Assemble SC234-2</field>
+        </record>
+
+    </data>
+</openerp>

--- a/account_invoice_rounding_by_currency/demo/data.xml
+++ b/account_invoice_rounding_by_currency/demo/data.xml
@@ -3,11 +3,11 @@
     <data noupdate="1">
 
         <record id="tax_code_10" model="account.tax.code">
-            <field name="name">IVA a credito 10%</field>
+            <field name="name">Credit VAT 10%</field>
         </record>
 
         <record id="tax_base_code_10" model="account.tax.code">
-            <field name="name">IVA a credito 10% (imponibile)</field>
+            <field name="name">Credit VAT 10% (base)</field>
         </record>
 
         <record id="tax_10" model="account.tax">
@@ -39,7 +39,7 @@
             <field name="company_id" ref="base.main_company"/>
             <field name="type">out_invoice</field>
             <field name="account_id" ref="account.a_pay"/>
-            <field name="date_invoice" eval="'2015-10-07'"/>
+            <field name="date_invoice" eval="time.strftime('%Y')+'-10-07'"/>
             <field name="partner_id" ref="base.res_partner_12"/>
         </record>
 
@@ -64,7 +64,7 @@
             <field name="company_id" ref="base.main_company"/>
             <field name="type">out_invoice</field>
             <field name="account_id" ref="account.a_pay"/>
-            <field name="date_invoice" eval="'2015-10-07'"/>
+            <field name="date_invoice" eval="time.strftime('%Y')+'-10-07'"/>
             <field name="partner_id" ref="base.res_partner_12"/>
         </record>
 
@@ -88,7 +88,7 @@
             <field name="company_id" ref="base.main_company"/>
             <field name="type">out_invoice</field>
             <field name="account_id" ref="account.a_pay"/>
-            <field name="date_invoice" eval="'2015-10-07'"/>
+            <field name="date_invoice" eval="time.strftime('%Y')+'-10-07'"/>
             <field name="partner_id" ref="base.res_partner_12"/>
         </record>
 

--- a/account_invoice_rounding_by_currency/i18n/it.po
+++ b/account_invoice_rounding_by_currency/i18n/it.po
@@ -1,0 +1,106 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#   * account_invoice_rounding_by_currency
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-10-14 12:05+0000\n"
+"PO-Revision-Date: 2015-10-14 12:05+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_invoice_rounding_by_currency
+#: model:ir.model,name:account_invoice_rounding_by_currency.model_res_company
+msgid "Companies"
+msgstr "Aziende"
+
+#. module: account_invoice_rounding_by_currency
+#: field:company.rounding,company_id:0
+msgid "Company"
+msgstr "Company"
+
+#. module: account_invoice_rounding_by_currency
+#: field:company.rounding,create_uid:0
+msgid "Created by"
+msgstr "Created by"
+
+#. module: account_invoice_rounding_by_currency
+#: field:company.rounding,create_date:0
+msgid "Created on"
+msgstr "Created on"
+
+#. module: account_invoice_rounding_by_currency
+#: view:account.config.settings:account_invoice_rounding_by_currency.view_account_config_settings_currency
+msgid "Currencies Rounding Rules"
+msgstr "Regole Arrotondamento per valuta"
+
+#. module: account_invoice_rounding_by_currency
+#: field:company.rounding,currency_id:0
+msgid "Currency"
+msgstr "Valuta"
+
+#. module: account_invoice_rounding_by_currency
+#: sql_constraint:company.rounding:0
+msgid "Currency must be unique per Company!"
+msgstr "La valuta deve essere univoca per azienda!"
+
+#. module: account_invoice_rounding_by_currency
+#: field:company.rounding,id:0
+msgid "ID"
+msgstr "ID"
+
+#. module: account_invoice_rounding_by_currency
+#: help:company.rounding,tax_calculation_rounding_method:0
+msgid "If you select 'Round per line' : for each tax, the tax amount will first be computed and rounded for each PO/SO/invoice line and then these rounded amounts will be summed, leading to the total amount for that tax. If you select 'Round globally': for each tax, the tax amount will be computed for each PO/SO/invoice line, then these amounts will be summed and eventually this total tax amount will be rounded. If you sell with tax included, you should choose 'Round per line' because you certainly want the sum of your tax-included line subtotals to be equal to the total amount with taxes."
+msgstr "Se si seleziona 'Arrotondamento per riga ' : per ciascuna imposta , l'importo dell'imposta viene calcolato e arrotondato per ogni riga di fattura e quindi tali importi arrotondati verranno riassunti , nella somma totale per tale imposta . Se si seleziona 'Arrotondamento a livello globale ' : per ciascuna imposta , l'importo dell'imposta sarà calcolato, quindi questi importi saranno sommati e alla fine l'importo totale dell'imposta sarà arrotondato . Se si vende con tasse incluse , si dovrebbe scegliere 'Arrotondamento per linea ' perché si vuole certamente la somma dei subtotali per riga fiscale incluso per essere pari all'importo totale con le tasse"
+
+#. module: account_invoice_rounding_by_currency
+#: model:ir.model,name:account_invoice_rounding_by_currency.model_account_invoice
+msgid "Invoice"
+msgstr "Fattura"
+
+#. module: account_invoice_rounding_by_currency
+#: field:company.rounding,write_uid:0
+msgid "Last Updated by"
+msgstr "Last Updated by"
+
+#. module: account_invoice_rounding_by_currency
+#: field:company.rounding,write_date:0
+msgid "Last Updated on"
+msgstr "Last Updated on"
+
+#. module: account_invoice_rounding_by_currency
+#: field:res.company,currency_rounding_rules:0
+msgid "Rounding Rule"
+msgstr "Regola di Arrotondamento"
+
+#. module: account_invoice_rounding_by_currency
+#: selection:company.rounding,tax_calculation_rounding_method:0
+msgid "Swedish Round by adding a line"
+msgstr "Swedish Round , per riga"
+
+#. module: account_invoice_rounding_by_currency
+#: selection:company.rounding,tax_calculation_rounding_method:0
+msgid "Swedish Round globally"
+msgstr "Swedish Round Globale"
+
+#. module: account_invoice_rounding_by_currency
+#: field:company.rounding,tax_calculation_rounding_method:0
+msgid "Tax Calculation Rounding Method"
+msgstr "Metodo di arrotondamento calcolo Imposte"
+
+#. module: account_invoice_rounding_by_currency
+#: field:company.rounding,tax_calculation_rounding_account_id:0
+msgid "Tax Rounding Account"
+msgstr "Conto per arrotondamento imposte"
+
+#. module: account_invoice_rounding_by_currency
+#: field:company.rounding,tax_calculation_rounding:0
+msgid "Tax Rounding unit"
+msgstr "Precisione di arrotondamento"

--- a/account_invoice_rounding_by_currency/models/__init__.py
+++ b/account_invoice_rounding_by_currency/models/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015 Alessio Gerace <alessio.gerace@agilebg.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import company
+from . import account
+from . import res_config

--- a/account_invoice_rounding_by_currency/models/account.py
+++ b/account_invoice_rounding_by_currency/models/account.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015 Alessio Gerace <alessio.gerace@agilebg.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from openerp import models
+
+
+class AccountInvoice(models.Model):
+    _inherit = "account.invoice"
+
+    def _compute_swedish_rounding(self, cr, uid, invoice, context=None):
+        """
+        Depending on the method defined, we add an invoice line or adapt the
+        tax lines to have a rounded total amount on the invoice
+        :param invoice: invoice browse record
+        :return dict: updated values for _amount_all
+        """
+        # avoid recusivity
+
+        if 'swedish_write' in context:
+            return {}
+        rounding_rule_model = self.pool.get('company.rounding')
+        company = invoice.company_id
+        if invoice.currency_id.id != company.currency_id.id:
+            ret_ids = rounding_rule_model.search(
+                cr, uid,
+                [
+                    ('company_id', '=', company.id),
+                    ('currency_id', '=', invoice.currency_id.id),
+                ],
+                context=context)
+            if ret_ids:
+                rule = rounding_rule_model.browse(
+                    cr, uid, ret_ids[0], context=context)
+                company.tax_calculation_rounding_method = (
+                    rule.tax_calculation_rounding_method)
+                company.tax_calculation_rounding = (
+                    rule.tax_calculation_rounding)
+                company.tax_calculation_rounding_account_id = (
+                    rule.tax_calculation_rounding_account_id)
+            else:
+                return {}
+
+        return super(AccountInvoice, self)._compute_swedish_rounding(
+            cr, uid, invoice, context=context)

--- a/account_invoice_rounding_by_currency/models/company.py
+++ b/account_invoice_rounding_by_currency/models/company.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015 Alessio Gerace <alessio.gerace@agilebg.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from openerp import models, fields
+
+
+class RoundingByCurrency(models.Model):
+    _name = 'company.rounding'
+
+    company_id = fields.Many2one('res.company', 'Company', required=True)
+    currency_id = fields.Many2one('res.currency', 'Currency', required=True)
+    tax_calculation_rounding = fields.Float('Tax Rounding Precision')
+    tax_calculation_rounding_account_id = fields.Many2one(
+        'account.account',
+        'Tax Rounding Account',
+        domain=[('type', '<>', 'view')]
+    )
+    tax_calculation_rounding_method = fields.Selection(
+        [
+            ('swedish_round_globally', 'Swedish Round globally'),
+            ('swedish_add_invoice_line', 'Swedish Round by adding a line'),
+        ],
+        string='Tax Calculation Rounding Method',
+        help="If you select 'Round per line' : for each tax, the tax "
+        "amount will first be computed and rounded for each "
+        "PO/SO/invoice line and then these rounded amounts will be "
+        "summed, leading to the total amount for that tax. If you "
+        "select 'Round globally': for each tax, the tax amount will "
+        "be computed for each PO/SO/invoice line, then these amounts"
+        " will be summed and eventually this total tax amount will "
+        "be rounded. If you sell with tax included, you should "
+        "choose 'Round per line' because you certainly want the sum "
+        "of your tax-included line subtotals to be equal to the "
+        "total amount with taxes."
+    )
+
+    _sql_constraints = [
+        ('currency_id_uniq_per_company', 'unique (currency_id, company_id)',
+            'Currency must be unique per Company!'),
+    ]
+
+
+class ResCompany(models.Model):
+    _inherit = 'res.company'
+
+    currency_rounding_rules = fields.One2many(
+        'company.rounding', 'company_id',
+        'Rounding Rule'
+    )

--- a/account_invoice_rounding_by_currency/models/company.py
+++ b/account_invoice_rounding_by_currency/models/company.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright 2015 Alessio Gerace <alessio.gerace@agilebg.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
 from openerp import models, fields
 
 
@@ -24,10 +25,10 @@ class RoundingByCurrency(models.Model):
         help="If you select 'Round per line' : for each tax, the tax "
         "amount will first be computed and rounded for each "
         "PO/SO/invoice line and then these rounded amounts will be "
-        "summed, leading to the total amount for that tax. If you "
+        "summed up, leading to the total amount for that tax. If you "
         "select 'Round globally': for each tax, the tax amount will "
         "be computed for each PO/SO/invoice line, then these amounts"
-        " will be summed and eventually this total tax amount will "
+        " will be summed up and eventually this total tax amount will "
         "be rounded. If you sell with tax included, you should "
         "choose 'Round per line' because you certainly want the sum "
         "of your tax-included line subtotals to be equal to the "
@@ -36,7 +37,7 @@ class RoundingByCurrency(models.Model):
 
     _sql_constraints = [
         ('currency_id_uniq_per_company', 'unique (currency_id, company_id)',
-            'Currency must be unique per Company!'),
+            'Currency must be unique per Company'),
     ]
 
 

--- a/account_invoice_rounding_by_currency/models/res_config.py
+++ b/account_invoice_rounding_by_currency/models/res_config.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015 Alessio Gerace <alessio.gerace@agilebg.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from openerp import models, fields
+
+
+class AccountConfigSettings(models.TransientModel):
+    _inherit = 'account.config.settings'
+
+    def _default_company(self):
+        return self.env.user.company_id.id
+
+    company_id = fields.Many2one(
+        'res.company', 'Company', required=True, default=_default_company)
+    currency_rounding_rules = fields.One2many(
+        related='company_id.currency_rounding_rules',
+        string='Rounding Rule',
+        domain=[('type', '<>', 'view')])
+
+    def onchange_company_id(self, cr, uid, ids, company_id, context=None):
+        res = super(AccountConfigSettings, self
+                    ).onchange_company_id(cr, uid, ids,
+                                          company_id, context=context)
+        company = self.pool.get('res.company').browse(cr, uid, company_id,
+                                                      context=context)
+        res['value']['currency_rounding_rules'] = \
+            company.currency_rounding_rules
+        return res

--- a/account_invoice_rounding_by_currency/models/res_config.py
+++ b/account_invoice_rounding_by_currency/models/res_config.py
@@ -14,8 +14,7 @@ class AccountConfigSettings(models.TransientModel):
         'res.company', 'Company', required=True, default=_default_company)
     currency_rounding_rules = fields.One2many(
         related='company_id.currency_rounding_rules',
-        string='Rounding Rule',
-        domain=[('type', '<>', 'view')])
+        string='Rounding Rule')
 
     def onchange_company_id(self, cr, uid, ids, company_id, context=None):
         res = super(AccountConfigSettings, self

--- a/account_invoice_rounding_by_currency/security/ir.model.access.csv
+++ b/account_invoice_rounding_by_currency/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+"id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
+"access_company_rounding","access_company_rounding","model_company_rounding","",1,0,0,0

--- a/account_invoice_rounding_by_currency/tests/__init__.py
+++ b/account_invoice_rounding_by_currency/tests/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015 Alessio Gerace <alessio.gerace@agilebg.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import test_rounding_by_currencies

--- a/account_invoice_rounding_by_currency/tests/test_rounding_by_currencies.py
+++ b/account_invoice_rounding_by_currency/tests/test_rounding_by_currencies.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Agile Business Group (<http://www.agilebg.com>)
+#    Author: Alessio Gerace <alessio.gerace@agilebg.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp import workflow
+import openerp.tests.common as test_common
+
+
+class TestRoundingByCurrencies(test_common.SingleTransactionCase):
+
+    def setUp(self):
+        super(TestRoundingByCurrencies, self).setUp()
+        self.data_model = self.registry('ir.model.data')
+        self.invoice_model = self.registry('account.invoice')
+        self.context = {}
+        self.maxDiff = None
+        self.company = self.env.ref('base.main_company')
+
+    def test_0_invoice(self):
+        cr, uid = self.cr, self.uid
+        invoice_id = self.data_model.get_object_reference(
+            cr, uid, 'account_invoice_rounding_by_currency',
+            'invtest_invoice_0'
+        )
+        if invoice_id:
+            invoice_id = invoice_id and invoice_id[1] or False
+        invoice = self.invoice_model.browse(cr, uid, invoice_id)
+        self.assertEqual(invoice.state, 'draft')
+        workflow.trg_validate(
+            uid, 'account.invoice', invoice_id, 'invoice_open', cr
+        )
+        self.assertEqual(invoice.state, 'open')
+        self.assertEqual(invoice.amount_total, 110.0)
+
+    def test_1_invoice(self):
+        cr, uid = self.cr, self.uid
+        invoice_id = self.data_model.get_object_reference(
+            cr, uid, 'account_invoice_rounding_by_currency',
+            'invtest_invoice_1'
+        )
+        if invoice_id:
+            invoice_id = invoice_id and invoice_id[1] or False
+        invoice = self.invoice_model.browse(cr, uid, invoice_id)
+        self.assertEqual(invoice.state, 'draft')
+        workflow.trg_validate(
+            uid, 'account.invoice', invoice_id, 'invoice_open', cr
+        )
+        self.assertEqual(invoice.state, 'open')
+        self.assertEqual(invoice.amount_total, 110.45)
+
+    def test_2_invoice(self):
+        cr, uid = self.cr, self.uid
+        invoice_id = self.data_model.get_object_reference(
+            cr, uid, 'account_invoice_rounding_by_currency',
+            'invtest_invoice_2'
+        )
+        if invoice_id:
+            invoice_id = invoice_id and invoice_id[1] or False
+        invoice = self.invoice_model.browse(cr, uid, invoice_id)
+        self.assertEqual(invoice.state, 'draft')
+        workflow.trg_validate(
+            uid, 'account.invoice', invoice_id, 'invoice_open', cr
+        )
+        self.assertEqual(invoice.state, 'open')
+        self.assertEqual(invoice.amount_total, 110.50)

--- a/account_invoice_rounding_by_currency/tests/test_rounding_by_currencies.py
+++ b/account_invoice_rounding_by_currency/tests/test_rounding_by_currencies.py
@@ -1,23 +1,7 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    Copyright (C) 2015 Agile Business Group (<http://www.agilebg.com>)
-#    Author: Alessio Gerace <alessio.gerace@agilebg.com>
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# Copyright 2015 Alessio Gerace <alessio.gerace@agilebg.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
 from openerp import workflow
 import openerp.tests.common as test_common
 

--- a/account_invoice_rounding_by_currency/views/res_config_view.xml
+++ b/account_invoice_rounding_by_currency/views/res_config_view.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="view_account_config_settings_currency" model="ir.ui.view">
+            <field name="name">account settings.add.rounding.currency</field>
+            <field name="model">account.config.settings</field>
+            <field name="inherit_id" ref="account_invoice_rounding.view_account_config_settings"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='tax_calculation_rounding_account_id']/ancestor::div[1]" position="after">
+                <div name="account_grp_currency">
+                <p class="oe_horizontal_separator" style="color: #555;">Currencies Rounding Rules</p>
+                    <field name="currency_rounding_rules" nolabel="1">
+                        <tree editable="bottom">
+                            <field name="currency_id"></field>
+                            <field name="tax_calculation_rounding"></field>
+                            <field name="tax_calculation_rounding_method"></field>
+                            <field name="tax_calculation_rounding_account_id"
+                            attrs="{'readonly': [('tax_calculation_rounding_method', '!=', 'swedish_add_invoice_line')] }"></field>
+                        </tree>
+                    </field>
+                </div>
+                </xpath>
+            </field>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION

Unit rounded invoice (Swedish rounding) by currency
===================================================

This module extends functionality of module Unit rounded invoice https://github.com/OCA/account-invoicing/tree/8.0/account_invoice_rounding

It allows to set, in accounting settings, a rounding precision for each currency,
such as 0.05 CHF for Swiss invoices

Configuration
=============

In Settings -> Configuration -> Accounting you will find
Currencies Rounding Rules
Set currency rule for each currency you need to handle.

- `Swedish Round globally`

  To round your invoice total amount, this option will do the adjustment in
  the most important tax line of your invoice.

- `Swedish Round by adding an invoice line`

  To round your invoice total amount, this option create a invoice line without
  taxes on it. This invoice line is tagged as `is_rounding`