### PR TITLE
[12.0][FIX] *: reference_type doesn't exist anymore

### DIFF
--- a/account_invoice_fiscal_position_update/tests/test_inv_fiscal_pos_update.py
+++ b/account_invoice_fiscal_position_update/tests/test_inv_fiscal_pos_update.py
@@ -87,7 +87,6 @@ class TestProductIdChange(AccountingTestCase):
 
         out_invoice = self.invoice_model.create({
             'partner_id': partner.id,
-            'reference_type': 'none',
             'name': 'invoice to client',
             'account_id': self.account_receivable.id,
             'type': 'out_invoice',

--- a/account_invoice_tax_required/tests/test_account_invoice_tax_required.py
+++ b/account_invoice_tax_required/tests/test_account_invoice_tax_required.py
@@ -55,7 +55,6 @@ class TestAccountInvoiceTaxRequired(TransactionCase):
 
         self.invoice = self.account_invoice.create(dict(
             name="Test Customer Invoice",
-            reference_type="none",
             journal_id=self.journal.id,
             partner_id=self.partner.id,
             account_id=self.account_rec1_id.id,


### PR DESCRIPTION
This field was moved to `res.company` as `invoice_reference_type`.