### PR TITLE
[REF] invoice_margin: Fix lints

### DIFF
--- a/invoice_margin/__openerp__.py
+++ b/invoice_margin/__openerp__.py
@@ -13,6 +13,7 @@
     'depends': [
         'account',
     ],
+    'license': 'AGPL-3',
     'data': [
         'views/view_account_invoice.xml',
         'data/decimal_precision.xml',

--- a/invoice_margin/hooks.py
+++ b/invoice_margin/hooks.py
@@ -9,6 +9,7 @@ _logger = logging.getLogger(__name__)
 
 
 def _create_column(cr, table_name, column_name, column_type):
+    # pylint: disable=sql-injection
     req = "ALTER TABLE %s ADD COLUMN %s %s" % (
         table_name, column_name, column_type)
     cr.execute(req)

--- a/invoice_margin/models/account_invoice_line.py
+++ b/invoice_margin/models/account_invoice_line.py
@@ -45,7 +45,7 @@ class AccountInvoiceLine(models.Model):
     # Compute Section
     @api.multi
     @api.depends(
-            'purchase_price', 'quantity', 'price_subtotal', 'invoice_id.type')
+        'purchase_price', 'quantity', 'price_subtotal', 'invoice_id.type')
     def _compute_multi_margin(self):
         for line in self.filtered(
                 lambda l: l.product_id and


### PR DESCRIPTION
Fix the following lints
```txt
invoice_margin/models/account_invoice_line.py:48:13: E126 continuation line over-indented for hanging indent
invoice_margin/__openerp__.py:6: [C8102(manifest-required-key), ] Missing required key "license" in manifest file
invoice_margin/hooks.py:12: [E8103(sql-injection), _create_column] SQL injection risk. Use parameters if you can. - More info https://github.com/OCA/maintainer-tools/blob/master/CONTRIBUTING.md#no-sql-injection
````