### PR TITLE
[10.0] [ADD] account_invoice_split_refund

### DIFF
--- a/account_invoice_split_refund/__init__.py
+++ b/account_invoice_split_refund/__init__.py
@@ -1,0 +1,1 @@
+from . import wizard

--- a/account_invoice_split_refund/__manifest__.py
+++ b/account_invoice_split_refund/__manifest__.py
@@ -1,0 +1,16 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+{
+    "name": "Account Invoice Split Refund",
+    "summary": "Split invoices and refunds from the sale order",
+    "version": "10.0.1.0.0",
+    "category": "Sale",
+    "website": "https://github.com/OCA/account-invoice",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": [
+        "sale_stock",
+    ],
+}

--- a/account_invoice_split_refund/readme/CONTRIBUTORS.rst
+++ b/account_invoice_split_refund/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Akim Juillerat <akim.juillerat@camptocamp.com>

--- a/account_invoice_split_refund/readme/DESCRIPTION.rst
+++ b/account_invoice_split_refund/readme/DESCRIPTION.rst
@@ -1,0 +1,3 @@
+This module adds a new "Advance Payment Method" to "Sales Advance Payment Invoice"
+wizard in order to split invoices and refunds, and not have any line with a negative
+quantity on the invoice or the refund.

--- a/account_invoice_split_refund/tests/__init__.py
+++ b/account_invoice_split_refund/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_invoice_split_refunds

--- a/account_invoice_split_refund/tests/test_invoice_split_refunds.py
+++ b/account_invoice_split_refund/tests/test_invoice_split_refunds.py
@@ -1,0 +1,102 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from datetime import datetime
+
+from odoo.addons.sale.tests.test_sale_common import TestSale
+
+
+class TestInvoiceSplitRefunds(TestSale):
+
+    def setUp(self):
+        super(TestInvoiceSplitRefunds, self).setUp()
+
+        receivable_acc = self.env['account.account'].search(
+            [('internal_type', '=', 'receivable')],
+            limit=1
+        )
+        customer = self.env['res.partner'].create({
+            'name': 'Customer',
+            'email': 'customer@example.com',
+            'property_account_receivable_id': receivable_acc.id,
+        })
+
+        self.delivery_product = self.env.ref('product.product_delivery_01')
+
+        self.sale_order = self.env['sale.order'].create({
+            'partner_id': customer.id,
+            'pricelist_id': self.env.ref('product.list0').id,
+        })
+        self.sale_order_line = self.env['sale.order.line'].create({
+            'order_id': self.sale_order.id,
+            'name': self.delivery_product.name,
+            'product_id': self.delivery_product.id,
+            'product_uom_qty': 5,
+            'product_uom': self.delivery_product.uom_id.id,
+            'price_unit': self.delivery_product.list_price
+        })
+        self.sale_order.action_confirm()
+        # import pdb; pdb.set_trace()
+        delivery_picking = self.sale_order.picking_ids
+        delivery_picking.force_assign()
+        delivery_picking.pack_operation_product_ids.write({'qty_done': 5})
+        delivery_picking.do_new_transfer()
+        # wiz = self.env[wiz_act['res_model']].browse(wiz_act['res_id'])
+        # wiz.process()
+        invoice_id = self.sale_order.action_invoice_create()
+        self.invoice = self.env['account.invoice'].browse(invoice_id)
+        self.invoice.action_invoice_open()
+
+        return_wiz = self.env['stock.return.picking'].with_context(
+            active_ids=delivery_picking.ids, active_id=delivery_picking.id
+        ).create({})
+        return_wiz.product_return_moves.write({
+            'quantity': 2,
+            'to_refund_so': True
+        })
+        return_id = return_wiz.create_returns()['res_id']
+        return_picking = self.env['stock.picking'].browse(return_id)
+        return_picking.force_assign()
+        return_picking.pack_operation_product_ids.write({'qty_done': 2})
+        return_picking.do_new_transfer()
+
+    def test_account_invoice_split_refunds(self):
+
+        self.assertEqual(self.sale_order_line.qty_delivered, 3)
+        self.assertEqual(self.sale_order_line.qty_invoiced, 5)
+
+        service_product = self.env.ref('product.service_order_01')
+
+        sale_order_line_2 = self.env['sale.order.line'].create({
+            'order_id': self.sale_order.id,
+            'name': service_product.name,
+            'product_id': service_product.id,
+            'product_uom_qty': 5,
+            'product_uom': service_product.uom_id.id,
+            'price_unit': service_product.list_price
+        })
+        self.assertEqual(sale_order_line_2.qty_invoiced, 0)
+        self.assertEqual(sale_order_line_2.qty_to_invoice, 5)
+        create_invoice_wiz = self.env['sale.advance.payment.inv'].with_context(
+            active_ids=self.sale_order.ids, active_id=self.sale_order.id
+        ).create({})
+        self.assertEqual(
+            create_invoice_wiz.advance_payment_method, 'all_split'
+        )
+        create_invoice_wiz.create_invoices()
+        self.assertEqual(len(self.sale_order.invoice_ids), 3)
+
+        new_refund = self.sale_order.invoice_ids.filtered(
+            lambda i: i.type == 'out_refund')
+        new_invoice = self.sale_order.invoice_ids - new_refund - self.invoice
+
+        self.assertEqual(
+            new_refund.invoice_line_ids.product_id, self.delivery_product
+        )
+        # As we invoiced 5 and returned 2, we must refund 2
+        self.assertEqual(new_refund.invoice_line_ids.quantity, 2)
+        self.assertEqual(
+            new_invoice.invoice_line_ids.product_id, service_product
+        )
+
+        self.assertEqual(new_refund.invoice_line_ids.quantity, 5)
+

