### PR TITLE
account_invoice_fiscal_position_update fix for partner_id change

### DIFF
--- a/account_invoice_fiscal_position_update/models/account_invoice.py
+++ b/account_invoice_fiscal_position_update/models/account_invoice.py
@@ -11,6 +11,12 @@ from openerp.exceptions import ValidationError
 class AccountInvoice(models.Model):
     _inherit = "account.invoice"
 
+    @api.onchange('partner_id', 'company_id')
+    def _onchange_partner_id(self):
+        ret = super(AccountInvoice, self)._onchange_partner_id()
+        self.onchange_fiscal_position_id()
+        return ret
+
     @api.onchange('fiscal_position_id')
     def onchange_fiscal_position_id(self):
         """Updates taxes and accounts on all invoice lines"""


### PR DESCRIPTION
When creating a Purchase Order, the fiscal position used was not from Contact/supplier
but some default one. Adding an onchange handler fixes this issue.