### PR TITLE
[13.0][FIX] account_invoice_fixed_discount, missing param with new Odoo

### DIFF
--- a/account_invoice_fixed_discount/models/account_move.py
+++ b/account_invoice_fixed_discount/models/account_move.py
@@ -75,12 +75,12 @@ class AccountMoveLine(models.Model):
 
     @api.model
     def _get_fields_onchange_balance_model(
-        self, quantity, discount, balance, move_type, currency, taxes
+        self, quantity, discount, balance, move_type, currency, taxes, price_subtotal
     ):
         if self.discount_fixed != 0:
             discount = ((self.discount_fixed) / self.price_unit) * 100 or 0.00
         return super(AccountMoveLine, self)._get_fields_onchange_balance_model(
-            quantity, discount, balance, move_type, currency, taxes
+            quantity, discount, balance, move_type, currency, taxes, price_subtotal
         )
 
     @api.model_create_multi

--- a/account_invoice_fixed_discount/readme/CONTRIBUTORS.rst
+++ b/account_invoice_fixed_discount/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Lois Rilo <lois.rilo@eficent.com>
 * Jordi Ballester <jordi.ballester@eficent.com>
 * Rattapong Chokmasermkul <rattapongc@ecosoft.co.th>
+* Kitti U. <kittiu@ecosoft.co.th>


### PR DESCRIPTION
Easy fix. Got the error when test with updated Odoo 13.