### PR TITLE
[12.0] account_invoice_transmit_method: use base_view_inheritance_extension

### DIFF
--- a/account_invoice_transmit_method/__manifest__.py
+++ b/account_invoice_transmit_method/__manifest__.py
@@ -9,7 +9,7 @@
     'summary': 'Configure invoice transmit method (email, post, portal, ...)',
     'author': 'Akretion, Odoo Community Association (OCA)',
     'website': 'https://github.com/OCA/account-invoicing',
-    'depends': ['account'],
+    'depends': ['account', 'base_view_inheritance_extension'],
     'data': [
         'security/ir.model.access.csv',
         'views/transmit_method.xml',

--- a/account_invoice_transmit_method/views/partner.xml
+++ b/account_invoice_transmit_method/views/partner.xml
@@ -39,7 +39,8 @@ for all users -->
             <field name="supplier_invoice_transmit_method_code" invisible="1"/>
         </xpath>
         <field name="child_ids" position="attributes">
-            <attribute name="context">{'default_parent_id': active_id, 'default_street': street, 'default_street2': street2, 'default_city': city, 'default_state_id': state_id, 'default_zip': zip, 'default_country_id': country_id, 'default_supplier': supplier, 'default_customer': customer, 'default_lang': lang, 'default_customer_invoice_transmit_method_code': customer_invoice_transmit_method_code, 'default_supplier_invoice_transmit_method_code': supplier_invoice_transmit_method_code}</attribute>
+            <attribute name="context" operation="python_dict" key="default_customer_invoice_transmit_method_code">customer_invoice_transmit_method_code</attribute>
+            <attribute name="context" operation="python_dict" key="default_supplier_invoice_transmit_method_code">supplier_invoice_transmit_method_code</attribute>
         </field>
     </field>
 </record>

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -6,4 +6,4 @@ brand
 server-backend
 stock-logistics-workflow
 web
-
+server-tools


### PR DESCRIPTION
Same PR as https://github.com/OCA/account-invoicing/pull/440/files

Seems the module base_view_inheritance_extension hasn't been ported to v12 yet ; I use the module for v11 which works without change for v12.