### PR TITLE
[10.0][FIX] account_invoice_triple_discount: Fix rounding

### DIFF
--- a/account_invoice_triple_discount/__manifest__.py
+++ b/account_invoice_triple_discount/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     'name': 'Account Invoice Triple Discount',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Accounting & Finance',
     'author': 'Tecnativa, '
               'Odoo Community Association (OCA)',

--- a/account_invoice_triple_discount/models/account_invoice.py
+++ b/account_invoice_triple_discount/models/account_invoice.py
@@ -11,22 +11,10 @@ class AccountInvoice(models.Model):
     _inherit = "account.invoice"
 
     def get_taxes_values(self):
-        vals = {}
-        for line in self.invoice_line_ids:
-            vals[line] = {
-                'price_unit': line.price_unit,
-                'discount': line.discount,
-            }
-            price_unit = line.price_unit * (1 - (line.discount or 0.0) / 100.0)
-            price_unit *= (1 - (line.discount2 or 0.0) / 100.0)
-            price_unit *= (1 - (line.discount3 or 0.0) / 100.0)
-            line.update({
-                'price_unit': price_unit,
-                'discount': 0.0,
-            })
+        prev_values = self.invoice_line_ids.triple_discount_preprocess()
         tax_grouped = super(AccountInvoice, self).get_taxes_values()
-        for line in self.invoice_line_ids:
-            line.update(vals[line])
+        self.env['account.invoice.line'].triple_discount_postprocess(
+            prev_values)
         return tax_grouped
 
 
@@ -47,18 +35,48 @@ class AccountInvoiceLine(models.Model):
     @api.multi
     @api.depends('discount2', 'discount3')
     def _compute_price(self):
+        prev_values = self.triple_discount_preprocess()
+        super(AccountInvoiceLine, self)._compute_price()
+        self.triple_discount_postprocess(prev_values)
+
+    def _get_triple_discount(self):
+        """Get the discount that is equivalent to the subsequent application
+        of discount, discount2 and discount3"""
+        discount_factor = 1.0
+        for discount in [self.discount, self.discount2, self.discount3]:
+            discount_factor *= (100.0 - discount) / 100.0
+        return 100.0 - (discount_factor * 100.0)
+
+    @api.multi
+    def triple_discount_preprocess(self):
+        """Save the values of the discounts in a dictionary,
+        to be restored in postprocess.
+        Resetting discount2 and discount3 to 0.0 avoids issues if
+        this method is called multiple times.
+        Updating the cache provides consistency through recomputations."""
+        prev_values = dict()
+        self.invalidate_cache(
+            fnames=['discount', 'discount2', 'discount3'],
+            ids=self.ids)
         for line in self:
-            prev_price_unit = line.price_unit
-            prev_discount = line.discount
-            price_unit = line.price_unit * (1 - (line.discount or 0.0) / 100.0)
-            price_unit *= (1 - (line.discount2 or 0.0) / 100.0)
-            price_unit *= (1 - (line.discount3 or 0.0) / 100.0)
-            line.update({
-                'price_unit': price_unit,
-                'discount': 0.0,
+            prev_values[line] = dict(
+                discount=line.discount,
+                discount2=line.discount2,
+                discount3=line.discount3,
+            )
+            line._cache.update({
+                'discount': line._get_triple_discount(),
+                'discount2': 0.0,
+                'discount3': 0.0
             })
-            super(AccountInvoiceLine, line)._compute_price()
-            line.update({
-                'price_unit': prev_price_unit,
-                'discount': prev_discount,
-            })
+        return prev_values
+
+    @api.model
+    def triple_discount_postprocess(self, prev_values):
+        """Restore the discounts of the lines in the dictionary prev_values.
+        Updating the cache provides consistency through recomputations."""
+        self.invalidate_cache(
+            fnames=['discount', 'discount2', 'discount3'],
+            ids=[l.id for l in prev_values.keys()])
+        for line, prev_vals_dict in prev_values.items():
+            line._cache.update(prev_vals_dict)

--- a/account_invoice_triple_discount/models/account_invoice.py
+++ b/account_invoice_triple_discount/models/account_invoice.py
@@ -52,19 +52,15 @@ class AccountInvoiceLine(models.Model):
         """Save the values of the discounts in a dictionary,
         to be restored in postprocess.
         Resetting discount2 and discount3 to 0.0 avoids issues if
-        this method is called multiple times.
-        Updating the cache provides consistency through recomputations."""
+        this method is called multiple times."""
         prev_values = dict()
-        self.invalidate_cache(
-            fnames=['discount', 'discount2', 'discount3'],
-            ids=self.ids)
         for line in self:
             prev_values[line] = dict(
                 discount=line.discount,
                 discount2=line.discount2,
                 discount3=line.discount3,
             )
-            line._cache.update({
+            line.update({
                 'discount': line._get_triple_discount(),
                 'discount2': 0.0,
                 'discount3': 0.0
@@ -73,10 +69,6 @@ class AccountInvoiceLine(models.Model):
 
     @api.model
     def triple_discount_postprocess(self, prev_values):
-        """Restore the discounts of the lines in the dictionary prev_values.
-        Updating the cache provides consistency through recomputations."""
-        self.invalidate_cache(
-            fnames=['discount', 'discount2', 'discount3'],
-            ids=[l.id for l in prev_values.keys()])
+        """Restore the discounts of the lines in the dictionary prev_values."""
         for line, prev_vals_dict in prev_values.items():
-            line._cache.update(prev_vals_dict)
+            line.update(prev_vals_dict)


### PR DESCRIPTION
The fix is pretty much the same applied in https://github.com/OCA/sale-workflow/pull/768.
This is to fix the behavior described in the unit test:
Use case of an invoice line having:

-  price_unit = 15.2,
-  qty = 131.04
-  discount = 50
-  discount2 = 0
-  discount3 = 3

The result should be the same as applying only one discount of 51.5