### PR TITLE
[8.0] Add module account_invoice_transmit_method

### DIFF
--- a/account_invoice_transmit_method/README.rst
+++ b/account_invoice_transmit_method/README.rst
@@ -1,0 +1,65 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=======================
+Invoice Transmit Method
+=======================
+
+This module allows to configure an *Invoice Transmit Method* on each partner. This module provides by default 3 transmission methods:
+
+* E-mail
+* Post
+* Customer Portal
+
+You can manually create additionnal transmission methods or other modules can create additionnal transmission methods (for example, the module *l10n_fr_chorus* creates a specific transmission method *Chorus*, which is the e-invoicing plateform of the French administration).
+
+Configuration
+=============
+
+If you need to add Transmit Methods, go to the menu *Accounting > Configuration > Miscellaneous > Transmit Methods*.
+
+Usage
+=====
+
+On the form view of a parent Partner (not a Contact), in the *Accounting* tab, there are 2 fields:
+
+* Customer Invoice Transmission Method
+* Vendor Invoice Reception Method
+
+When you create an invoice, this value is automatically copied on the invoice (and can be modified).
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/95/8.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/account-invoicing/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Alexis de Lattre <alexis.delattre@akretion.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/account_invoice_transmit_method/__init__.py
+++ b/account_invoice_transmit_method/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/account_invoice_transmit_method/__openerp__.py
+++ b/account_invoice_transmit_method/__openerp__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# © 2017 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    'name': 'Invoice Transmit Method',
+    'version': '8.0.1.0.0',
+    'category': 'Accounting & Finance',
+    'license': 'AGPL-3',
+    'summary': 'Configure invoice transmit method (email, post, portal, ...)',
+    'author': 'Akretion,Odoo Community Association (OCA)',
+    'website': 'http://www.akretion.com',
+    'depends': ['account'],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/transmit_method.xml',
+        'views/account_invoice.xml',
+        'views/partner.xml',
+        'data/transmit_method.xml',
+    ],
+    'demo': ['demo/partner.xml'],
+    'installable': True,
+}

--- a/account_invoice_transmit_method/data/transmit_method.xml
+++ b/account_invoice_transmit_method/data/transmit_method.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  © 2017 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+
+<openerp>
+<data noupdate="1">
+
+<record id="mail" model="transmit.method">
+    <field name="code">mail</field>
+    <field name="name">E-Mail</field>
+</record>
+
+<record id="post" model="transmit.method">
+    <field name="code">post</field>
+    <field name="name">Post</field>
+</record>
+
+<record id="portal" model="transmit.method">
+    <field name="code">portal</field>
+    <field name="name">Customer Portal</field>
+</record>
+
+</data>
+</openerp>

--- a/account_invoice_transmit_method/demo/partner.xml
+++ b/account_invoice_transmit_method/demo/partner.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  © 2017 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+
+<openerp>
+<data noupdate="1">
+
+<record id="base.res_partner_12" model="res.partner"> <!-- C2C -->
+    <field name="customer_invoice_transmit_method_id" ref="mail"/>
+    <field name="supplier_invoice_transmit_method_id" ref="mail"/>
+</record>
+
+<record id="base.res_partner_1" model="res.partner">  <!-- Asus -->
+    <field name="supplier_invoice_transmit_method_id" ref="mail"/>
+</record>
+
+<record id="base.res_partner_2" model="res.partner"> <!-- Agrolait -->
+    <field name="customer_invoice_transmit_method_id" ref="post"/>
+</record>
+
+</data>
+</openerp>

--- a/account_invoice_transmit_method/models/__init__.py
+++ b/account_invoice_transmit_method/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+
+from . import transmit_method
+from . import partner
+from . import account_invoice

