### PR TITLE
[FIX] Combining invoices keeps the sale.order.line reference intact

### DIFF
--- a/account_invoice_merge/__openerp__.py
+++ b/account_invoice_merge/__openerp__.py
@@ -5,7 +5,7 @@
 
 {
     'name': 'Account Invoice Merge Wizard',
-    'version': '9.0.1.0.0',
+    'version': '9.0.1.0.1',
     'category': 'Finance',
     'author': "Elico Corp,Odoo Community Association (OCA)",
     'website': 'http://www.openerp.net.cn',


### PR DESCRIPTION
Because self.env['sale.order'] returns an empty record set, this is evaluated to False.
This in turn never calls the code to restore the link between sale order and invoice.
Because this code was never called in version 9 and above, it never encountered the issue
that the the field invoice_ids is now a computed field without a search.
Searching on that field returned all the sale.orders.
The linked sale_line_ids are now copied like the rest of the fields.