### PR TITLE
[10.0] account_invoice_transmit_method: Remove arg with wrong syntax

### DIFF
--- a/account_invoice_transmit_method/models/partner.py
+++ b/account_invoice_transmit_method/models/partner.py
@@ -11,14 +11,14 @@ class ResPartner(models.Model):
 
     customer_invoice_transmit_method_id = fields.Many2one(
         'transmit.method', string='Customer Invoice Transmission Method',
-        company_dependant=True, track_visibility='onchange',
+        track_visibility='onchange',
         domain=[('customer_ok', '=', True)], ondelete='restrict')
     customer_invoice_transmit_method_code = fields.Char(
         related='customer_invoice_transmit_method_id.code',
         string='Customer Invoice Transmission Method Code', readonly=True)
     supplier_invoice_transmit_method_id = fields.Many2one(
         'transmit.method', string='Vendor Invoice Reception Method',
-        company_dependant=True, track_visibility='onchange',
+        track_visibility='onchange',
         domain=[('supplier_ok', '=', True)], ondelete='restrict')
     supplier_invoice_transmit_method_code = fields.Char(
         related='supplier_invoice_transmit_method_id.code',


### PR DESCRIPTION
In the initial dev of the module, I made a typo in the definition of the
fields customer_invoice_transmit_method_id and supplier_invoice_transmit_method_id
on res.partner: I wrote "company_dependant=True" instead of
"company_dependent=True".
As a result, these 2 fields were not company-specific.
So we have 2 options:
1) Fix the typo and write migration scripts
2) Keep these 2 fields with company_dependent=False, as nobody as
complained so far about the fact that the value of this parameter didn't
vary from one company to another.

This PR implement option 2.