--- a/account_invoice_transmit_method/models/account_invoice.py
+++ b/account_invoice_transmit_method/models/account_invoice.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# © 2017 Akretion (http://www.akretion.com)
+# @author: Alexis de Lattre <alexis.delattre@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import models, fields, api
+
+
+class AccountInvoice(models.Model):
+    _inherit = 'account.invoice'
+
+    transmit_method_id = fields.Many2one(
+        'transmit.method', string='Transmission Method',
+        track_visibility='onchange', ondelete='restrict')  # domain in the view
+    # Field used to match specific invoice transmit method
+    # to show/display fields/buttons, add constraints, etc...
+    transmit_method_code = fields.Char(
+        related='transmit_method_id.code', readonly=True, store=True)
+
+    @api.multi
+    def onchange_partner_id(
+            self, type, partner_id, date_invoice=False,
+            payment_term=False, partner_bank_id=False, company_id=False):
+        res = super(AccountInvoice, self).onchange_partner_id(
+            type, partner_id, date_invoice=date_invoice,
+            payment_term=payment_term, partner_bank_id=partner_bank_id,
+            company_id=company_id)
+        if partner_id and type:
+            partner = self.env['res.partner'].browse(partner_id)
+            if type in ('out_invoice', 'out_refund'):
+                res['value']['transmit_method_id'] =\
+                    partner.customer_invoice_transmit_method_id.id or False
+            else:
+                res['value']['transmit_method_id'] =\
+                    partner.supplier_invoice_transmit_method_id.id or False
+        else:
+            res['value']['transmit_method_id'] = False
+        return res
+
+    @api.model
+    def create(self, vals):
+        if (
+                'transmit_method_id' not in vals and
+                vals.get('type') and
+                vals.get('partner_id')):
+            partner = self.env['res.partner'].browse(vals['partner_id'])
+            if vals['type'] in ('out_invoice', 'out_refund'):
+                vals['transmit_method_id'] =\
+                    partner.customer_invoice_transmit_method_id.id or False
+            else:
+                vals['transmit_method_id'] =\
+                    partner.supplier_invoice_transmit_method_id.id or False
+        return super(AccountInvoice, self).create(vals)

--- a/account_invoice_transmit_method/models/partner.py
+++ b/account_invoice_transmit_method/models/partner.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# © 2017 Akretion (http://www.akretion.com)
+# @author: Alexis de Lattre <alexis.delattre@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import models, fields, api
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    customer_invoice_transmit_method_id = fields.Many2one(
+        'transmit.method', string='Customer Invoice Transmission Method',
+        company_dependant=True, track_visibility='onchange',
+        domain=[('customer_ok', '=', True)], ondelete='restrict')
+    customer_invoice_transmit_method_code = fields.Char(
+        related='customer_invoice_transmit_method_id.code',
+        string='Customer Invoice Transmission Method Code', readonly=True)
+    supplier_invoice_transmit_method_id = fields.Many2one(
+        'transmit.method', string='Vendor Invoice Reception Method',
+        company_dependant=True, track_visibility='onchange',
+        domain=[('supplier_ok', '=', True)], ondelete='restrict')
+    supplier_invoice_transmit_method_code = fields.Char(
+        related='supplier_invoice_transmit_method_id.code',
+        string='Vendor Invoice Reception Method Code', readonly=True)
+
+    @api.model
+    def _commercial_fields(self):
+        return super(ResPartner, self)._commercial_fields() + [
+            'customer_invoice_transmit_method_id',
+            'supplier_invoice_transmit_method_id']

--- a/account_invoice_transmit_method/models/transmit_method.py
+++ b/account_invoice_transmit_method/models/transmit_method.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# © 2017 Akretion (http://www.akretion.com)
+# @author: Alexis de Lattre <alexis.delattre@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import models, fields
+
+
+class TransmitMethod(models.Model):
+    _name = 'transmit.method'
+    _description = 'Transmit Method of a document'
+
+    name = fields.Char(string='Name', required=True)
+    code = fields.Char(
+        string='Code', copy=False,
+        help="Do not modify the code of an existing Transmit Method "
+        "because it may be used to identify a particular transmit method.")
+    customer_ok = fields.Boolean(
+        string='Selectable on Customers', default=True)
+    supplier_ok = fields.Boolean(
+        string='Selectable on Vendors', default=True)
+
+    _sql_constraints = [(
+        'code_unique',
+        'unique(code)',
+        'This transmit method code already exists!'
+    )]

