### PR TITLE
[12.0][FIX] account_payment_term_extension: consider day_of_the_month in compute()

### DIFF
--- a/account_payment_term_extension/models/account_payment_term.py
+++ b/account_payment_term_extension/models/account_payment_term.py
@@ -179,6 +179,10 @@ class AccountPaymentTerm(models.Model):
                 next_date += relativedelta(days=line.days,
                                            weeks=line.weeks,
                                            months=line.months)
+                if line.day_of_the_month > 0:
+                    months_delta = (line.day_of_the_month < next_date.day) and 1 or 0
+                    next_date += relativedelta(
+                        day=line.day_of_the_month, months=months_delta)
             elif line.option == 'after_invoice_month':
                 # Getting 1st of next month
                 next_first_date = next_date + relativedelta(day=1, months=1)


### PR DESCRIPTION
Odoo standard logic in the `compute()` of the `account.payment.term` considers Terms' `day_of_the_month`.
https://github.com/odoo/odoo/blob/6ed05368ab616aa6b256898bcef35fac93dcbb54/addons/account/models/account_invoice.py#L2067-L2069

As `account_payment_term_extension` overwrites the `compute()` of the `account.payment.term` and `day_of_the_month` is no long being considered in the overwritten method. Hence this PR is trying to keep the `compute()` consistent with standard logic.