### PR TITLE
[11.0][FIX] sale_order_invoicing_grouping_criteria: An user without invoicin…

### DIFF
--- a/sale_order_invoicing_grouping_criteria/readme/CONTRIBUTORS.rst
+++ b/sale_order_invoicing_grouping_criteria/readme/CONTRIBUTORS.rst
@@ -1,3 +1,7 @@
 * `Tecnativa <https://www.tecnativa.com>`__:
 
   * Pedro M. Baeza
+
+* `NuoBiT Solutions, S.L. <https://www.nuobit.com>`__:
+
+  * Eric Antones <eantones@nuobit.com>

--- a/sale_order_invoicing_grouping_criteria/views/res_partner_views.xml
+++ b/sale_order_invoicing_grouping_criteria/views/res_partner_views.xml
@@ -6,6 +6,7 @@
     <record id="view_partner_form" model="ir.ui.view">
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form"/>
+        <field name="groups_id" eval="[(6, 0, [ref('account.group_account_invoice')])]"/>
         <field name="arch" type="xml">
             <xpath expr="//group[@name='acc_sale']" position="inside">
                 <field name="sale_invoicing_grouping_criteria_id" string="Invoicing Grouping Criteria"/>


### PR DESCRIPTION
…g permissions cannot access to the partners

Accessing to partner form or tree views leads to an error if your user does not belong to any of the invoicing groups.

@pedrobaeza 

Thanks!