### PR TITLE
[FIX] sale_order_invoicing_grouping_criteria: Error accessing partners

### DIFF
--- a/sale_order_invoicing_grouping_criteria/views/res_partner_views.xml
+++ b/sale_order_invoicing_grouping_criteria/views/res_partner_views.xml
@@ -5,7 +5,7 @@
 
     <record id="view_partner_form" model="ir.ui.view">
         <field name="model">res.partner</field>
-        <field name="inherit_id" ref="base.view_partner_form"/>
+        <field name="inherit_id" ref="account.view_partner_property_form"/>
         <field name="arch" type="xml">
             <xpath expr="//group[@name='acc_sale']" position="inside">
                 <field name="sale_invoicing_grouping_criteria_id" string="Invoicing Grouping Criteria"/>


### PR DESCRIPTION
Hi,

Small fix that change the inheritance of partner's view because the record that use to position the new data in the view is from other inheritance limited to group "account.group_account_invoice" and if the user has not this group, it fails accessing partner's view.

Regards.