### PR TITLE
[FIX] account_invoice_merge: Don't fail on multiple invoices from SO

### DIFF
--- a/account_invoice_merge/__openerp__.py
+++ b/account_invoice_merge/__openerp__.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 # © 2010-2011 Ian Li <ian.li@elico-corp.com>
 # © 2015 Cédric Pigeon <cedric.pigeon@acsone.eu>
-# © 2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
+# © 2016-2017 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {
     'name': 'Account Invoice Merge Wizard',
-    'version': '8.0.2.0.0',
+    'version': '8.0.2.0.1',
     'category': 'Finance',
     'author': "Elico Corp, "
               "ACSONE A/V, "

--- a/account_invoice_merge/models/account_invoice.py
+++ b/account_invoice_merge/models/account_invoice.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # © 2010-2011 Ian Li <ian.li@elico-corp.com>
 # © 2015 Cédric Pigeon <cedric.pigeon@acsone.eu>
-# © 2016 Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+# © 2016-2017 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # © 2016 Luc De Meyer <luc.demeyer@noviat.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
@@ -202,12 +202,13 @@ class AccountInvoice(models.Model):
                 todos.write({'invoice_ids': [(4, new_invoice_id)]})
                 for org_so in todos:
                     for so_line in org_so.order_line:
-                        org_ilines = so_line.mapped('invoice_lines')
-                        invoice_line_ids = []
-                        for org_iline in org_ilines:
-                            invoice_line_ids.append(
-                                invoice_lines_info[
-                                    new_invoice_id][org_iline.id])
+                        inv_line_dict = invoice_lines_info[new_invoice_id]
+                        org_ilines = so_line.mapped('invoice_lines').filtered(
+                            lambda x: x.id in inv_line_dict.keys()
+                        )
+                        invoice_line_ids = [
+                            inv_line_dict[x.id] for x in org_ilines
+                        ]
                         so_line.write(
                             {'invoice_lines': [(6, 0, invoice_line_ids)]})
         # recreate link (if any) between original analytic account line


### PR DESCRIPTION
If you generate more than one invoice from the SO, and you try to merge one of these invoices with another, then there's a key error, as there are invoice lines not included in the merging operation.