### PR TITLE
[12.0] remove unidecode depedency from .travis.yml?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ install:
   - git clone https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
   - git clone https://github.com/OCA/bank-payment.git -b ${VERSION} ${HOME}/bank-payment
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
-  - pip install unidecode
   - travis_install_nightly
   - pip install anybox.testing.openerp # needed for testing account_invoice_line_sort
 


### PR DESCRIPTION
I found no addon from this repo is using *unidecode*... is that correct ?