### PR TITLE
[FIX] account_invoice_transmit_method: Transmit method does not propagated to invoice when user invoices from saler orders

### DIFF
--- a/account_invoice_transmit_method/models/account_invoice.py
+++ b/account_invoice_transmit_method/models/account_invoice.py
@@ -26,8 +26,6 @@ class AccountInvoice(models.Model):
             else:
                 self.transmit_method_id = self.partner_id.\
                     supplier_invoice_transmit_method_id.id or False
-        else:
-            self.transmit_method_id = False
         return res
 
     @api.model


### PR DESCRIPTION
cc @Tecnativa TT22168
When you do a invoice from sale order the method _prepare_invoice invokes an invoice_onchage only with partner_id key, so we can not presuppose that partner has not a n invoice transmit method...
https://github.com/odoo/odoo/blob/4e90f7bbc5e32998942ec6d0542ffa6cb5ed474a/addons/sale/models/sale.py#L472-L474
With this patch, the create method will do a query to partner to get transmit method.