### PR TITLE
[FIX] do_merge now returns a tuple.

### DIFF
--- a/account_invoice_merge/wizard/invoice_merge.py
+++ b/account_invoice_merge/wizard/invoice_merge.py
@@ -83,8 +83,10 @@ class InvoiceMerge(models.TransientModel):
         aw_obj = self.env['ir.actions.act_window']
         ids = self.env.context.get('active_ids', [])
         invoices = inv_obj.browse(ids)
-        allinvoices = invoices.do_merge(keep_references=self.keep_references,
-                                        date_invoice=self.date_invoice)
+        invoices_info, invoice_lines_info = invoices.do_merge(
+            keep_references=self.keep_references,
+            date_invoice=self.date_invoice
+        )
         xid = {
             'out_invoice': 'action_invoice_tree1',
             'out_refund': 'action_invoice_tree3',
@@ -93,6 +95,6 @@ class InvoiceMerge(models.TransientModel):
         }[invoices[0].type]
         action = aw_obj.for_xml_id('account', xid)
         action.update({
-            'domain': [('id', 'in', ids + allinvoices.keys())],
+            'domain': [('id', 'in', ids + invoices_info.keys())],
         })
         return action


### PR DESCRIPTION
do_merge method should have a consistent return value. Now we had a crash in a database where account_invoice_merge_purchase was not installed. This was due to this being a new module, and an existing database. But can also happen in databases were purchase is not needed and installed, so auto_install of account_invoice_merge_purchase will not be done.