### PR TITLE
[8.0] account_invoice_line_default_account

### DIFF
--- a/account_invoice_line_default_account/README.rst
+++ b/account_invoice_line_default_account/README.rst
@@ -1,0 +1,37 @@
+Account Invoice Line default Account
+====================================
+
+When entering sales or purchase invoices directly, the user has to select an
+account which will be used as a counterpart in the generated move lines. Each
+supplier will mostly be linked to one account. For instance when ordering paper
+from a supplier that deals in paper, the counterpart account will mostly be
+something like 'office expenses'. The same principle has been applied for
+customers. This module will add a default counterpart expense and income
+account to a partner, comparable to the similiar field in product. When an
+invoice is entered, withouth a product, the field from partner will be used as
+default. Also when an account is entered on an invoice line (not automatically
+selected for a product), the account will be automatically linked to the
+partner as default expense or income account, unless explicitly disabled in the
+partner record.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Jacques-Etienne Baudoux <je@bcim.be> (BCIM sprl)
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose mission is to support the collaborative development of Odoo features and promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.
+

--- a/account_invoice_line_default_account/__init__.py
+++ b/account_invoice_line_default_account/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/account_invoice_line_default_account/__openerp__.py
+++ b/account_invoice_line_default_account/__openerp__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright 2012 Therp BV (<http://therp.nl>)
+# Copyright 2013-2018 BCIM SPRL (<http://www.bcim.be>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+{
+    'name': 'Account Invoice Line Default Account',
+    'version': '8.0.1.0.0',
+    'depends': [
+        'account'
+    ],
+    'author': 'Therp BV,BCIM,Odoo Community Association (OCA)',
+    'contributors': ['Jacques-Etienne Baudoux <je@bcim.be>'],
+    'license': 'AGPL-3',
+    'category': 'Accounting',
+    'data': [
+        'views/res_partner.xml',
+        'views/account_invoice.xml',
+    ],
+    'installable': True,
+}

--- a/account_invoice_line_default_account/i18n/account_invoice_line_default_account.pot
+++ b/account_invoice_line_default_account/i18n/account_invoice_line_default_account.pot
@@ -1,0 +1,59 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#	* account_invoice_line_default_account
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.saas~1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2013-09-18 16:01+0000\n"
+"PO-Revision-Date: 2013-09-18 16:01+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_invoice_line_default_account
+#: field:res.partner,property_account_expense:0
+msgid "Default Expense Account"
+msgstr ""
+
+#. module: account_invoice_line_default_account
+#: help:res.partner,property_account_expense:0
+msgid "Default counterpart account for purchases on invoice lines"
+msgstr ""
+
+#. module: account_invoice_line_default_account
+#: help:res.partner,auto_update_account_expense:0
+msgid "When an account is selected on an invoice line, automatically assign it as default expense account"
+msgstr ""
+
+#. module: account_invoice_line_default_account
+#: code:addons/account_invoice_line_default_account/model/account_invoice_line.py:27
+#: code:addons/account_invoice_line_default_account/model/account_invoice_line.py:47
+#, python-format
+msgid "No object created for partner %d"
+msgstr ""
+
+#. module: account_invoice_line_default_account
+#: model:ir.model,name:account_invoice_line_default_account.model_account_invoice_line
+msgid "Invoice Line"
+msgstr ""
+
+#. module: account_invoice_line_default_account
+#: view:res.partner:0
+msgid "autosave from invoice line"
+msgstr ""
+
+#. module: account_invoice_line_default_account
+#: field:res.partner,auto_update_account_expense:0
+msgid "Autosave Selection on Invoice Line"
+msgstr ""
+
+#. module: account_invoice_line_default_account
+#: model:ir.model,name:account_invoice_line_default_account.model_res_partner
+msgid "Partner"
+msgstr ""
+

