### PR TITLE
[FIX][account_invoice_force_number] make journal writable in draft mode when we force a number

### DIFF
--- a/account_invoice_force_number/invoice_view.xml
+++ b/account_invoice_force_number/invoice_view.xml
@@ -14,6 +14,9 @@
                     <attribute name="invisible">0</attribute>
                     <attribute name="groups">account_invoice_force_number.group_allow_invoice_force_number</attribute>
                 </field>
+                <field name="journal_id" position="attributes">
+                    <attribute name="attrs">{'readonly': [('state', '!=', 'draft'), ('internal_number', '!=', False)]}</attribute>
+                </field>
             </field>
         </record>
 
@@ -28,6 +31,9 @@
                     <attribute name="help">Force invoice number. Use this field if you don't want to use the default numbering</attribute>
                     <attribute name="invisible">0</attribute>
                     <attribute name="groups">account_invoice_force_number.group_allow_invoice_force_number</attribute>
+                </field>
+                <field name="journal_id" position="attributes">
+                    <attribute name="attrs">{'readonly': [('state', '!=', 'draft'), ('internal_number', '!=', False)]}</attribute>
                 </field>
             </field>
         </record>


### PR DESCRIPTION
without this, creating an invoice with a forced number and customized journal will yield the default journal, as Odoo doesn't write readonly fields