### PR TITLE
[FIX][10.0] sale_timesheet_invoice_description: minor fix in README

### DIFF
--- a/sale_timesheet_invoice_description/README.rst
+++ b/sale_timesheet_invoice_description/README.rst
@@ -39,7 +39,7 @@ To use this module, you need to:
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
-   :target: https://runbot.odoo-community.org/runbot/95/9.0
+   :target: https://runbot.odoo-community.org/runbot/95/10.0
 
 
 Bug Tracker


### PR DESCRIPTION
The button Try Me On Runbot points to version 9.0, should be 10.0