--- a/account_invoice_line_default_account/i18n/fr.po
+++ b/account_invoice_line_default_account/i18n/fr.po
@@ -1,0 +1,59 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#	* account_invoice_line_default_account
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.saas~1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2013-09-18 16:01+0000\n"
+"PO-Revision-Date: 2013-09-18 16:01+0000\n"
+"Last-Translator: Jacques-Etienne Baudoux <je@bcim.be>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_invoice_line_default_account
+#: field:res.partner,property_account_expense:0
+msgid "Default Expense Account"
+msgstr "Compte de charge par défaut"
+
+#. module: account_invoice_line_default_account
+#: help:res.partner,property_account_expense:0
+msgid "Default counterpart account for purchases on invoice lines"
+msgstr "Compte de contrepartie par défaut pour les lignes de factures d'achat"
+
+#. module: account_invoice_line_default_account
+#: help:res.partner,auto_update_account_expense:0
+msgid "When an account is selected on an invoice line, automatically assign it as default expense account"
+msgstr "Lorsqu'un compte est sélectionné sur une ligne de facture, l'assigner automatiquement comme compte de charge par défaut"
+
+#. module: account_invoice_line_default_account
+#: code:addons/account_invoice_line_default_account/model/account_invoice_line.py:27
+#: code:addons/account_invoice_line_default_account/model/account_invoice_line.py:47
+#, python-format
+msgid "No object created for partner %d"
+msgstr ""
+
+#. module: account_invoice_line_default_account
+#: model:ir.model,name:account_invoice_line_default_account.model_account_invoice_line
+msgid "Invoice Line"
+msgstr ""
+
+#. module: account_invoice_line_default_account
+#: view:res.partner:0
+msgid "autosave from invoice line"
+msgstr "sauvegarde automatique"
+
+#. module: account_invoice_line_default_account
+#: field:res.partner,auto_update_account_expense:0
+msgid "Autosave Selection on Invoice Line"
+msgstr ""
+
+#. module: account_invoice_line_default_account
+#: model:ir.model,name:account_invoice_line_default_account.model_res_partner
+msgid "Partner"
+msgstr ""
+

--- a/account_invoice_line_default_account/i18n/nl.po
+++ b/account_invoice_line_default_account/i18n/nl.po
@@ -1,0 +1,59 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#	* account_invoice_line_default_account
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.saas~1\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2013-09-18 16:01+0000\n"
+"PO-Revision-Date: 2013-09-18 16:01+0000\n"
+"Last-Translator: Jacques-Etienne Baudoux <je@bcim.be>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_invoice_line_default_account
+#: field:res.partner,property_account_expense:0
+msgid "Default Expense Account"
+msgstr "Standaard kostenrekening"
+
+#. module: account_invoice_line_default_account
+#: help:res.partner,property_account_expense:0
+msgid "Default counterpart account for purchases on invoice lines"
+msgstr "Standaard tegenrekening voor inkoop factuur lijnen"
+
+#. module: account_invoice_line_default_account
+#: help:res.partner,auto_update_account_expense:0
+msgid "When an account is selected on an invoice line, automatically assign it as default expense account"
+msgstr "Wanneer een rekening op een factuur lijn is geselecteerd, automatisch toewijzen als standaard kostenrekening"
+
+#. module: account_invoice_line_default_account
+#: code:addons/account_invoice_line_default_account/model/account_invoice_line.py:27
+#: code:addons/account_invoice_line_default_account/model/account_invoice_line.py:47
+#, python-format
+msgid "No object created for partner %d"
+msgstr ""
+
+#. module: account_invoice_line_default_account
+#: model:ir.model,name:account_invoice_line_default_account.model_account_invoice_line
+msgid "Invoice Line"
+msgstr ""
+
+#. module: account_invoice_line_default_account
+#: view:res.partner:0
+msgid "autosave from invoice line"
+msgstr "automatisch bewaren"
+
+#. module: account_invoice_line_default_account
+#: field:res.partner,auto_update_account_expense:0
+msgid "Autosave Selection on Invoice Line"
+msgstr ""
+
+#. module: account_invoice_line_default_account
+#: model:ir.model,name:account_invoice_line_default_account.model_res_partner
+msgid "Partner"
+msgstr ""
+

--- a/account_invoice_line_default_account/models/__init__.py
+++ b/account_invoice_line_default_account/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: UTF-8 -*-
+
+from . import res_partner
+from . import account_invoice_line

