### PR TITLE
[11.0][FIX] purchase_stock_picking_return_invoicing: Trigger returned qty computation on move qty change

### DIFF
--- a/purchase_stock_picking_return_invoicing/models/purchase_order.py
+++ b/purchase_stock_picking_return_invoicing/models/purchase_order.py
@@ -139,6 +139,7 @@ class PurchaseOrderLine(models.Model):
     @api.depends(
         'move_ids.state',
         'move_ids.returned_move_ids.state',
+        'move_ids.product_uom_qty',
     )
     def _compute_qty_returned(self):
         """Made through read_group for not impacting in performance."""


### PR DESCRIPTION
Steps to reproduce:

- Create a PO with stockable product.
- Deliver it.
- Return that product.
- Returned qty is set to the product qty.
- Now unlock the returned picking and changed qty to for example 0.
- Returned qty on PO is still the previous one, while it should be 0.

cc @Tecnativa