### PR TITLE
[12.0][FIX] account_menu_invoice_refund, fix test error on old odoo12

### DIFF
--- a/account_menu_invoice_refund/tests/test_pay_net_invoice_refund.py
+++ b/account_menu_invoice_refund/tests/test_pay_net_invoice_refund.py
@@ -83,8 +83,7 @@ class TestAccountMenuInvoiceRefund(TransactionCase):
             Form(PaymentWizard.with_context(ctx), view=view_id)
         refund.action_invoice_open()
         # Finally, do the payment
-        with Form(PaymentWizard.with_context(ctx), view=view_id) as f:
-            f.amount = 450.0
+        f = Form(PaymentWizard.with_context(ctx), view=view_id)
         payment = f.save()
         payment.create_payments()
         self.assertEqual(invoice.state, 'paid')


### PR DESCRIPTION
With latest update of core odoo12, test was error.
This PR fix it.