### PR TITLE
[FIX] account_invoice_refund_link: Fix integration tests

### DIFF
--- a/account_invoice_refund_link/__manifest__.py
+++ b/account_invoice_refund_link/__manifest__.py
@@ -7,7 +7,7 @@
 {
     "name": "Link refund invoice with original",
     "summary": "Link refund invoice with its original invoice",
-    "version": "10.0.1.0.2",
+    "version": "10.0.1.0.3",
     "category": "Accounting & Finance",
     "website": "https://odoo-community.org/",
     "author": "Pexego, "

--- a/account_invoice_refund_link/tests/test_invoice_refund_link.py
+++ b/account_invoice_refund_link/tests/test_invoice_refund_link.py
@@ -3,11 +3,13 @@
 # Copyright 2014-2017 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo.tests import common
+from odoo.tests import at_install, post_install, SavepointCase
 from .. import post_init_hook
 
 
-class TestInvoiceRefundLinkBase(common.SavepointCase):
+@at_install(False)
+@post_install(True)
+class TestInvoiceRefundLinkBase(SavepointCase):
     filter_refund = 'refund'
 
     @classmethod


### PR DESCRIPTION
Creating partners in integration environment raises this error:

    IntegrityError: null value in column "sale_warn" violates not-null constraint

Moving to post install mode to avoid such errors.

@tecnativa