### PR TITLE
[10.0][FIX] account_invoice_fiscal_position_update: On invoice creati…

### DIFF
--- a/account_invoice_fiscal_position_update/__manifest__.py
+++ b/account_invoice_fiscal_position_update/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Invoice Fiscal Position Update',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Accounting & Finance',
     'license': 'AGPL-3',
     'summary': 'Changing the fiscal position of an invoice will auto-update '

--- a/account_invoice_fiscal_position_update/models/account_invoice.py
+++ b/account_invoice_fiscal_position_update/models/account_invoice.py
@@ -12,6 +12,14 @@ from odoo import models, api, _
 class AccountInvoice(models.Model):
     _inherit = "account.invoice"
 
+    @api.onchange('partner_id')
+    def _onchange_partner_id(self):
+        fiscal_position = self.fiscal_position_id
+        res = super(AccountInvoice, self)._onchange_partner_id()
+        if fiscal_position != self.fiscal_position_id:
+            self.fiscal_position_change()
+        return res
+
     @api.onchange('fiscal_position_id')
     def fiscal_position_change(self):
         """Updates taxes and accounts on all invoice lines"""


### PR DESCRIPTION
…on, tax mapping could be wrong set

Steps to reproduce :

Create a account tax mapping depending on fiscal position
Create a purchase order with products and a partner that have the first fiscal position
From purchase order, go to Vendor Bills, then Create

The generated lines come with product taxes instead of the mapped taxes on fiscal position.