### PR TITLE
[DUMMY] account_invoice_check_total: Translate term with missing arg

### DIFF
--- a/account_invoice_check_total/i18n/es.po
+++ b/account_invoice_check_total/i18n/es.po
@@ -55,7 +55,7 @@ msgid ""
 "There is a difference of %s"
 msgstr ""
 "Por favor, verifique el total de la factura.\n"
-"                        El total introducido (%s) no "
+"                        El total introducido (s) no "
 "corresponde                        con el total calculado (%s)!\n"
 "Hay una diferencia de %s"
 


### PR DESCRIPTION
This is to test the case where the number of arguments (%s) of the
original string doesn't match the translated string.

This is related to https://github.com/OCA/pylint-odoo/issues/274