### PR TITLE
[10.0][FIX] account_invoice_transmit_method: fix typo

### DIFF
--- a/account_invoice_transmit_method/__manifest__.py
+++ b/account_invoice_transmit_method/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Invoice Transmit Method',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.1.0',
     'category': 'Accounting & Finance',
     'license': 'AGPL-3',
     'summary': 'Configure invoice transmit method (email, post, portal, ...)',

--- a/account_invoice_transmit_method/models/partner.py
+++ b/account_invoice_transmit_method/models/partner.py
@@ -11,14 +11,14 @@ class ResPartner(models.Model):
 
     customer_invoice_transmit_method_id = fields.Many2one(
         'transmit.method', string='Customer Invoice Transmission Method',
-        company_dependant=True, track_visibility='onchange',
+        company_dependent=True, track_visibility='onchange',
         domain=[('customer_ok', '=', True)], ondelete='restrict')
     customer_invoice_transmit_method_code = fields.Char(
         related='customer_invoice_transmit_method_id.code',
         string='Customer Invoice Transmission Method Code', readonly=True)
     supplier_invoice_transmit_method_id = fields.Many2one(
         'transmit.method', string='Vendor Invoice Reception Method',
-        company_dependant=True, track_visibility='onchange',
+        company_dependent=True, track_visibility='onchange',
         domain=[('supplier_ok', '=', True)], ondelete='restrict')
     supplier_invoice_transmit_method_code = fields.Char(
         related='supplier_invoice_transmit_method_id.code',


### PR DESCRIPTION
Replace `company_dependant` by `company_dependent`.