### PR TITLE
[FIX][8.0] account_invoice_pricelist fail with fiscal position Incl -> Excl

### DIFF
--- a/account_invoice_pricelist/model/account_invoice.py
+++ b/account_invoice_pricelist/model/account_invoice.py
@@ -17,8 +17,7 @@ class AccountInvoice(models.Model):
 
     @api.multi
     def onchange_partner_id(
-            self, type, partner_id, date_invoice=False,
-            payment_term=False,
+            self, type, partner_id, date_invoice=False, payment_term=False,
             partner_bank_id=False, company_id=False):
         partner_obj = self.env['res.partner']
         res = super(AccountInvoice, self).onchange_partner_id(

--- a/account_invoice_pricelist/model/account_invoice.py
+++ b/account_invoice_pricelist/model/account_invoice.py
@@ -17,7 +17,8 @@ class AccountInvoice(models.Model):
 
     @api.multi
     def onchange_partner_id(
-            self, type, partner_id, date_invoice=False, payment_term=False,
+            self, type, partner_id, date_invoice=False,
+            payment_term=False,
             partner_bank_id=False, company_id=False):
         partner_obj = self.env['res.partner']
         res = super(AccountInvoice, self).onchange_partner_id(


### PR DESCRIPTION
This PR fixes incompatibility between account_invoice_pricelist and fiscal_position, in the case when fiscal position map taxes from TAX incl to Tax Excl. (B2B fiscal position in a B2C context).

**Scenario**
- Product : price 12€ vat Incl, (VAT 20%). (So 10€ Vat Excl)
- Pricelist : discount of 10%. (sale price * 0.9)
- Fiscal position that map Tax 20% Incl --> Tax 20% Excl

**Current Result**
- Saling the product, the result is 10.8 € Vat Excl. (compute : 12€ - 10%) that is wrong

**Expected Result**
- saling the product, the result should be 9€ Vat Excl.
    - Pricelist process : 12,00€ Incl --> 10,80 € Incl  ( x 0.9)
    - Fiscal Position Process : 10,80 € Incl --> 9€ Excl ( / (1 + 0,2))

**Origin**
In the core, the function `product_id_change` call a function `_fix_tax_included_price` that fix the unit price with such fiscal position. 
This module overwrite product_id_change, and doesn't call this function. _fix_tax_included_price