### PR TITLE
[10.0][FIX] account_invoice_refund_link: fix init hook by matching invoices and refunds only if in same company

### DIFF
--- a/account_invoice_refund_link/__manifest__.py
+++ b/account_invoice_refund_link/__manifest__.py
@@ -7,7 +7,7 @@
 {
     "name": "Link refund invoice with original",
     "summary": "Link refund invoice with its original invoice",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.0.1",
     "category": "Accounting & Finance",
     "website": "https://odoo-community.org/",
     "author": "Pexego, "

--- a/account_invoice_refund_link/hooks.py
+++ b/account_invoice_refund_link/hooks.py
@@ -14,6 +14,7 @@ def _invoice_match(env, invoice):
     return env['account.invoice'].search([
         ('type', '=', inv_type),
         ('number', '=ilike', invoice.origin),
+        ('company_id', '=', invoice.company_id.id),
     ])
 
 


### PR DESCRIPTION
I tried to install this module on a multi-company database and it fails due to the pre-init-hook.
It tried to match records from different companies.