### PR TITLE
[12.0][FIX] No taxes defined! warning in notes or/and section

### DIFF
--- a/account_invoice_tax_required/models/account_invoice.py
+++ b/account_invoice_tax_required/models/account_invoice.py
@@ -15,7 +15,8 @@ class AccountInvoice(models.Model):
     def _test_invoice_line_tax(self):
         errors = []
         error_template = _("Invoice has a line with product %s with no taxes")
-        for invoice_line in self.mapped('invoice_line_ids'):
+        for invoice_line in self.mapped('invoice_line_ids').filtered(
+            lambda x: x.display_type is False):
             if not invoice_line.invoice_line_tax_ids:
                 error_string = error_template % (invoice_line.name)
                 errors.append(error_string)

--- a/account_invoice_tax_required/models/account_invoice.py
+++ b/account_invoice_tax_required/models/account_invoice.py
@@ -16,7 +16,7 @@ class AccountInvoice(models.Model):
         errors = []
         error_template = _("Invoice has a line with product %s with no taxes")
         for invoice_line in self.mapped('invoice_line_ids').filtered(
-            lambda x: x.display_type is False):
+                lambda x: not x.display_type):
             if not invoice_line.invoice_line_tax_ids:
                 error_string = error_template % (invoice_line.name)
                 errors.append(error_string)

--- a/account_invoice_tax_required/readme/CONTRIBUTORS.rst
+++ b/account_invoice_tax_required/readme/CONTRIBUTORS.rst
@@ -3,3 +3,4 @@
 * Kitti U. <kittiu@ecosoft.co.th>
 * Jorge Camacho <jcamacho@trey.es>
 * Nikul Chaudhary <nikulchaudhary2112@gmail.com>
+* Juan Vicente Pascual <jvpascual@puntsistemes.es>


### PR DESCRIPTION
Create a quotation with sections or/and notes, confirm it and invoice it.
Then if module account_invoice_tax_required is installed, you get:
No taxes defined! warning in the section or not line.

The expected behavior should be to skip section lines and note line.

Thanks.