--- a/account_invoice_line_default_account/models/account_invoice_line.py
+++ b/account_invoice_line_default_account/models/account_invoice_line.py
@@ -1,0 +1,81 @@
+# -*- coding: UTF-8 -*-
+# Copyright 2012 Therp BV (<http://therp.nl>)
+# Copyright 2013-2018 BCIM SPRL (<http://www.bcim.be>)
+
+from openerp.osv import orm
+from openerp.tools.translate import _
+
+
+class account_invoice_line(orm.Model):
+    _inherit = 'account.invoice.line'
+
+    def _account_id_default(self, cr, uid, context=None):
+        if context is None:
+            context = {}
+        partner_id = context.get('partner_id')
+        if not partner_id:
+            return False
+        assert isinstance(partner_id, (int, long)), (
+            _('No valid id for context partner_id %d') % partner_id)
+        invoice_type = context.get('type')
+        partner_model = self.pool.get('res.partner')
+        if invoice_type in ['in_invoice', 'in_refund']:
+            partner = partner_model.read(
+                cr, uid, partner_id,
+                ['property_account_expense'], context=context)
+            if partner['property_account_expense']:
+                return partner['property_account_expense']
+        elif invoice_type in ['out_invoice', 'out_refund']:
+            partner = partner_model.read(
+                cr, uid, partner_id,
+                ['property_account_income'], context=context)
+            if partner['property_account_income']:
+                return partner['property_account_income']
+        return self._default_account(cr, uid, context=context)
+
+    _defaults = {
+        'account_id': _account_id_default,
+    }
+
+    def onchange_account_id(
+            self, cr, uid, ids, product_id, partner_id, inv_type,
+            fposition_id, account_id, context=None):
+        if not account_id or not partner_id or product_id:
+            return super(account_invoice_line, self).onchange_account_id(
+                cr, uid, ids, product_id, partner_id, inv_type,
+                fposition_id, account_id)
+        context = context or {}
+        if context.get('journal_id'):
+            journal = self.pool['account.journal'].browse(
+                cr, uid, context.get('journal_id'), context=context)
+            if account_id in [
+                    journal.default_credit_account_id.id,
+                    journal.default_debit_account_id.id]:
+                return super(account_invoice_line, self).onchange_account_id(
+                    cr, uid, ids, product_id, partner_id, inv_type,
+                    fposition_id, account_id)
+        # We have a manually entered account_id (no product_id, so the
+        # account_id is not the result of a product selection).
+        # Store this account_id as future default in res_partner.
+        partner_model = self.pool.get('res.partner')
+        partner = partner_model.read(
+            cr, uid, partner_id,
+            ['auto_update_account_expense', 'property_account_expense',
+             'auto_update_account_income', 'property_account_income'],
+            context=context)
+        vals = {}
+        if (inv_type in ['in_invoice', 'in_refund'] and
+                partner['auto_update_account_expense']):
+            if account_id != partner['property_account_expense']:
+                # only write when something really changed
+                vals.update({'property_account_expense': account_id})
+        elif (inv_type in ['out_invoice', 'out_refund'] and
+                partner['auto_update_account_income']):
+            if account_id != partner['property_account_income']:
+                # only write when something really changed
+                vals.update({'property_account_income': account_id})
+        if vals:
+            partner_model.write(cr, uid, partner_id, vals, context=context)
+        return super(account_invoice_line, self).onchange_account_id(
+            cr, uid, ids, product_id, partner_id, inv_type,
+            fposition_id, account_id)