--- a/account_invoice_transmit_method/security/ir.model.access.csv
+++ b/account_invoice_transmit_method/security/ir.model.access.csv
@@ -1,0 +1,4 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_transmit_method_read,Read access on transmit.method to everybody,model_transmit_method,,1,0,0,0
+access_transmit_method_full,Full access on transmit.method to Settings group,model_transmit_method,base.group_system,1,1,1,1
+access_transmit_method_full_account,Full access on transmit.method to Financial Manager,model_transmit_method,account.group_account_manager,1,1,1,1

--- a/account_invoice_transmit_method/tests/__init__.py
+++ b/account_invoice_transmit_method/tests/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import test_invoice_transmit_method

--- a/account_invoice_transmit_method/tests/test_invoice_transmit_method.py
+++ b/account_invoice_transmit_method/tests/test_invoice_transmit_method.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# © 2017 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp.tests.common import TransactionCase
+
+
+class TestAccountInvoiceTransmitMethod(TransactionCase):
+
+    def test_create_invoice(self):
+        post_method = self.env.ref('account_invoice_transmit_method.post')
+        partner1 = self.env['res.partner'].create({
+            'is_company': True,
+            'name': 'Old School Company',
+            'customer': True,
+            'customer_invoice_transmit_method_id': post_method.id,
+            })
+        inv1 = self.env['account.invoice'].create({
+            'partner_id': partner1.id,
+            'type': 'out_invoice',
+            'journal_id': self.env.ref('account.sales_journal').id,
+            'account_id': self.env.ref('account.a_recv').id,
+            })
+        self.assertEqual(inv1.transmit_method_id, post_method)

--- a/account_invoice_transmit_method/views/account_invoice.xml
+++ b/account_invoice_transmit_method/views/account_invoice.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  © 2017 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+
+<openerp>
+<data>
+
+
+<record id="invoice_form" model="ir.ui.view">
+    <field name="name">Add Transmit Method on Customer Invoice form view</field>
+    <field name="model">account.invoice</field>
+    <field name="inherit_id" ref="account.invoice_form"/>
+    <field name="arch" type="xml">
+        <field name="journal_id" position="before">
+            <field name="transmit_method_id" widget="selection"
+                domain="[('customer_ok', '=', True)]"/>
+            <field name="transmit_method_code" invisible="1"/>
+        </field>
+        <button name="action_invoice_sent" position="attributes">
+            <attribute name="attrs">{'invisible': ['|', '|', ('sent', '=', True), ('state', 'not in', ('open', 'paid')), ('transmit_method_code', 'not in', ('mail', False))]}</attribute> <!-- Only show the "Send by Mail" button when the transmit method is E-mail or empty. But I also modify the condition on 'state' field: we should be able to send the invoice by email even when the invoice is 'paid' (Even if the customer made an advance payment, he needs an invoice for his accounting !) -->
+        </button>
+    </field>
+</record>
+
+<record id="invoice_supplier_form" model="ir.ui.view">
+    <field name="name">Add Transmit Method on Supplier Invoice form view</field>
+    <field name="model">account.invoice</field>
+    <field name="inherit_id" ref="account.invoice_supplier_form"/>
+    <field name="arch" type="xml">
+        <field name="period_id" position="after">
+            <field name="transmit_method_id" widget="selection"
+                domain="[('supplier_ok', '=', True)]"/>
+            <field name="transmit_method_code" invisible="1"/>
+        </field>
+    </field>
+</record>
+
+
+</data>
+</openerp>

