### PR TITLE
[11.0][add] account_invoice_anglo_saxon_no_cogs_deferral

### DIFF
--- a/account_invoice_anglo_saxon_no_cogs_deferral/README.rst
+++ b/account_invoice_anglo_saxon_no_cogs_deferral/README.rst
@@ -1,0 +1,29 @@
+.. image:: https://img.shields.io/badge/license-AGPLv3-blue.svg
+   :target: https://www.gnu.org/licenses/agpl.html
+   :alt: License: AGPL-3
+
+============================================
+Account Invoice Anglo Saxon no COGS deferral
+============================================
+
+This module invalidates the COGS deferral introduced by the Anglo Saxon
+Accounting module.
+
+In companies that send the customer invoice at the time of shipping the
+products the COGS deferral method is not really required, and makes an added
+complexity to accounting to make sure that there are no imbalances in the
+COGS deferral account.
+
+
+Usage
+=====
+In order for this module to work correctly please ensure to set an
+Expense / Cost of Goods Sold as output account in the product category.
+
+
+Credits
+=======
+
+Contributors
+------------
+* Jordi Ballester Alomar <jordi.ballester@eficent.com>

--- a/account_invoice_anglo_saxon_no_cogs_deferral/__init__.py
+++ b/account_invoice_anglo_saxon_no_cogs_deferral/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/account_invoice_anglo_saxon_no_cogs_deferral/__manifest__.py
+++ b/account_invoice_anglo_saxon_no_cogs_deferral/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2015-2018 Eficent Business and IT Consulting Services S.L.
+# - Jordi Ballester Alomar
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "Account Invoice Anglo Saxon no COGS deferral",
+    "summary": "Invalidates the COGS deferral introduced by the anglo saxon "
+               "module",
+    "version": "10.0.1.0.0",
+    "author": "Eficent, "
+              "Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/account-invoicing",
+    "category": "Accounting & Finance",
+    "depends": ["stock_account", "sale_stock"],
+    "license": "AGPL-3",
+    'installable': True,
+}

--- a/account_invoice_anglo_saxon_no_cogs_deferral/models/__init__.py
+++ b/account_invoice_anglo_saxon_no_cogs_deferral/models/__init__.py
@@ -1,1 +1,1 @@
-from . import account
+from . import account_invoice

--- a/account_invoice_anglo_saxon_no_cogs_deferral/models/__init__.py
+++ b/account_invoice_anglo_saxon_no_cogs_deferral/models/__init__.py
@@ -1,0 +1,1 @@
+from . import account

--- a/account_invoice_anglo_saxon_no_cogs_deferral/models/account_invoice.py
+++ b/account_invoice_anglo_saxon_no_cogs_deferral/models/account_invoice.py
@@ -1,0 +1,16 @@
+# Copyright 2015-2018 Eficent Business and IT Consulting Services S.L.
+# - Jordi Ballester Alomar
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, models
+
+
+class AccountInvoice(models.Model):
+    _inherit = "account.invoice"
+
+    @api.model
+    def _anglo_saxon_sale_move_lines(self, i_line):
+        # We override the standard method to invalidate it
+        super(AccountInvoice, self)._anglo_saxon_sale_move_lines(
+            i_line)
+        return []

--- a/account_invoice_anglo_saxon_no_cogs_deferral/readme/CONTRIBUTORS.rst
+++ b/account_invoice_anglo_saxon_no_cogs_deferral/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Jordi Ballester Alomar <jordi.ballester@eficent.com>

--- a/account_invoice_anglo_saxon_no_cogs_deferral/readme/DESCRIPTION.rst
+++ b/account_invoice_anglo_saxon_no_cogs_deferral/readme/DESCRIPTION.rst
@@ -1,0 +1,7 @@
+This module invalidates the COGS deferral introduced by the Anglo Saxon
+Accounting module.
+
+In companies that send the customer invoice at the time of shipping the
+products the COGS deferral method is not really required, and makes an added
+complexity to accounting to make sure that there are no imbalances in the
+COGS deferral account.

--- a/account_invoice_anglo_saxon_no_cogs_deferral/readme/USAGE.rst
+++ b/account_invoice_anglo_saxon_no_cogs_deferral/readme/USAGE.rst
@@ -1,0 +1,2 @@
+In order for this module to work correctly please ensure to set an
+Expense / Cost of Goods Sold as output account in the product category.

--- a/account_invoice_anglo_saxon_no_cogs_deferral/tests/__init__.py
+++ b/account_invoice_anglo_saxon_no_cogs_deferral/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_account_invoice_anglo_saxon_no_cogs_deferral