--- a/account_invoice_line_default_account/models/res_partner.py
+++ b/account_invoice_line_default_account/models/res_partner.py
@@ -1,0 +1,46 @@
+# -*- coding: UTF-8 -*-
+'''
+Created on 30 jan. 2013
+
+@author: Ronald Portier, Therp
+@contributor: Jacques-Etienne Baudoux, BCIM
+'''
+
+from openerp.osv import orm
+from openerp.osv import fields
+
+
+class res_partner(orm.Model):
+    _inherit = 'res.partner'
+
+    _columns = {
+        'property_account_income': fields.property(
+            obj_prop='account.account',
+            type='many2one',
+            relation='account.account',
+            string='Default Income Account',
+            domain='''[('user_type.report_type', '=', 'income')]''',
+            help='Default counterpart account for sales on invoice lines',
+            required=False),
+        'auto_update_account_income': fields.boolean(
+            'Autosave Selection on Invoice Line',
+            help='When an account is selected on an invoice line, '
+                 'automatically assign it as default income account'),
+        'property_account_expense': fields.property(
+            obj_prop='account.account',
+            type='many2one',
+            relation='account.account',
+            string='Default Expense Account',
+            domain='''[('user_type.report_type', '=', 'expense')]''',
+            help='Default counterpart account for purchases on invoice lines',
+            required=False),
+        'auto_update_account_expense': fields.boolean(
+            'Autosave Selection on Invoice Line',
+            help='When an account is selected on an invoice line, '
+                 'automatically assign it as default expense account'),
+    }
+
+    _defaults = {
+        'auto_update_account_income': True,
+        'auto_update_account_expense': True,
+    }

--- a/account_invoice_line_default_account/views/account_invoice.xml
+++ b/account_invoice_line_default_account/views/account_invoice.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+<data>
+    <record id="invoice_form" model="ir.ui.view">
+        <field name="name">invoice_line_ids partner context</field>
+        <field name="model">account.invoice</field>
+        <field name="type">form</field>
+        <field name="inherit_id" ref="account.invoice_form" />
+        <field name="arch" type="xml">
+            <field name="invoice_line" position="attributes">
+                <attribute name="context">{'partner_id': partner_id, 'type': type, 'journal_id': journal_id}</attribute>
+            </field>
+        </field>
+    </record>
+
+    <record id="invoice_supplier_form" model="ir.ui.view">
+        <field name="name">invoice_line_ids partner context</field>
+        <field name="model">account.invoice</field>
+        <field name="type">form</field>
+        <field name="inherit_id" ref="account.invoice_supplier_form"/>
+        <field name="arch" type="xml">
+            <field name="invoice_line" position="attributes">
+                <attribute name="context">{'partner_id': partner_id, 'price_type': context.get('price_type') or False, 'type': type, 'journal_id': journal_id}</attribute>
+            </field>
+        </field>
+    </record>
+
+</data>
+</openerp>

--- a/account_invoice_line_default_account/views/res_partner.xml
+++ b/account_invoice_line_default_account/views/res_partner.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record
+            id="view_partner_expense_property_form"
+            model="ir.ui.view">
+            <field name="name">res.partner.property.form.inherit</field>
+            <field name="model">res.partner</field>
+            <field name="type">form</field>
+            <field name="priority">2</field>
+            <field
+                name="inherit_id"
+                ref="account.view_partner_property_form" />
+            <field
+                name="arch"
+                type="xml">
+                <field
+                    name="property_account_receivable"
+                    position="after">
+                    <label for="property_account_income" />
+                    <div>
+                        <field
+                            name="property_account_income"
+                            groups="account.group_account_invoice" />
+                        <div style=" white-space: nowrap; ">
+                            <field
+                                name="auto_update_account_income"
+                                nolabel="1"
+                                groups="account.group_account_invoice" />
+                            <label for="auto_update_account_income" string="autosave from invoice line"/>
+                        </div>
+                    </div>
+                </field>
+                <field
+                    name="property_account_payable"
+                    position="after">
+                    <label for="property_account_expense" />
+                    <div>
+                        <field
+                            name="property_account_expense"
+                            groups="account.group_account_invoice" />
+                        <div style=" white-space: nowrap; ">
+                            <field
+                                name="auto_update_account_expense"
+                                nolabel="1"
+                                groups="account.group_account_invoice" />
+                            <label for="auto_update_account_expense" string="autosave from invoice line"/>
+                        </div>
+                    </div>
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
Add default expense and income account on partner. Auto-save and use them when filling an invoice.
Replace https://github.com/OCA/account-invoicing/pull/23

I copied the module on a fresh 8.0 repo as it could not be rebased. (was initially extracted from LP on 6.1 but never merged)

Also ported to v10 here: https://github.com/OCA/account-invoicing/pull/351