### PR TITLE
[10.0] account_group_invoice_line One fix and code simplification

### DIFF
--- a/account_group_invoice_line/__manifest__.py
+++ b/account_group_invoice_line/__manifest__.py
@@ -7,7 +7,7 @@
 
 {
     'name': 'Account Group Invoice Lines',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.1.0',
     'category': 'Accounting & Finance',
     'summary': 'Add option to group invoice lines per account',
     'author': 'SYLEAM,Akretion,Odoo Community Association (OCA)',

--- a/account_group_invoice_line/models/account_invoice.py
+++ b/account_group_invoice_line/models/account_invoice.py
@@ -11,29 +11,13 @@ from odoo import models, api
 class AccountInvoice(models.Model):
     _inherit = 'account.invoice'
 
-    def inv_line_characteristic_hashcode(self, invoice_line):
-        """Inherit the native method that generate hashcodes for grouping.
-        When grouping per account, we remove the product_id from
-        the hashcode.
-        WARNING: I suppose that the other methods that inherit this
-        method add data on the end of the hashcode, not at the beginning.
-        This is the case of github/OCA/account-closing/
-        account_cutoff_prepaid/account.py"""
-        res = super(AccountInvoice, self).inv_line_characteristic_hashcode(
-            invoice_line)
-        if self.journal_id.group_method == 'account':
-            hash_list = res.split('-')
-            # remove product_id from hashcode
-            hash_list.pop(2)
-            res = '-'.join(hash_list)
-        return res
-
     @api.model
     def line_get_convert(self, line, part):
         res = super(AccountInvoice, self).line_get_convert(line, part)
-        if (
-                self.journal_id.group_invoice_lines and
-                self.journal_id.group_method == 'account'):
-            res['name'] = '/'
-            res['product_id'] = False
+        if line.get('invoice_id'):
+            inv = self.browse(line['invoice_id'])
+            jrl = inv.journal_id
+            if jrl.group_invoice_lines and jrl.group_method == 'account':
+                res['name'] = '/'
+                res['product_id'] = False
         return res


### PR DESCRIPTION
We are not supposed to use self.journal_id on an @api.model method ; with this change, it fixes the use of action_invoice_open() on multi-recordset

I removed the inherit of the method inv_line_characteristic_hashcode() which was in fact useless: line_get_convert() is called before inv_line_characteristic_hashcode() and line_get_convert() set the product_id key to False, so there's no point in removing it from the hash (and it fact, it was poping the wrong position !)

