### PR TITLE
[12.0][IMP] stock_picking_invoicing set name from moves instead of product

### DIFF
--- a/stock_picking_invoicing/views/stock_picking.xml
+++ b/stock_picking_invoicing/views/stock_picking.xml
@@ -74,7 +74,7 @@
             <button name="%(stock.act_stock_return_picking)d" position="after">
                 <button name="set_to_be_invoiced" type="object" string="Set to be invoiced"
                         attrs="{'invisible':['|', '|',
-                         ('invoice_state', 'in', ('2binvoiced', 'invoiced')),
+                         ('invoice_state', '=', 'invoiced'),
                          ('invoice_ids', '=', True), ('state', '=', 'cancel')]}"/>
             </button>
         </field>

--- a/stock_picking_invoicing/wizards/stock_invoice_onshipping.py
+++ b/stock_picking_invoicing/wizards/stock_invoice_onshipping.py
@@ -401,7 +401,7 @@ class StockInvoiceOnshipping(models.TransientModel):
         :param invoice: account.invoice
         :return: dict
         """
-        name = ", ".join(moves.mapped("product_id.name"))
+        name = ", ".join(moves.mapped("name"))
         move = fields.first(moves)
         product = move.product_id
         fiscal_position = self.env['account.fiscal.position'].browse(
@@ -455,6 +455,7 @@ class StockInvoiceOnshipping(models.TransientModel):
             'invoice_id': invoice.id,
         })
         values = self._simulate_invoice_line_onchange(values)
+        values.update({'name': name})
         return values
 
     @api.multi
@@ -502,6 +503,7 @@ class StockInvoiceOnshipping(models.TransientModel):
                     pickings
                 )
                 lines = [(5, 0, {})]
+                line_values = False
                 for moves in moves_list:
                     line_values = self._get_invoice_line_values(
                         moves, invoice_values, invoice
@@ -510,6 +512,7 @@ class StockInvoiceOnshipping(models.TransientModel):
                         lines.append((0, 0, line_values))
                 if line_values:  # Only create the invoice if it have lines
                     invoice_values['invoice_line_ids'] = lines
+                    invoice_values['date_invoice'] = self.invoice_date
                     invoice = self._create_invoice(invoice_values)
                     invoice._onchange_invoice_line_ids()
                     invoice.compute_taxes()


### PR DESCRIPTION
Get name and uom from stock move to put in created invoice line.
In the same way, get price and discount from purchase line if exists and link invoice to it.