### PR TITLE
[9.0] [IMP] account_invoice_supplier_ref_unique: set unique number in refund wizard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+*.eggs
 
 # Installer logs
 pip-log.txt

--- a/account_invoice_supplier_ref_unique/__init__.py
+++ b/account_invoice_supplier_ref_unique/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import models
+from . import wizards

--- a/account_invoice_supplier_ref_unique/__openerp__.py
+++ b/account_invoice_supplier_ref_unique/__openerp__.py
@@ -15,5 +15,8 @@
     'depends': [
         'account'
     ],
-    'data': ['views/account_invoice.xml'],
+    'data': [
+        'wizards/account_invoice_refund.xml',
+        'views/account_invoice.xml',
+    ],
 }

--- a/account_invoice_supplier_ref_unique/models/account_invoice.py
+++ b/account_invoice_supplier_ref_unique/models/account_invoice.py
@@ -59,6 +59,13 @@ class AccountInvoice(models.Model):
                 'reference' in vals:
             vals['reference'] = ''
 
+        # If a supplier invoice number is set on the wizard, pass it to the
+        # credit note
+        supplier_invoice_number = self.env.context.get(
+            'supplier_invoice_number', False)
+        if supplier_invoice_number:
+            vals['supplier_invoice_number'] = supplier_invoice_number
+
         return vals
 
     @api.multi

--- a/account_invoice_supplier_ref_unique/tests/test_account_invoice_supplier_ref_unique.py
+++ b/account_invoice_supplier_ref_unique/tests/test_account_invoice_supplier_ref_unique.py
@@ -2,6 +2,7 @@
 # Copyright 2016 Acsone
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from openerp import fields
 from openerp.exceptions import ValidationError
 from openerp.tests.common import SavepointCase
 
@@ -15,6 +16,7 @@ class TestAccountInvoiceSupplierRefUnique(SavepointCase):
         # ENVIRONMENTS
         self.account_account = self.env['account.account']
         self.account_invoice = self.env['account.invoice']
+        self.account_invoice_line = self.env['account.invoice.line']
 
         # INSTANCES
         self.partner = self.env.ref('base.res_partner_2')
@@ -24,6 +26,10 @@ class TestAccountInvoiceSupplierRefUnique(SavepointCase):
               '=',
               self.env.ref('account.data_account_type_receivable').id
               )], limit=1)
+        self.account_expenses = self.account_account.search(
+            [('user_type_id',
+              '=',
+              self.env.ref('account.data_account_type_expenses').id)], limit=1)
         # Invoice with unique reference 'ABC123'
         self.invoice = self.account_invoice.create({
             'partner_id': self.partner.id,
@@ -51,3 +57,31 @@ class TestAccountInvoiceSupplierRefUnique(SavepointCase):
         self.assertEqual(self.invoice.reference,
                          self.invoice.supplier_invoice_number,
                          "_onchange_supplier_invoice_number")
+
+    def test_refund_with_unique_supplier_invoice_number(self):
+        self.account_invoice_line.create({
+            'invoice_id': self.invoice.id,
+            'product_qty': 1.00,
+            'price_unit': 1.00,
+            'name': "Invoice line 1",
+            'account_id': self.account_expenses.id,
+        })
+        self.invoice.signal_workflow('invoice_open')
+
+        invoice_refund_model = self.env['account.invoice.refund']
+        invoice_refund_model = invoice_refund_model.with_context(
+            active_ids=[self.invoice.id])
+
+        account_invoice_refund = invoice_refund_model.create({
+            'description': "Refund test",
+            'date': fields.Date.today(),
+            'filter_refund': 'refund',
+            'supplier_invoice_number': "321CBA"
+        })
+
+        # I clicked on refund button.
+        res = account_invoice_refund.invoice_refund()
+        credit_note_id = res['domain'][1][2][0]
+        credit_note = self.account_invoice.browse(credit_note_id)
+        self.assertEqual(credit_note.type, 'in_refund')
+        self.assertEqual(credit_note.supplier_invoice_number, '321CBA')

--- a/account_invoice_supplier_ref_unique/wizards/__init__.py
+++ b/account_invoice_supplier_ref_unique/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import account_invoice_refund

--- a/account_invoice_supplier_ref_unique/wizards/account_invoice_refund.py
+++ b/account_invoice_supplier_ref_unique/wizards/account_invoice_refund.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import api, fields, models
+
+
+class AccountInvoiceRefund(models.TransientModel):
+    _inherit = 'account.invoice.refund'
+
+    supplier_invoice_number = fields.Char(
+        string='Vendor invoice number'
+    )
+
+    @api.multi
+    def compute_refund(self, mode='refund'):
+        res = True
+        for form in self:
+            res = super(
+                AccountInvoiceRefund, form.with_context(
+                    supplier_invoice_number=form.supplier_invoice_number)).\
+                compute_refund(mode=mode)
+        return res

--- a/account_invoice_supplier_ref_unique/wizards/account_invoice_refund.xml
+++ b/account_invoice_supplier_ref_unique/wizards/account_invoice_refund.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2016 ACSONE SA/NV
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+
+    <record model="ir.ui.view" id="account_invoice_refund_form_view">
+        <field name="name">account.invoice.refund.form (in account_invoice_supplier_ref_unique)</field>
+        <field name="model">account.invoice.refund</field>
+        <field name="inherit_id" ref="account.view_account_invoice_refund"/>
+        <field name="arch" type="xml">
+            <field name="description" position="after">
+                <field name="supplier_invoice_number"/>
+            </field>
+        </field>
+    </record>
+
+
+</odoo>


### PR DESCRIPTION
This improvement adds a new field on the refund wizard to allow to initialize the unique vendor number of the credit note.