### PR TITLE
[11.0][purchase_stock_picking_return_invoicing] - Add compatibility with purchase_force_invoiced of OCA/purchase-workflow

### DIFF
--- a/purchase_stock_picking_return_invoicing/__manifest__.py
+++ b/purchase_stock_picking_return_invoicing/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Purchase Stock Picking Return Invoicing",
     "summary": "Add an option to refund returned pickings",
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.0.1",
     "category": "Purchases",
     "website": "https://github.com/OCA/account-invoicing",
     "author": "Eficent,"

--- a/purchase_stock_picking_return_invoicing/models/purchase_order.py
+++ b/purchase_stock_picking_return_invoicing/models/purchase_order.py
@@ -26,6 +26,12 @@ class PurchaseOrder(models.Model):
             'Product Unit of Measure'
         )
         for order in self.filtered(lambda x: x.state in ('purchase', 'done')):
+            # the field 'force_invoiced' is defined in the
+            # 'purchase_force_invoiced' module of OCA/purchase-workflow.
+            if getattr(order, 'force_invoiced', None) and \
+                    order.force_invoiced and \
+                    order.invoice_status == 'invoiced':
+                continue
             if any(
                 float_compare(
                     line.qty_invoiced, line.product_qty


### PR DESCRIPTION
This PR intends to force the purchase invoice status to = 'Nothing to bill' when the status has been forced in module purchase_force_invoiced. See https://github.com/OCA/purchase-workflow/pull/642