### PR TITLE
[IMP] account_invoice_supplier_ref_unique: Disable Odoo unique constaint on vendor reference field.

### DIFF
--- a/account_invoice_supplier_ref_unique/models/account_invoice.py
+++ b/account_invoice_supplier_ref_unique/models/account_invoice.py
@@ -69,3 +69,11 @@ class AccountInvoice(models.Model):
         if self.type in ['in_invoice', 'in_refund']:
             default = dict(default or {}, reference='')
         return super(AccountInvoice, self).copy(default)
+
+    @api.multi
+    def _check_invoice_reference(self):
+        """
+        In some cases, vendor reference for payment may already exists.
+        So, disable Odoo constraint on this field.
+        """
+        return

--- a/account_invoice_supplier_ref_unique/tests/test_account_invoice_supplier_ref_unique.py
+++ b/account_invoice_supplier_ref_unique/tests/test_account_invoice_supplier_ref_unique.py
@@ -29,6 +29,7 @@ class TestAccountInvoiceSupplierRefUnique(SavepointCase):
             'partner_id': self.partner.id,
             'account_id': self.account.id,
             'type': 'in_invoice',
+            'reference': 'ABC123',
             'supplier_invoice_number': 'ABC123'})
 
     def test_check_unique_supplier_invoice_number_insensitive(self):
@@ -38,12 +39,14 @@ class TestAccountInvoiceSupplierRefUnique(SavepointCase):
                 'partner_id': self.partner.id,
                 'account_id': self.account.id,
                 'type': 'in_invoice',
+                'reference': 'ABC123',
                 'supplier_invoice_number': 'ABC123'})
         # A new invoice instance with a new supplier_invoice_number
         self.account_invoice.create({
             'partner_id': self.partner.id,
             'account_id': self.account.id,
             'type': 'in_invoice',
+            'reference': 'ABC123',
             'supplier_invoice_number': 'ABC123bis'})
 
     def test_onchange_supplier_invoice_number(self):


### PR DESCRIPTION
For instance in Belgium, some suppliers provide recurring invoices which contain the same communication for the payment. From the version 9.0, the field Vendor refrence is used for payment communication and the maching on bank statement. So, in this case, we have to put the communication from the payment in this field and, as explained just above, may be the same as on another invoice. Therefore, this commit disables this constraint.

- [x] Depends on https://github.com/odoo/odoo/pull/20343