### PR TITLE
[11.0] Add module enabling to reuse supplier invoice references

### DIFF
--- a/account_invoice_supplier_ref_reuse/README.rst
+++ b/account_invoice_supplier_ref_reuse/README.rst
@@ -1,0 +1,54 @@
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+=================================
+Reuse Supplier Invoice References
+=================================
+
+In some cases, having more than one supplier invoice with the same
+reference is possible. For instance, in Switzerland, BVR/ESR numbers
+are used as a type of reference. Generally, this number is unique and
+used only for one invoice. However, some suppliers do use the same BVR
+reference for several invoices (usually for recurring invoices).
+
+Installation
+============
+
+To install this module, just click the install button.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/account-invoicing/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://odoo-community.org/logo.png>`_.
+
+Contributors
+------------
+
+* Alexandre Saunier - Camptocamp <alexandre.saunier@camptocamp.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/account_invoice_supplier_ref_reuse/__init__.py
+++ b/account_invoice_supplier_ref_reuse/__init__.py
@@ -1,0 +1,4 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import models
+from . import tests

--- a/account_invoice_supplier_ref_reuse/__manifest__.py
+++ b/account_invoice_supplier_ref_reuse/__manifest__.py
@@ -1,0 +1,15 @@
+# Copyright 2018 Camptocamp
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{
+    'name': 'Reuse Supplier Invoice References',
+    'version': '11.0.1.0.0',
+    'summary': 'Makes it possible to reuse supplier invoice references',
+    'author': 'Camptocamp, '
+              'Odoo Community Association (OCA)',
+    'website': 'https://www.camptocamp.com',
+    'license': 'AGPL-3',
+    'category': 'Accounting & Finance',
+    'depends': [
+        'account'
+    ],
+}

--- a/account_invoice_supplier_ref_reuse/models/__init__.py
+++ b/account_invoice_supplier_ref_reuse/models/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import account_invoice

--- a/account_invoice_supplier_ref_reuse/models/account_invoice.py
+++ b/account_invoice_supplier_ref_reuse/models/account_invoice.py
@@ -1,0 +1,14 @@
+# Copyright 2018 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class AccountInvoice(models.Model):
+    _inherit = "account.invoice"
+
+    @api.multi
+    def _check_duplicate_supplier_reference(self):
+        # Do nothing instead of checking if the reference number already
+        # exists.
+        pass

--- a/account_invoice_supplier_ref_reuse/tests/__init__.py
+++ b/account_invoice_supplier_ref_reuse/tests/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import test_invoice_supplier_reference_reuse

--- a/account_invoice_supplier_ref_reuse/tests/test_invoice_supplier_reference_reuse.py
+++ b/account_invoice_supplier_ref_reuse/tests/test_invoice_supplier_reference_reuse.py
@@ -1,0 +1,51 @@
+# Copyright 2018 Camptocamp
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import SavepointCase
+
+
+class TestInvoiceSupplierReferenceReuse(SavepointCase):
+
+    @classmethod
+    def setUpClass(self):
+        super().setUpClass()
+
+        # Inspired by TestAccountSupplierInvoice
+        # https://github.com/odoo/odoo/blob/11.0/addons/account/tests/test_account_supplier_invoice.py
+
+        self.invoice_account = self.env['account.account'].search(
+            [('user_type_id',
+              '=',
+              self.env.ref('account.data_account_type_receivable').id
+              )], limit=1).id
+        self.invoice_line_account = self.env['account.account'].search(
+            [('user_type_id',
+              '=',
+              self.env.ref('account.data_account_type_expenses').id
+              )], limit=1).id
+
+        self.invoice = self._create_invoice_with_reference(self, 'ABC123')
+
+    def _create_invoice_with_reference(self, reference):
+        invoice = self.env['account.invoice'].create({
+            'partner_id': self.env.ref('base.res_partner_2').id,
+            'account_id': self.invoice_account,
+            'type': 'in_invoice',
+            'reference': reference
+        })
+        self.env['account.invoice.line'].create({
+            'product_id': self.env.ref('product.product_product_4').id,
+            'quantity': 1.0,
+            'price_unit': 100.0,
+            'invoice_id': invoice.id,
+            'name': 'product that cost 100',
+            'account_id': self.invoice_line_account,
+        })
+        invoice.action_invoice_open()
+        return invoice
+
+    def test_01_reference_reuse(self):
+        """ Check that reusing the reference number is possible
+        """
+        invoice2 = self._create_invoice_with_reference(self.invoice.reference)
+        self.assertEqual(invoice2.reference, self.invoice.reference)


### PR DESCRIPTION
In some cases, having more than one supplier invoice with the same reference is possible. For instance, in Switzerland, BVR/ESR numbers are used as a type of reference. Generally, this number is unique and used only for one invoice. However, some suppliers do use the same BVR reference for several invoices (usually for recurring invoices).

Related to https://github.com/odoo/odoo/pull/15891