--- a/account_invoice_transmit_method/views/partner.xml
+++ b/account_invoice_transmit_method/views/partner.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  © 2017 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+
+<openerp>
+<data>
+
+
+<record id="view_partner_property_form" model="ir.ui.view">
+    <field name="name">Add Invoice Transmit Methods on partner form view</field>
+    <field name="model">res.partner</field>
+    <field name="inherit_id" ref="account.view_partner_property_form"/>
+    <field name="arch" type="xml">
+        <field name="property_payment_term" position="after">
+            <field name="customer_invoice_transmit_method_id" widget="selection"/>
+            <field name="customer_invoice_transmit_method_code" invisible="1"/>
+        </field>
+        <field name="property_supplier_payment_term" position="after">
+            <field name="supplier_invoice_transmit_method_id" widget="selection"/>
+            <field name="supplier_invoice_transmit_method_code" invisible="1"/>
+        </field>
+        <xpath expr="//field[@name='child_ids']/form//field[@name='customer']" position="after">
+            <field name="customer_invoice_transmit_method_code" invisible="1"/>
+            <field name="supplier_invoice_transmit_method_code" invisible="1"/>
+        </xpath>
+        <field name="child_ids" position="attributes">
+            <attribute name="context">{'default_parent_id': active_id, 'default_street': street, 'default_street2': street2, 'default_city': city, 'default_state_id': state_id, 'default_zip': zip, 'default_country_id': country_id, 'default_supplier': supplier, 'default_customer': customer, 'default_use_parent_address': True, 'default_customer_invoice_transmit_method_code': customer_invoice_transmit_method_code, 'default_supplier_invoice_transmit_method_code': supplier_invoice_transmit_method_code}</attribute>
+        </field>
+    </field>
+</record>
+
+
+</data>
+</openerp>

--- a/account_invoice_transmit_method/views/transmit_method.xml
+++ b/account_invoice_transmit_method/views/transmit_method.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  © 2017 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+
+<openerp>
+<data>
+
+
+<record id="transmit_method_form" model="ir.ui.view">
+    <field name="name">Transmit Method Form view</field>
+    <field name="model">transmit.method</field>
+    <field name="arch" type="xml">
+        <form string="Transmit Method">
+            <group name="main">
+                <field name="name"/>
+                <field name="code"/>
+                <field name="customer_ok"/>
+                <field name="supplier_ok"/>
+            </group>
+        </form>
+    </field>
+</record>
+
+<record id="transmit_method_tree" model="ir.ui.view">
+    <field name="name">Transmit Method Tree view</field>
+    <field name="model">transmit.method</field>
+    <field name="arch" type="xml">
+        <tree string="Transmit Methods">
+            <field name="name"/>
+            <field name="code"/>
+            <field name="customer_ok"/>
+            <field name="supplier_ok"/>
+        </tree>
+    </field>
+</record>
+
+<record id="transmit_method_search" model="ir.ui.view">
+    <field name="name">Transmit Method Search view</field>
+    <field name="model">transmit.method</field>
+    <field name="arch" type="xml">
+        <search string="Search Transmit Methods">
+            <field name="name" filter_domain="['|', ('name', 'ilike', self), ('code', 'ilike', self)]" string="Name or Code"/>
+            <filter name="customer_ok" string="Selectable on Customers" domain="[('customer_ok', '=', True)]"/>
+            <filter name="supplier_ok" string="Selectable on Vendors" domain="[('supplier_ok', '=', True)]"/>
+        </search>
+    </field>
+</record>
+
+<record id="transmit_method_action" model="ir.actions.act_window">
+    <field name="name">Transmit Methods</field>
+    <field name="res_model">transmit.method</field>
+    <field name="view_mode">tree,form</field>
+</record>
+
+<menuitem id="transmit_method_menu"
+    action="transmit_method_action"
+    parent="account.menu_configuration_misc"
+    sequence="100"/>
+
+
+</data>
+</openerp>


### PR DESCRIPTION
This module allows to configure an *Invoice Transmit Method* on each partner (e-mail, post, customer portal, ... and you can define more methods). Please see the README.rst of the module for more info.

It will be used as a base module for l10n_fr_chorus (Chorus is the e-invoicing plateform of the french administration), which I'll publish soon.