### PR TITLE
[FIX][#377] possible fix for error in computation of amount_untaxed

### DIFF
--- a/account_invoice_rounding/account.py
+++ b/account_invoice_rounding/account.py
@@ -172,8 +172,9 @@ class AccountInvoice(models.Model):
                 if 'amount_tax' in swedish_rounding:
                     self.amount_tax = swedish_rounding['amount_tax']
                 elif 'amount_untaxed' in swedish_rounding:
-                    self.amount_untaxed = (
-                        swedish_rounding['amount_untaxed'])
+                    if sum(line.price_subtotal for line in self.invoice_line) != self.amount_untaxed:
+                        self.amount_untaxed = (
+                            swedish_rounding['amount_untaxed'])
 
     @api.multi
     def _get_rounding_invoice_line_id(self):


### PR DESCRIPTION
This seems to fix #377 but I'm sure there is a more elegant solution for this. So another solution (or validation) would be greatly appreciated.
The problem seems to be that the core _compute_amount method already includes the amount of the rounding invoice line while the global_round_line_id on the invoice is not yet set which is why the amount is not removed here: 
https://github.com/OCA/account-invoicing/blob/8.0/account_invoice_rounding/account.py#L168
Before it is added back/again here: 
https://github.com/OCA/account-invoicing/blob/8.0/account_invoice_rounding/account.py#L177