--- a/account_invoice_split_refund/tests/test_invoice_split_refunds.py
+++ b/account_invoice_split_refund/tests/test_invoice_split_refunds.py
@@ -72,7 +72,7 @@ class TestInvoiceSplitRefunds(TestSale):
             'price_unit': service_product.list_price
         })
         self.assertEqual(sale_order_line_2.qty_invoiced, 0)
-        self.assertEqual(sale_order_line_2.qty_to_invoice, 5)
+        self.assertEqual(sale_order_line_2.qty_to_invoice, 6)
         create_invoice_wiz = self.env['sale.advance.payment.inv'].with_context(
             active_ids=self.sale_order.ids, active_id=self.sale_order.id
         ).create({})

--- a/account_invoice_split_refund/tests/test_invoice_split_refunds.py
+++ b/account_invoice_split_refund/tests/test_invoice_split_refunds.py
@@ -1,7 +1,5 @@
 # Copyright 2019 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
-from datetime import datetime
-
 from odoo.addons.sale.tests.test_sale_common import TestSale
 
 
@@ -35,13 +33,12 @@ class TestInvoiceSplitRefunds(TestSale):
             'price_unit': self.delivery_product.list_price
         })
         self.sale_order.action_confirm()
-        # import pdb; pdb.set_trace()
+
         delivery_picking = self.sale_order.picking_ids
         delivery_picking.force_assign()
         delivery_picking.pack_operation_product_ids.write({'qty_done': 5})
         delivery_picking.do_new_transfer()
-        # wiz = self.env[wiz_act['res_model']].browse(wiz_act['res_id'])
-        # wiz.process()
+
         invoice_id = self.sale_order.action_invoice_create()
         self.invoice = self.env['account.invoice'].browse(invoice_id)
         self.invoice.action_invoice_open()
@@ -70,7 +67,7 @@ class TestInvoiceSplitRefunds(TestSale):
             'order_id': self.sale_order.id,
             'name': service_product.name,
             'product_id': service_product.id,
-            'product_uom_qty': 5,
+            'product_uom_qty': 6,
             'product_uom': service_product.uom_id.id,
             'price_unit': service_product.list_price
         })
@@ -98,5 +95,4 @@ class TestInvoiceSplitRefunds(TestSale):
             new_invoice.invoice_line_ids.product_id, service_product
         )
 
