### PR TITLE
12.0 [FIX] the sequential line was not visible

### DIFF
--- a/account_payment_term_extension/views/account_payment_term.xml
+++ b/account_payment_term_extension/views/account_payment_term.xml
@@ -17,7 +17,7 @@
         <field name="model">account.payment.term</field>
         <field name="inherit_id" ref="account.view_payment_term_form"/>
         <field name="arch" type="xml">
-            <field name="active" position="after">
+            <field name="name" position="after">
                 <field name="sequential_lines"/>
             </field>
             <field name="line_ids" position="after">


### PR DESCRIPTION
the field sequential_line was not visible due "active" is now a smart button.