### PR TITLE
[IMP][12.0] purchase_stock_picking_return_invoicing: ease multi refund

### DIFF
--- a/purchase_stock_picking_return_invoicing/__manifest__.py
+++ b/purchase_stock_picking_return_invoicing/__manifest__.py
@@ -18,6 +18,7 @@
         "purchase_stock",
     ],
     "data": [
+        "views/account_invoice_view.xml",
         "views/purchase_view.xml",
     ],
     "maintainers": [

--- a/purchase_stock_picking_return_invoicing/views/account_invoice_view.xml
+++ b/purchase_stock_picking_return_invoicing/views/account_invoice_view.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- Add purchase orders to refund -->
+    <record id="view_invoice_supplier_purchase_form" model="ir.ui.view">
+        <field name="model">account.invoice</field>
+        <field name="inherit_id" ref="purchase.view_invoice_supplier_purchase_form"/>
+        <field name="arch" type="xml">
+            <field name="vendor_bill_id" position="after">
+                <field name="vendor_bill_purchase_id" attrs="{'invisible': ['|', '|', ('state','not in',['draft']), ('state', '=', 'purchase'), ('type', '=', 'in_invoice')]}" class="oe_edit_only" domain="[('partner_id','child_of',[partner_id])]" placeholder="Select a purchase order or an old bill" options="{'no_create': True, 'no_open': True}"/>
+            </field>
+            <field name="vendor_bill_id" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
- Show "Auto-Complete" field in supplier refunds to allow refunding
multiple orders.

FW port of https://github.com/OCA/account-invoicing/pull/624

cc @Tecnativa TT18623