### PR TITLE
[FIX] Convert prices to purchase UOM

### DIFF
--- a/account_invoice_supplierinfo_update/README.rst
+++ b/account_invoice_supplierinfo_update/README.rst
@@ -51,7 +51,6 @@ Known Issues / Roadmap
 
 * This module does not manage correctly difference if
 
-    * invoice line UoM are not the same as Supplierinfo UoM
     * invoice line taxes are not the same as products taxes. (If one is
       marked as tax included in the price and the other is marked as
       tax excluded in the price)
@@ -65,6 +64,7 @@ Contributors
 * Chafique Delli <chafique.delli@akretion.com>
 * Sylvain LE GAL (https://twitter.com/legalsylvain)
 * Mourad EL HADJ MIMOUNE <mourad.elhadj.mimoune@akretion.com>
+* Stefan Rijnhart <stefan@opener.amsterdam>
 
 Maintainer
 ----------

--- a/account_invoice_supplierinfo_update/__manifest__.py
+++ b/account_invoice_supplierinfo_update/__manifest__.py
@@ -9,9 +9,9 @@
     'summary': 'In the supplier invoice, automatically updates all products '
                'whose unit price on the line is different from '
                'the supplier price',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Accounting & Finance',
-    'website': 'http://akretion.com',
+    'website': 'https://github.com/OCA/account-invoicing',
     'author':
         'Akretion,'
         'GRAP,'

--- a/account_invoice_supplierinfo_update/models/account_invoice_line.py
+++ b/account_invoice_supplierinfo_update/models/account_invoice_line.py
@@ -18,19 +18,29 @@ class AccountInvoiceLine(models.Model):
         return supplierinfos and supplierinfos[0] or False
 
     @api.multi
+    def _get_unit_price_in_purchase_uom(self):
+        self.ensure_one()
+        if not self.product_id:
+            return self.price_unit
+        return self.invoice_id.currency_id.round(
+            self.uom_id._compute_price(
+                self.price_unit, self.product_id.uom_po_id))
+
+    @api.multi
     def _is_correct_price(self, supplierinfo):
         """Return True if the partner information matche with line info
             Overload this function in custom module if extra fields
             are added in supplierinfo. (discount for exemple)
         """
         self.ensure_one()
-        return self.price_unit == supplierinfo.price
+        return self._get_unit_price_in_purchase_uom() == supplierinfo.price
 
     @api.multi
     def _prepare_supplier_wizard_line(self, supplierinfo):
         """Prepare the value that will proposed to user in the wizard
         to update supplierinfo"""
         self.ensure_one()
+        price_unit = self._get_unit_price_in_purchase_uom()
         price_variation = False
 
         if not supplierinfo:
@@ -40,14 +50,14 @@ class AccountInvoiceLine(models.Model):
             # Compute price variation
             if supplierinfo.price:
                 price_variation = 100 *\
-                    (self.price_unit - supplierinfo.price) / supplierinfo.price
+                    (price_unit - supplierinfo.price) / supplierinfo.price
             else:
                 price_variation = False
         return {
             'product_id': self.product_id.id,
             'supplierinfo_id': supplierinfo and supplierinfo.id or False,
             'current_price': supplierinfo and supplierinfo.price or False,
-            'new_price': self.price_unit,
+            'new_price': price_unit,
             'current_min_quantity':
                 supplierinfo and supplierinfo.min_qty or False,
             'new_min_quantity':


### PR DESCRIPTION
Convert the invoice' prices to the UOM that is valid for the supplierinfo's
to which they are written. This UOM is the product's purchase order UOM.