### PR TITLE
[12.0][FIX] account_payment_term_extension: bad use of precision_digits vs precision_rounding

### DIFF
--- a/account_payment_term_extension/models/account_payment_term.py
+++ b/account_payment_term_extension/models/account_payment_term.py
@@ -173,7 +173,7 @@ class AccountPaymentTerm(models.Model):
             if not self.sequential_lines:
                 # For all lines, the beginning date is `date_ref`
                 next_date = fields.Date.from_string(date_ref)
-                if float_is_zero(amt, precision_rounding=prec):
+                if float_is_zero(amt, precision_digits=prec):
                     continue
             if line.option == 'day_after_invoice_date':
                 next_date += relativedelta(days=line.days,
@@ -193,7 +193,7 @@ class AccountPaymentTerm(models.Model):
                 next_date += relativedelta(day=line.days, months=0)
             next_date = self.apply_payment_days(line, next_date)
             next_date = self.apply_holidays(next_date)
-            if not float_is_zero(amt, precision_rounding=prec):
+            if not float_is_zero(amt, precision_digits=prec):
                 result.append((fields.Date.to_string(next_date), amt))
                 amount -= amt
         amount = reduce(lambda x, y: x + y[1], result, 0.0)

--- a/account_payment_term_extension/tests/test_payment_term.py
+++ b/account_payment_term_extension/tests/test_payment_term.py
@@ -38,6 +38,14 @@ class TestAccountPaymentTerm(TransactionCase):
             '2015-03-16',
             'Error in the compute of payment terms with weeks')
 
+    def test_02_compute(self):
+        # test for bug caused by bad use of precision_digits/precision_rounding
+        res = self.env.ref("account.account_payment_term_15days").compute(
+            0.2, date_ref="2015-03-01")
+        self.assertEquals(
+            res[0][0][0], "2015-03-16", "Error in the compute of payment terms 15 days",
+        )
+
     def test_postpone_holiday(self):
         str_date_invoice = '2015-03-02'
         str_date_holiday = '2015-03-16'


### PR DESCRIPTION
I added a test for that particular bug.