### PR TITLE
[8.0][ADD] Module account_invoice_so_exception_reset.

### DIFF
--- a/account_invoice_so_exception_reset/README.rst
+++ b/account_invoice_so_exception_reset/README.rst
@@ -1,0 +1,50 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License: AGPL-3
+
+====================================================
+Reset Invoice Exception on SO after reviving Invoice
+====================================================
+
+This module ensures that when a SO has gone into state 'Invoice Exception',
+due to the cancelling of an invoice, that state is reset, when the invoice is
+reset to draft.
+
+Usage
+=====
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/95/8.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on
+`GitHub Issues <https://github.com/OCA/account-invoicing/issues>`_.
+In case of trouble, please check there if your issue has already been
+reported. If you spotted it first, help us smashing it by providing a
+detailed and welcomed feedback
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Ronald Portier <ronald@therp.nl>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/account_invoice_so_exception_reset/__init__.py
+++ b/account_invoice_so_exception_reset/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# © 2017 Therp BV <http://therp.nl>                                               
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). 
+from . import models

--- a/account_invoice_so_exception_reset/__openerp__.py
+++ b/account_invoice_so_exception_reset/__openerp__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# © 2017 Therp BV <http://therp.nl>                                               
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). 
+# © 2017 Therp BV <https://therp.nl>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'Reset Invoice Exception on SO after reviving Invoice',
     'version': '8.0.1.0.0',

--- a/account_invoice_so_exception_reset/__openerp__.py
+++ b/account_invoice_so_exception_reset/__openerp__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# © 2017 Therp BV <http://therp.nl>                                               
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). 
+{
+    'name': 'Reset Invoice Exception on SO after reviving Invoice',
+    'version': '8.0.1.0.0',
+    'category': 'Accounting & Finance',
+    'author': 'Therp BV,Odoo Community Association (OCA)',
+    'website': 'https://therp.nl',
+    'license': 'AGPL-3',
+    'depends': [
+        'stock_account',
+    ],
+    'installable': True
+}

--- a/account_invoice_so_exception_reset/models/__init__.py
+++ b/account_invoice_so_exception_reset/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# © 2017 Therp BV <http://therp.nl>                                               
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). 
+from . import account_invoice

--- a/account_invoice_so_exception_reset/models/account_invoice.py
+++ b/account_invoice_so_exception_reset/models/account_invoice.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# © 2017 Therp BV <http://therp.nl>                                               
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). 
+from openerp import api, models
+
+
+class AccountInvoice(models.Model):
+    _inherit = 'account.invoice'
+
+    @api.multi
+    def action_cancel_draft(self):
+        """Also reset state in SO, if SO in Invoice Exception."""
+        sale_model = self.env['sale.order']
+        super(AccountInvoice, self).action_cancel_draft()
+        for this in self:
+            so = sale_model.search([('invoice_ids', '=', this.id)])
+            so.signal_workflow('invoice_corrected')
+        return True

--- a/account_invoice_so_exception_reset/models/account_invoice.py
+++ b/account_invoice_so_exception_reset/models/account_invoice.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# © 2017 Therp BV <http://therp.nl>                                               
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). 
+# © 2017 Therp BV <http://therp.nl>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from openerp import api, models
 
 
@@ -11,8 +11,8 @@ class AccountInvoice(models.Model):
     def action_cancel_draft(self):
         """Also reset state in SO, if SO in Invoice Exception."""
         sale_model = self.env['sale.order']
-        super(AccountInvoice, self).action_cancel_draft()
+        result = super(AccountInvoice, self).action_cancel_draft()
         for this in self:
             so = sale_model.search([('invoice_ids', '=', this.id)])
             so.signal_workflow('invoice_corrected')
-        return True
+        return result


### PR DESCRIPTION
Prevent Sale Order from staying in state 'Invoice Exception' when invoice is cancelled and subsequently reset to draft and later on paid after all....