-        self.assertEqual(new_refund.invoice_line_ids.quantity, 5)
-
+        self.assertEqual(new_invoice.invoice_line_ids.quantity, 6)

--- a/account_invoice_split_refund/wizard/__init__.py
+++ b/account_invoice_split_refund/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_make_invoice_advance

--- a/account_invoice_split_refund/wizard/sale_make_invoice_advance.py
+++ b/account_invoice_split_refund/wizard/sale_make_invoice_advance.py
@@ -27,8 +27,10 @@ class SaleAdvancePaymentInv(models.TransientModel):
             self._context.get('active_ids', []))
         # Create all the invoices first
         sale_orders.action_invoice_create()
+        still_to_invoice = sum(sale_orders.mapped('order_line.qty_to_invoice'))
+        if still_to_invoice:
         # Create any refund afterwards
-        sale_orders.action_invoice_create(final=True)
+            sale_orders.action_invoice_create(final=True)
         # Open invoices or close the wizard according to context key
         if self._context.get('open_invoices', False):
             return sale_orders.action_view_invoice()

--- a/account_invoice_split_refund/wizard/sale_make_invoice_advance.py
+++ b/account_invoice_split_refund/wizard/sale_make_invoice_advance.py
@@ -30,7 +30,7 @@ class SaleAdvancePaymentInv(models.TransientModel):
         to_refund = bool(filter(lambda qty: qty < 0, qties_to_invoice))
         # Create all the invoices
         if to_invoice:
-            sale_orders.action_invoice_create()
+            sale_orders.action_invoice_create(final=False)
         # Create all the refunds
         if to_refund:
             sale_orders.action_invoice_create(final=True)

--- a/account_invoice_split_refund/wizard/sale_make_invoice_advance.py
+++ b/account_invoice_split_refund/wizard/sale_make_invoice_advance.py
@@ -1,0 +1,35 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import models, fields, api
+
+
+class SaleAdvancePaymentInv(models.TransientModel):
+
+    _inherit = "sale.advance.payment.inv"
+
+    advance_payment_method = fields.Selection(
+        selection_add=[
+            ('all_split', 'Invoiceable lines (Split refunds from invoices)')
+        ],
+        default=lambda self: self._get_advance_payment_method(),
+    )
+
+    @api.model
+    def _get_advance_payment_method(self):
+        """Force splitting refunds from invoices as default method"""
+        return 'all_split'
+
+    @api.multi
+    def create_invoices(self):
+        if self.advance_payment_method != 'all_split':
+            return super(SaleAdvancePaymentInv, self).create_invoices()
+        sale_orders = self.env['sale.order'].browse(
+            self._context.get('active_ids', []))
+        # Create all the invoices first
+        sale_orders.action_invoice_create()
+        # Create any refund afterwards
+        sale_orders.action_invoice_create(final=True)
+        # Open invoices or close the wizard according to context key
+        if self._context.get('open_invoices', False):
+            return sale_orders.action_view_invoice()
+        return {'type': 'ir.actions.act_window_close'}

--- a/account_invoice_split_refund/wizard/sale_make_invoice_advance.py
+++ b/account_invoice_split_refund/wizard/sale_make_invoice_advance.py
@@ -27,9 +27,9 @@ class SaleAdvancePaymentInv(models.TransientModel):
             self._context.get('active_ids', []))
         # Create all the invoices first
         sale_orders.action_invoice_create()
-        still_to_invoice = sum(sale_orders.mapped('order_line.qty_to_invoice'))
+        still_to_invoice = any(sale_orders.mapped('order_line.qty_to_invoice'))
         if still_to_invoice:
-        # Create any refund afterwards
+            # Create any refund afterwards
             sale_orders.action_invoice_create(final=True)
         # Open invoices or close the wizard according to context key
         if self._context.get('open_invoices', False):


### PR DESCRIPTION
This module adds a new "Advance Payment Method" to "Sales Advance Payment Invoice"
wizard in order to split invoices and refunds, and not have any line with a negative
quantity on the invoice or the refund.
