### PR TITLE
[FEAT] Choose the purchase order on the vendor bill

### DIFF
--- a/purchase_stock_picking_return_invoicing/README.rst
+++ b/purchase_stock_picking_return_invoicing/README.rst
@@ -126,6 +126,10 @@ Contributors
 
   * Pedro M. Baeza
 
+* Avoin.Systems <https://avoin.systems>:
+
+  * Atte Isopuro
+
 Maintainers
 ~~~~~~~~~~~
 

--- a/purchase_stock_picking_return_invoicing/__manifest__.py
+++ b/purchase_stock_picking_return_invoicing/__manifest__.py
@@ -19,6 +19,7 @@
         "purchase",
     ],
     "data": [
+        "views/account_invoice_view.xml",
         "views/purchase_view.xml",
     ],
     "maintainers": [

--- a/purchase_stock_picking_return_invoicing/views/account_invoice_view.xml
+++ b/purchase_stock_picking_return_invoicing/views/account_invoice_view.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_inherit_account_invoice_vendor_bill_form" model="ir.ui.view">
+        <field name="name">view.inherit.account.invoice.vendor.bill.form</field>
+        <field name="model">account.invoice</field>
+        <field name="inherit_id" ref="purchase.view_invoice_supplier_purchase_form"/>
+        <field name="arch" type="xml">
+
+            <xpath expr="//field[@name='purchase_id']" position="attributes">
+                <!--The 'invisible' domain used to be ['|', ('state', '=', 'purchase'), ('type', '=', 'in_refund')],
+                change it to allow selecting the purchase order on vendor refunds-->
+                <attribute name="attrs">{'readonly': [('state','not in',['draft'])], 'invisible': [('state', '=', 'purchase')]}</attribute>
+            </xpath>
+
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Sometimes, due to e.g. integration, users may be given pre-made refunds
instead of being able to generate the refund from the purchase order. In
these cases it is useful to be able to select the purchase order directly
onto the bill, similarly to how it can be selected onto vendor bills.