### PR TITLE
[FIX]  account_invoice_change_currency: Failing when new invoice

### DIFF
--- a/account_invoice_change_currency/models/account_change_currency.py
+++ b/account_invoice_change_currency/models/account_change_currency.py
@@ -102,6 +102,8 @@ class AccountInvoice(models.Model):
     @api.multi
     def get_last_currency_id(self, skip_update_currency=False):
         self.ensure_one()
+        if not self.id:
+            return self.currency_id
         subtype_id = self.env.ref(
             'account_invoice_change_currency.mt_currency_update')
         subtype_create_id = self.env.ref('account.mt_invoice_created')


### PR DESCRIPTION
created, newid record not consider at onchange and get_last_currency
method.

This is a cherry-pick from https://github.com/OCA/account-invoicing/pull/477