### PR TITLE
[10.0][FIX] account_invoice_merge: fix wrong usage of non-existent xml ids

### DIFF
--- a/account_invoice_merge/__manifest__.py
+++ b/account_invoice_merge/__manifest__.py
@@ -8,7 +8,7 @@
 
 {
     'name': 'Account Invoice Merge',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Finance',
     'summary': "Merge invoices in draft",
     'author': "Elico Corp,Odoo Community Association (OCA)",

--- a/account_invoice_merge/wizard/invoice_merge.py
+++ b/account_invoice_merge/wizard/invoice_merge.py
@@ -89,9 +89,9 @@ class InvoiceMerge(models.TransientModel):
                                         date_invoice=self.date_invoice)
         xid = {
             'out_invoice': 'action_invoice_tree1',
-            'out_refund': 'action_invoice_tree3',
+            'out_refund': 'action_invoice_tree1',
             'in_invoice': 'action_invoice_tree2',
-            'in_refund': 'action_invoice_tree4',
+            'in_refund': 'action_invoice_tree2',
         }[invoices[0].type]
         action = aw_obj.for_xml_id('account', xid)
         action.update({


### PR DESCRIPTION
It is impossible to merge credit notes without this PR as the wizard tries to redirect to unexistent views