### PR TITLE
[12.0][FIX] too generic xpath expr

### DIFF
--- a/account_invoice_refund_reason/views/account_invoice_view.xml
+++ b/account_invoice_refund_reason/views/account_invoice_view.xml
@@ -21,7 +21,7 @@
             <xpath expr="//page[@name='other_info']/group/group[1]/field[@name='name']" position="attributes">
                 <attribute name="attrs">{'invisible': [('type', 'in', ['in_refund', 'out_refund'])]}</attribute>
             </xpath>
-            <xpath expr="//field[@name='date']" position="after">
+            <xpath expr="//page[@name='other_info']/group/group[1]/field[@name='date']" position="after">
                 <field name="reason_id" attrs="{'invisible': [('reason_id', '=', False)]}" readonly="1"/>
             </xpath>
         </field>


### PR DESCRIPTION
account_invoice_refund_reason could conflicts with other modules because the xpath definition is too generic
This PR fix this.