### PR TITLE
[FIX] do not use sale pricelist for purchase invoices

### DIFF
--- a/account_invoice_pricelist/model/account_invoice_line.py
+++ b/account_invoice_pricelist/model/account_invoice_line.py
@@ -25,15 +25,18 @@ class AccountInvoiceLine(models.Model):
         context = self._context
         partner = self.env['res.partner'].browse(partner_id)
         pricelist_id = context.get('pricelist_id', False)
-        if type in ('out_invoice', 'out_refund'):
-            # Customer Invoices
-            pricelist_id = partner.property_product_pricelist.id
-        elif type in ('in_invoice', 'in_refund'):
-            # Supplier Invoices
-            if partner._model._columns.get(
-                    'property_product_pricelist_purchase', False):
-                pricelist_id =\
-                    partner.property_product_pricelist_purchase.id
+        if not pricelist_id:
+            # If pricelist is not set on invoice, or not available in the
+            # context, use the pricelist of the partner
+            if type in ('out_invoice', 'out_refund'):
+                # Customer Invoices
+                pricelist_id = partner.property_product_pricelist.id
+            elif type in ('in_invoice', 'in_refund'):
+                # Supplier Invoices
+                if partner._model._columns.get(
+                        'property_product_pricelist_purchase', False):
+                    pricelist_id =\
+                        partner.property_product_pricelist_purchase.id
 
         if not pricelist_id:
             return res

--- a/account_invoice_pricelist/model/account_invoice_line.py
+++ b/account_invoice_pricelist/model/account_invoice_line.py
@@ -24,8 +24,17 @@ class AccountInvoiceLine(models.Model):
             return res
         context = self._context
         partner = self.env['res.partner'].browse(partner_id)
-        pricelist_id = context.get(
-            'pricelist_id', partner.property_product_pricelist.id)
+        pricelist_id = context.get('pricelist_id', False)
+        if type in ('out_invoice', 'out_refund'):
+            # Customer Invoices
+            pricelist_id = partner.property_product_pricelist.id
+        elif type in ('in_invoice', 'in_refund'):
+            # Supplier Invoices
+            if partner._model._columns.get(
+                    'property_product_pricelist_purchase', False):
+                pricelist_id =\
+                    partner.property_product_pricelist_purchase.id
+
         if not pricelist_id:
             return res
         company_id = company_id or context.get('company_id', False)

--- a/account_invoice_pricelist/view/account_invoice_view.xml
+++ b/account_invoice_pricelist/view/account_invoice_view.xml
@@ -21,7 +21,7 @@
                         />
                 </field>
                 <field name="user_id" position="after">
-                    <field name="pricelist_id"/>
+                    <field name="pricelist_id" domain="[('type', '=', 'sale')]"/>
                 </field>
                 <field name="invoice_line" position="attributes">
                     <attribute
@@ -54,7 +54,7 @@
                         />
                 </field>
                 <field name="user_id" position="after">
-                    <field name="pricelist_id"/>
+                    <field name="pricelist_id" domain="[('type', '=', 'purchase')]"/>
                 </field>
                 <field name="invoice_line" position="attributes">
                     <attribute


### PR DESCRIPTION
This fix applies the same behaviour in account.invoice.line as in account.invoice file : 
The pricelist will be selected from property_product_pricelist for 'out_invoice' / 'out_refund'
The pricelist will be selected from property_product_pricelist_purchase for 'in_invoice' / 'in_refund'

thanks for your review.