### PR TITLE
[10.0] invoice_supplierinfo_update reworked naming on wizard buttons

### DIFF
--- a/account_invoice_supplierinfo_update/__manifest__.py
+++ b/account_invoice_supplierinfo_update/__manifest__.py
@@ -9,7 +9,7 @@
     'summary': 'In the supplier invoice, automatically updates all products '
                'whose unit price on the line is different from '
                'the supplier price',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Accounting & Finance',
     'website': 'http://akretion.com',
     'author':

--- a/account_invoice_supplierinfo_update/i18n/fr.po
+++ b/account_invoice_supplierinfo_update/i18n/fr.po
@@ -9,8 +9,8 @@ msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-11-23 13:51+0000\n"
-"PO-Revision-Date: 2018-11-16 12:20+0000\n"
-"Last-Translator: Pierrick Brun <brun.pierrick@protonmail.com>\n"
+"PO-Revision-Date: 2019-01-15 12:20+0000\n"
+"Last-Translator: Pierrick Brun <pierrick.brun@akretion.com>\n"
 "Language-Team: French (https://www.transifex.com/oca/teams/23907/fr/)\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
@@ -66,13 +66,13 @@ msgstr ""
 #: model:ir.model.fields,field_description:account_invoice_supplierinfo_update.field_wizard_update_invoice_supplierinfo_create_uid
 #: model:ir.model.fields,field_description:account_invoice_supplierinfo_update.field_wizard_update_invoice_supplierinfo_line_create_uid
 msgid "Created by"
-msgstr "Created by"
+msgstr "Créé par"
 
 #. module: account_invoice_supplierinfo_update
 #: model:ir.model.fields,field_description:account_invoice_supplierinfo_update.field_wizard_update_invoice_supplierinfo_create_date
 #: model:ir.model.fields,field_description:account_invoice_supplierinfo_update.field_wizard_update_invoice_supplierinfo_line_create_date
 msgid "Created on"
-msgstr "Created on"
+msgstr "Créé le"
 
 #. module: account_invoice_supplierinfo_update
 #: model:ir.model.fields,field_description:account_invoice_supplierinfo_update.field_wizard_update_invoice_supplierinfo_display_name
@@ -93,8 +93,8 @@ msgstr "ID"
 
 #. module: account_invoice_supplierinfo_update
 #: model:ir.ui.view,arch_db:account_invoice_supplierinfo_update.view_wizard_update_invoice_supplierinfo_form
-msgid "Ignore"
-msgstr "Ignorer"
+msgid "Mark as checked without updating"
+msgstr "Marquer comme vérifié sans mettre à jour"
 
 #. module: account_invoice_supplierinfo_update
 #: model:ir.model,name:account_invoice_supplierinfo_update.model_account_invoice
@@ -109,7 +109,7 @@ msgstr "Ligne de facture"
 #. module: account_invoice_supplierinfo_update
 #: model:ir.model.fields,field_description:account_invoice_supplierinfo_update.field_wizard_update_invoice_supplierinfo_invoice_id
 msgid "Invoice id"
-msgstr "Invoice id"
+msgstr "id de facture"
 
 #. module: account_invoice_supplierinfo_update
 #: model:ir.model.fields,field_description:account_invoice_supplierinfo_update.field_wizard_update_invoice_supplierinfo___last_update
@@ -177,7 +177,7 @@ msgstr "Article"
 #. module: account_invoice_supplierinfo_update
 #: model:ir.model.fields,field_description:account_invoice_supplierinfo_update.field_wizard_update_invoice_supplierinfo_line_state
 msgid "State"
-msgstr "Etat"
+msgstr "État"
 
 #. module: account_invoice_supplierinfo_update
 #: model:ir.model.fields,field_description:account_invoice_supplierinfo_update.field_wizard_update_invoice_supplierinfo_state
@@ -235,8 +235,8 @@ msgstr "Mettre à jour les Informations Fournisseur"
 
 #. module: account_invoice_supplierinfo_update
 #: model:ir.ui.view,arch_db:account_invoice_supplierinfo_update.view_wizard_update_invoice_supplierinfo_form
-msgid "Update and Validate"
-msgstr "Mettre à jour et valider"
+msgid "Update definitively"
+msgstr "Mettre à jour définitivement"
 
 #. module: account_invoice_supplierinfo_update
 #: code:addons/account_invoice_supplierinfo_update/models/account_invoice.py:69
@@ -246,8 +246,8 @@ msgstr "Mettre à jour les informations fournisseurs des produits"
 
 #. module: account_invoice_supplierinfo_update
 #: model:ir.ui.view,arch_db:account_invoice_supplierinfo_update.view_wizard_update_invoice_supplierinfo_form
-msgid "Update without Validating"
-msgstr "Mettre à jour sans valider"
+msgid "Update temporarily"
+msgstr "Mettre à jour temporairement"
 
 #. module: account_invoice_supplierinfo_update
 #: model:ir.model.fields,field_description:account_invoice_supplierinfo_update.field_wizard_update_invoice_supplierinfo_line_wizard_id

--- a/account_invoice_supplierinfo_update/wizard/wizard_update_invoice_supplierinfo.xml
+++ b/account_invoice_supplierinfo_update/wizard/wizard_update_invoice_supplierinfo.xml
@@ -23,20 +23,21 @@
                     </tree>
                 </field>
                 <footer>
-                    <button name="update_supplierinfo"
-                            string="Update without Validating"
-                            type="object"
-                            class="oe_highlight"/>
                     <button name="update_supplierinfo_validate"
-                            string="Update and Validate"
+                            string="Update definitively"
+                            help="The supplierinfo will be updated and the invoice marked as checked (about supplierinfo)"
                             type="object" states="draft,proforma2"
-                            groups="account.group_account_invoice"/>
-                    <button name="set_supplierinfo_ok" string="Ignore" type="object"
-                        confirm="Do you want to set invoice as checked ?" help="This will mark the invoice as checked. It will be possible to uncheck manually in the 'Other Info' tab."/>
-                    or
+                            groups="account.group_account_invoice"
+                            class="oe_highlight"/>
+                    <button name="update_supplierinfo"
+                            string="Update temporarily"
+                            help="The supplierinfo will be updated but the invoice will not be marked as checked (about supplierinfo)"
+                            type="object"/>
+                    <button name="set_supplierinfo_ok" string="Mark as checked without updating" type="object"
+                        confirm="Do you want to set this invoice as checked ? (about its supplierinfo)" help="This will mark the invoice as checked. It will be possible to uncheck manually in the 'Other Info' tab."/>
                     <button string="Cancel" class="oe_link" special="cancel"/>
                 </footer>
             </form>
         </field>
-    </record>    
+    </record>
 </odoo>


### PR DESCRIPTION
The buttons names where confusing, this commit makes it more
understandable.
It is only cosmetic change