--- a/account_invoice_anglo_saxon_no_cogs_deferral/tests/test_account_invoice_anglo_saxon_no_cogs_deferral.py
+++ b/account_invoice_anglo_saxon_no_cogs_deferral/tests/test_account_invoice_anglo_saxon_no_cogs_deferral.py
@@ -1,0 +1,114 @@
+# Copyright 2015-2018 Eficent Business and IT Consulting Services S.L.
+# - Jordi Ballester Alomar
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo.tests.common import TransactionCase
+
+
+class TestAccountAngloSaxonNoCogsDeferral(TransactionCase):
+
+    def setUp(self):
+        super(TestAccountAngloSaxonNoCogsDeferral, self).setUp()
+
+        # ENVIRONEMENTS
+        self.Invoice = self.env['account.invoice']
+        self.Account = self.env['account.account']
+        # INSTANCES
+        self.stock_location = self.env.ref('stock.stock_location_stock')
+        self.customer_location = self.env.ref(
+            'stock.stock_location_customers')
+        self.supplier_location = self.env.ref(
+            'stock.stock_location_suppliers')
+        self.uom_unit = self.env.ref('product.product_uom_unit')
+        self.partner = self.env['res.partner'].create({
+            'name': 'Test partner'
+        })
+        self.product1 = self.env['product.product'].create({
+            'name': 'Product A',
+            'type': 'product',
+            'categ_id': self.env.ref('product.product_category_all').id,
+        })
+        self.product1.product_tmpl_id.valuation = 'real_time'
+        self.product1.product_tmpl_id.cost_method = 'fifo'
+        self.stock_input_account = self.Account.create({
+            'name': 'Stock Input',
+            'code': 'StockIn',
+            'user_type_id': self.env.ref(
+                'account.data_account_type_current_liabilities').id,
+        })
+        self.stock_output_account = self.Account.create({
+            'name': 'COGS',
+            'code': 'cogs',
+            'user_type_id': self.env.ref(
+                'account.data_account_type_expenses').id,
+        })
+        self.stock_valuation_account = self.Account.create({
+            'name': 'Stock Valuation',
+            'code': 'Stock Valuation',
+            'user_type_id': self.env.ref(
+                'account.data_account_type_current_assets').id,
+        })
+        self.stock_journal = self.env['account.journal'].create({
+            'name': 'Stock Journal',
+            'code': 'STJTEST',
+            'type': 'general',
+        })
+        self.product1.categ_id.write({
+            'property_stock_account_input_categ_id':
+                self.stock_input_account.id,
+            'property_stock_account_output_categ_id':
+                self.stock_output_account.id,
+            'property_stock_valuation_account_id':
+                self.stock_valuation_account.id,
+            'property_stock_journal': self.stock_journal.id,
+        })
+
+    def test_create_invoice(self):
+        # receive 10 units @ 10.00 per unit
+        move1 = self.env['stock.move'].create({
+            'name': 'IN 10 units @ 10.00 per unit',
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
+            'product_id': self.product1.id,
+            'product_uom': self.uom_unit.id,
+            'product_uom_qty': 10.0,
+            'price_unit': 10.0,
+        })
+        move1._action_confirm()
+        move1._action_assign()
+        move1.move_line_ids.qty_done = 10.0
+        move1._action_done()
+        # create a so
+        so = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'partner_invoice_id': self.partner.id,
+            'partner_shipping_id': self.partner.id,
+            'order_line': [(0, 0, {'name': self.product1.name,
+                                   'product_id': self.product1.id,
+                                   'product_uom_qty': 1,
+                                   'product_uom': self.product1.uom_id.id,
+                                   'price_unit': self.product1.list_price})],
+            'pricelist_id': self.env.ref('product.list0').id,
+            'picking_policy': 'direct',
+        })
+        so.action_confirm()
+        # invoice on order
+        so.action_invoice_create()
+        pick = so.picking_ids
+        pick.force_assign()
+        pick.move_lines.write({'quantity_done': 1})
+        pick.button_validate()
+        self.assertEqual(pick.state, 'done')
+        invoice = so.invoice_ids
+        invoice.action_invoice_open()
+        # Check that there's no cogs line involved in the customer invoice
+        cogs_line = invoice.move_id.mapped('line_ids').filtered(
+            lambda l: l.account_id.code == 'cogs')
+        self.assertEqual(len(cogs_line), 0)
+        # Check that the account move originating from the stock move has a
+        # COGS account.
+        move = self.env['account.move'].search([('ref', '=', pick.name)])
+        self.assertEquals(len(move), 1)
+        cogs_line = move.mapped('line_ids').filtered(
+            lambda l: l.account_id.code == 'cogs')
+        self.assertEqual(len(cogs_line), 1)

--- a/setup/account_invoice_anglo_saxon_no_cogs_deferral/odoo/addons/account_invoice_anglo_saxon_no_cogs_deferral
+++ b/setup/account_invoice_anglo_saxon_no_cogs_deferral/odoo/addons/account_invoice_anglo_saxon_no_cogs_deferral
@@ -1,0 +1,1 @@
+../../../account_invoice_anglo_saxon_no_cogs_deferral/

--- a/setup/account_invoice_anglo_saxon_no_cogs_deferral/setup.cfg
+++ b/setup/account_invoice_anglo_saxon_no_cogs_deferral/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/setup/account_invoice_anglo_saxon_no_cogs_deferral/setup.py
+++ b/setup/account_invoice_anglo_saxon_no_cogs_deferral/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Account Invoice Anglo Saxon no COGS deferral
====================================

This module invalidates the COGS deferral introduced by the Anglo Saxon
Accounting module.

In companies that send the customer invoice at the time of shipping the
products the COGS deferral method is not really required, and makes an added
complexity to accounting to make sure that there are no imbalances in the
COGS deferral account.


Usage
=====
In order for this module to work correctly please ensure to set an
Expense / Cost of Goods Sold as output account in the product category.
