### PR TITLE
[12.0] Add module sale_invoice_line_note

### DIFF
--- a/sale_invoice_line_note/__init__.py
+++ b/sale_invoice_line_note/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizard

--- a/sale_invoice_line_note/__manifest__.py
+++ b/sale_invoice_line_note/__manifest__.py
@@ -1,0 +1,19 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+{
+    "name": "Sale invoice line note",
+    "summary": "Propagate sale order note lines to the invoice",
+    "version": "12.0.1.0.0",
+    "category": "Sales",
+    "website": "https://github.com/OCA/account-invoicing",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": [
+        "sale",
+    ],
+    "data": [
+        "wizard/sale_make_invoice_advance.xml",
+    ],
+}

--- a/sale_invoice_line_note/models/__init__.py
+++ b/sale_invoice_line_note/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order

--- a/sale_invoice_line_note/models/sale_order.py
+++ b/sale_invoice_line_note/models/sale_order.py
@@ -1,0 +1,38 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import models, api
+
+
+class SaleOrder(models.Model):
+
+    _inherit = 'sale.order'
+
+    @api.multi
+    def action_invoice_create(self, grouped=False, final=False):
+        """Create invoice note lines with notes from the sale order"""
+        invoice_ids = super().action_invoice_create(
+            grouped=grouped, final=final
+        )
+        if self.env.context.get('_copy_notes'):
+            note_lines_vals = []
+            for sale_order in self:
+                invoice = sale_order.invoice_ids.filtered(
+                    lambda i: i.id in invoice_ids
+                )
+                if not invoice:
+                    # The sale order did not generate an invoice
+                    continue
+                notes_to_create = sale_order.order_line.filtered(
+                    lambda l: l.display_type == 'line_note'
+                )
+                for note in notes_to_create:
+                    note_vals = {
+                        'origin': sale_order.name,
+                        'invoice_id': invoice.id,
+                        'sequence': note.sequence,
+                        'display_type': 'line_note',
+                        'name': note.name
+                    }
+                    note_lines_vals.append(note_vals)
+            self.env['account.invoice.line'].create(note_lines_vals)
+        return invoice_ids

--- a/sale_invoice_line_note/readme/CONTRIBUTORS.rst
+++ b/sale_invoice_line_note/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Akim Juillerat <akim.juillerat@camptocamp.com>

--- a/sale_invoice_line_note/readme/DESCRIPTION.rst
+++ b/sale_invoice_line_note/readme/DESCRIPTION.rst
@@ -1,0 +1,3 @@
+This module adds a checkbox 'Copy notes to invoice' in the create invoice
+wizard from the sale order, to propagate sale order line of 'Note' type to the
+created invoice.

--- a/sale_invoice_line_note/readme/ROADMAP.rst
+++ b/sale_invoice_line_note/readme/ROADMAP.rst
@@ -1,0 +1,1 @@
+* Implement propagation of notes for downpayment methods

--- a/sale_invoice_line_note/tests/__init__.py
+++ b/sale_invoice_line_note/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_sale_invoice_line_note

--- a/sale_invoice_line_note/tests/test_sale_invoice_line_note.py
+++ b/sale_invoice_line_note/tests/test_sale_invoice_line_note.py
@@ -1,0 +1,45 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo.tests import SavepointCase
+
+
+class TestSaleInvoiceLineNote(SavepointCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.sale_order = cls.env['sale.order'].create({
+            'partner_id': cls.env.ref('base.res_partner_12').id,
+        })
+        product = cls.env.ref('product.product_product_1')
+        product.invoice_policy = 'order'
+        cls.env['sale.order.line'].create([{
+            'order_id': cls.sale_order.id,
+            'product_id': product.id,
+            'name': product.name,
+            'price_unit': 1.0,
+            'product_uom_qty': 1.0,
+        }, {
+            'order_id': cls.sale_order.id,
+            'display_type': 'line_note',
+            'name': 'Test sale order line note',
+            'sequence': 12,
+        }])
+        cls.sale_order.action_confirm()
+
+    def test_sale_note_to_invoice(self):
+        wizard = self.env['sale.advance.payment.inv'].with_context(
+            active_ids=self.sale_order.ids).create({
+                'advance_payment_method': 'all',
+            })
+        self.assertTrue(wizard.copy_notes_to_invoice)
+        wizard.create_invoices()
+        invoice = self.sale_order.invoice_ids
+        self.assertEqual(
+            len(self.sale_order.order_line), len(invoice.invoice_line_ids)
+        )
+        invoice_line_note = invoice.invoice_line_ids.filtered(
+            lambda l: l.display_type == 'line_note'
+        )
+        self.assertEqual(invoice_line_note.name, 'Test sale order line note')
+        self.assertEqual(invoice_line_note.sequence, 12)

--- a/sale_invoice_line_note/tests/test_sale_invoice_line_note.py
+++ b/sale_invoice_line_note/tests/test_sale_invoice_line_note.py
@@ -43,3 +43,16 @@ class TestSaleInvoiceLineNote(SavepointCase):
         )
         self.assertEqual(invoice_line_note.name, 'Test sale order line note')
         self.assertEqual(invoice_line_note.sequence, 12)
