### PR TITLE
[IMP][11.0] purchase_stock_picking_return_invoicing: ease multi refund

### DIFF
--- a/purchase_stock_picking_return_invoicing/__manifest__.py
+++ b/purchase_stock_picking_return_invoicing/__manifest__.py
@@ -19,6 +19,7 @@
         "purchase",
     ],
     "data": [
+        "views/account_invoice_view.xml",
         "views/purchase_view.xml",
     ],
     "maintainers": [

--- a/purchase_stock_picking_return_invoicing/views/account_invoice_view.xml
+++ b/purchase_stock_picking_return_invoicing/views/account_invoice_view.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- Add purchase orders to refund -->
+    <record id="view_invoice_supplier_purchase_form" model="ir.ui.view">
+        <field name="model">account.invoice</field>
+        <field name="inherit_id" ref="purchase.view_invoice_supplier_purchase_form"/>
+        <field name="arch" type="xml">
+            <field name="reference" position="after">
+                <field name="purchase_id" attrs="{'readonly': [('state','not in',['draft'])], 'invisible': ['|', ('state', '=', 'purchase'), ('type', '=', 'in_invoice')]}" class="oe_edit_only" options="{'no_create': True}" context="{'show_total_amount': True}"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>

--- a/purchase_stock_picking_return_invoicing/views/purchase_view.xml
+++ b/purchase_stock_picking_return_invoicing/views/purchase_view.xml
@@ -9,11 +9,11 @@
             <button name="action_view_invoice" position="after">
                 <button type="object" name="action_view_invoice_refund"
                         class="oe_stat_button"
-                        icon="fa-pencil-square-o">
+                        icon="fa-pencil-square-o"
+                        attrs="{'invisible': [('state', 'in', ('draft', 'sent', 'to approve'))]}">
                     <field name="invoice_refund_count"
                            widget="statinfo"
                            string="Refunds"
-                           attrs="{'invisible': [('state', 'in', ('draft', 'sent', 'to approve'))]}"
                     />
                 </button>
             </button>


### PR DESCRIPTION
- Show "Add purchase order" field in supplier refunds to allow refunding
multiple orders.
- Improve "Refunds" stat button to fit 12.0 improvements like:
  - Enter draft mode as soon as the stat button is clicked.
  - [FIX] When no refund was made yet, the whole customers refunds would
appear.

cc @Tecnativa TT18623