### PR TITLE
[10.0][FIX][account_invoice_triple_discount] Fix the discount rounding problem

### DIFF
--- a/account_invoice_triple_discount/__manifest__.py
+++ b/account_invoice_triple_discount/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     'name': 'Account Invoice Triple Discount',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Accounting & Finance',
     'author': 'Tecnativa, '
               'Odoo Community Association (OCA)',

--- a/account_invoice_triple_discount/models/account_invoice.py
+++ b/account_invoice_triple_discount/models/account_invoice.py
@@ -10,23 +10,28 @@ from odoo.addons import decimal_precision as dp
 class AccountInvoice(models.Model):
     _inherit = "account.invoice"
 
+    @api.multi
     def get_taxes_values(self):
-        vals = {}
+        tax_grouped = {}
         for line in self.invoice_line_ids:
-            vals[line] = {
-                'price_unit': line.price_unit,
-                'discount': line.discount,
-            }
             price_unit = line.price_unit * (1 - (line.discount or 0.0) / 100.0)
-            price_unit *= (1 - (line.discount2 or 0.0) / 100.0)
-            price_unit *= (1 - (line.discount3 or 0.0) / 100.0)
-            line.update({
-                'price_unit': price_unit,
-                'discount': 0.0,
-            })
-        tax_grouped = super(AccountInvoice, self).get_taxes_values()
-        for line in self.invoice_line_ids:
-            line.update(vals[line])
+            price_unit *= 1 - (line.discount2 or 0.0) / 100.0
+            price_unit *= 1 - (line.discount3 or 0.0) / 100.0
+            taxes = line.invoice_line_tax_ids.\
+                        compute_all(price_unit, self.currency_id,
+                                    line.quantity, line.product_id,
+                                    self.partner_id)['taxes']
+            for tax in taxes:
+                val = self._prepare_tax_line_vals(line, tax)
+                key = self.env['account.tax'].browse(tax['id']).\
+                    get_grouping_key(val)
+
+                if key not in tax_grouped:
+                    tax_grouped[key] = val
+                else:
+                    tax_grouped[key]['amount'] += val['amount']
+                    tax_grouped[key]['base'] += val['base']
+
         return tax_grouped
 
 
@@ -44,21 +49,36 @@ class AccountInvoiceLine(models.Model):
         default=0.0,
     )
 
-    @api.multi
-    @api.depends('discount2', 'discount3')
+    @api.one
+    @api.depends('price_unit', 'discount', 'invoice_line_tax_ids', 'quantity',
+        'product_id', 'invoice_id.partner_id', 'invoice_id.currency_id',
+        'invoice_id.company_id', 'invoice_id.date_invoice', 'invoice_id.date',
+        'discount2', 'discount3')
     def _compute_price(self):
-        for line in self:
-            prev_price_unit = line.price_unit
-            prev_discount = line.discount
-            price_unit = line.price_unit * (1 - (line.discount or 0.0) / 100.0)
-            price_unit *= (1 - (line.discount2 or 0.0) / 100.0)
-            price_unit *= (1 - (line.discount3 or 0.0) / 100.0)
-            line.update({
-                'price_unit': price_unit,
-                'discount': 0.0,
-            })
-            super(AccountInvoiceLine, line)._compute_price()
-            line.update({
-                'price_unit': prev_price_unit,
-                'discount': prev_discount,
-            })
+        if self.discount2 or self.discount3:
+            currency = self.invoice_id and self.invoice_id.currency_id or None
+            price = self.price_unit * (1 - (self.discount or 0.0) / 100.0)
+            price *= 1 - (self.discount2 or 0.0) / 100.0
+            price *= 1 - (self.discount3 or 0.0) / 100.0
+
+            taxes = False
+            if self.invoice_line_tax_ids:
+                taxes = self.invoice_line_tax_ids.\
+                    compute_all(price, currency, self.quantity,
+                                product=self.product_id,
+                                partner=self.invoice_id.partner_id)
+            self.price_subtotal = \
+                price_subtotal_signed = taxes['total_excluded'] \
+                if taxes else self.quantity * price
+            if self.invoice_id.currency_id and self.invoice_id.company_id and \
+                    self.invoice_id.currency_id != \
+                    self.invoice_id.company_id.currency_id:
+                price_subtotal_signed = self.invoice_id.currency_id.\
+                    with_context(date=self.invoice_id.\
+                                 _get_currency_rate_date()).\
+                                 compute(price_subtotal_signed,
+                                        self.invoice_id.company_id.currency_id)
+            sign = self.invoice_id.type in ['in_refund', 'out_refund'] and -1 or 1
+            self.price_subtotal_signed = price_subtotal_signed * sign
+        else:
+            super(AccountInvoiceLine, self)._compute_price()


### PR DESCRIPTION
After playing with this module I've found some rounding problem compared against odoo standard calculation, so using only one discount. For example using value such as:

quantity = 4
price_unit = 28.5
discount = 35

on standard Odoo this will lead to:
total_amount = 74.10

while instead triple discount wrongly calculate
total_amount = 74.12

so avoid such wrong rounding problems I've avoided to do call the super() and instead replace the method by the Odoo standard including the 2 additional discounts