+
+    def test_sale_note_no_copy(self):
+        wizard = self.env['sale.advance.payment.inv'].with_context(
+            active_ids=self.sale_order.ids).create({
+            'advance_payment_method': 'all',
+        })
+        wizard.copy_notes_to_invoice = False
+        wizard.create_invoices()
+        invoice = self.sale_order.invoice_ids
+        invoice_line_note = invoice.invoice_line_ids.filtered(
+            lambda l: l.display_type == 'line_note'
+        )
+        self.assertFalse(invoice_line_note)

--- a/sale_invoice_line_note/tests/test_sale_invoice_line_note.py
+++ b/sale_invoice_line_note/tests/test_sale_invoice_line_note.py
@@ -47,8 +47,8 @@ class TestSaleInvoiceLineNote(SavepointCase):
     def test_sale_note_no_copy(self):
         wizard = self.env['sale.advance.payment.inv'].with_context(
             active_ids=self.sale_order.ids).create({
-            'advance_payment_method': 'all',
-        })
+                'advance_payment_method': 'all',
+            })
         wizard.copy_notes_to_invoice = False
         wizard.create_invoices()
         invoice = self.sale_order.invoice_ids

--- a/sale_invoice_line_note/wizard/__init__.py
+++ b/sale_invoice_line_note/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_make_invoice_advance

--- a/sale_invoice_line_note/wizard/sale_make_invoice_advance.py
+++ b/sale_invoice_line_note/wizard/sale_make_invoice_advance.py
@@ -17,6 +17,5 @@ class SaleAdvancePaymentInv(models.TransientModel):
     @api.multi
     def create_invoices(self):
         if self.copy_notes_to_invoice:
-            return super(SaleAdvancePaymentInv, self.with_context(
-                _copy_notes=True)).create_invoices()
+            self = self.with_context(_copy_notes=True)
         return super().create_invoices()

--- a/sale_invoice_line_note/wizard/sale_make_invoice_advance.py
+++ b/sale_invoice_line_note/wizard/sale_make_invoice_advance.py
@@ -1,0 +1,22 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import models, fields, api
+
+
+class SaleAdvancePaymentInv(models.TransientModel):
+
+    _inherit = "sale.advance.payment.inv"
+
+    copy_notes_to_invoice = fields.Boolean(
+        default=True,
+        string="Copy notes to invoice",
+        help="Mark this to create invoice line notes from the notes in the "
+             "sale order",
+    )
+
+    @api.multi
+    def create_invoices(self):
+        if self.copy_notes_to_invoice:
+            return super(SaleAdvancePaymentInv, self.with_context(
+                _copy_notes=True)).create_invoices()
+        return super().create_invoices()

--- a/sale_invoice_line_note/wizard/sale_make_invoice_advance.xml
+++ b/sale_invoice_line_note/wizard/sale_make_invoice_advance.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_sale_advance_payment_inv_inherit" model="ir.ui.view">
+        <field name="name">Invoice Orders inherit</field>
+        <field name="model">sale.advance.payment.inv</field>
+        <field name="inherit_id" ref="sale.view_sale_advance_payment_inv" />
+        <field name="arch" type="xml">
+            <xpath expr="//group" position="inside">
+                <field name="copy_notes_to_invoice" attrs="{'invisible': [('advance_payment_method', 'in', ('fixed', 'percentage'))]}" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This module adds a checkbox 'Copy notes to invoice' in the create invoice
wizard from the sale order, to propagate sale order line of 'Note' type to the
created invoice.