### PR TITLE
[13.0][ADD] account_invoice_section_sale_order

### DIFF
--- a/account_invoice_section_sale_order/__init__.py
+++ b/account_invoice_section_sale_order/__init__.py
@@ -1,0 +1,4 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import models
+from . import tests

--- a/account_invoice_section_sale_order/__manifest__.py
+++ b/account_invoice_section_sale_order/__manifest__.py
@@ -1,0 +1,13 @@
+# Copyright 2020 Camptocamp
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{
+    "name": "Acccount Invoice Section Sale Order",
+    "version": "13.0.1.0.0",
+    "summary": "For invoices targetting multiple sale order add"
+    "sections with sale order name.",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/account-invoicing",
+    "license": "AGPL-3",
+    "category": "Accounting & Finance",
+    "depends": ["account", "sale"],
+}

--- a/account_invoice_section_sale_order/models/__init__.py
+++ b/account_invoice_section_sale_order/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order

--- a/account_invoice_section_sale_order/models/sale_order.py
+++ b/account_invoice_section_sale_order/models/sale_order.py
@@ -1,0 +1,54 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import models
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    def _create_invoices(self, grouped=False, final=False):
+        """Add sections by sale order in the invoice line.
+
+        Order the invoicing lines by sale order and add lines section with
+        the sale order name.
+        Only do this for invoices targetting multiple sale order
+        """
+        invoice_ids = super()._create_invoices(grouped=grouped, final=final)
+        for invoice in invoice_ids:
+            if len(invoice.line_ids.mapped("sale_line_ids.order_id.id")) == 1:
+                continue
+            so = None
+            sequence = 10
+            section_lines = []
+            lines = invoice.line_ids.sorted(
+                key=lambda r: r.sale_line_ids.order_id.id
+            ).filtered(lambda r: not r.exclude_from_invoice_tab)
+            for line in lines:
+                if line.sale_line_ids.order_id and so != line.sale_line_ids.order_id:
+                    so = line.sale_line_ids.order_id
+                    section_lines.append(
+                        (
+                            0,
+                            0,
+                            {
+                                "name": so._get_saleorder_section_name(),
+                                "display_type": "line_section",
+                                "sequence": sequence,
+                            },
+                        )
+                    )
+                    sequence += 10
+                line.sequence = sequence
+                sequence += 10
+            invoice.line_ids = section_lines
+
+        return invoice_ids
+
+    def _get_saleorder_section_name(self):
+        """Returns the text for the section name."""
+        self.ensure_one()
+        if self.client_order_ref:
+            return "{} - {}".format(self.name, self.client_order_ref or "")
+        else:
+            return self.name

--- a/account_invoice_section_sale_order/readme/CONTRIBUTORS.rst
+++ b/account_invoice_section_sale_order/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `Camptocamp <https://www.camptocamp.com>`_
+
+  * Thierry Ducrest <thierry.ducrest@camptocamp.com>

--- a/account_invoice_section_sale_order/readme/DESCRIPTION.rst
+++ b/account_invoice_section_sale_order/readme/DESCRIPTION.rst
@@ -1,0 +1,7 @@
+When invoicing multiple sale orders at the same time, sale orders may be grouped
+by customer into a single invoice. Unfortunately when this happens, it is hard
+to know which invoice line belongs to which sale order.
+
+This module helps by grouping invoicing lines into sections with the name of the
+targeted sale order.
+This is only done when an invoice targets multiple sale order.

--- a/account_invoice_section_sale_order/tests/__init__.py
+++ b/account_invoice_section_sale_order/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_invoice_group_by_sale_order

--- a/account_invoice_section_sale_order/tests/test_invoice_group_by_sale_order.py
+++ b/account_invoice_section_sale_order/tests/test_invoice_group_by_sale_order.py
@@ -1,0 +1,109 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo.tests.common import SavepointCase
+
+
+class TestInvoiceGroupBySaleOrder(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner_1 = cls.env.ref("base.res_partner_1")
+        cls.product_1 = cls.env.ref("product.product_product_1")
+        cls.product_1.invoice_policy = "order"
+        cls.order1_p1 = cls.env["sale.order"].create(
+            {
+                "partner_id": cls.partner_1.id,
+                "partner_shipping_id": cls.partner_1.id,
+                "partner_invoice_id": cls.partner_1.id,
+                "client_order_ref": "ref123",
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "order 1 line 1",
+                            "product_id": cls.product_1.id,
+                            "price_unit": 20,
+                            "product_uom_qty": 1,
+                            "product_uom": cls.product_1.uom_id.id,
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "order 1 line 2",
+                            "product_id": cls.product_1.id,
+                            "price_unit": 20,
+                            "product_uom_qty": 1,
+                            "product_uom": cls.product_1.uom_id.id,
+                        },
+                    ),
+                ],
+            }
+        )
+        cls.order1_p1.action_confirm()
+        cls.order2_p1 = cls.env["sale.order"].create(
+            {
+                "partner_id": cls.partner_1.id,
+                "partner_shipping_id": cls.partner_1.id,
+                "partner_invoice_id": cls.partner_1.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "order 2 line 1",
+                            "product_id": cls.product_1.id,
+                            "price_unit": 20,
+                            "product_uom_qty": 1,
+                            "product_uom": cls.product_1.uom_id.id,
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "order 2 line 2",
+                            "product_id": cls.product_1.id,
+                            "price_unit": 20,
+                            "product_uom_qty": 1,
+                            "product_uom": cls.product_1.uom_id.id,
+                        },
+                    ),
+                ],
+            }
+        )
+        cls.order2_p1.action_confirm()
+
+    def test_create_invoice(self):
+        """ Check invoice is generated  with sale order sections."""
+        result = {
+            0: "".join([self.order1_p1.name, " - ", self.order1_p1.client_order_ref]),
+            1: "order 1 line 1",
+            2: "order 1 line 2",
+            3: self.order2_p1.name,
+            4: "order 2 line 1",
+            5: "order 2 line 2",
+        }
+        invoice_ids = (self.order1_p1 + self.order2_p1)._create_invoices()
+        lines = (
+            invoice_ids[0]
+            .line_ids.sorted("sequence")
+            .filtered(lambda r: not r.exclude_from_invoice_tab)
+        )
+        for idx, line in enumerate(lines):
+            self.assertEqual(line.name, result[idx])
+
+    def test_create_invoice_no_section(self):
+        """ Check invoice for only one sale order
+
+        No need to create sections
+
+        """
+        invoice_id = (self.order1_p1)._create_invoices()
+        line_sections = invoice_id.line_ids.filtered(
+            lambda r: r.display_type == "line_section"
+        )
+        self.assertEqual(len(line_sections), 0)


### PR DESCRIPTION
Description from the readme :

When invoicing multiple sale orders at the same time, sale orders may be grouped
by customer into a single invoice. Unfortunately when this happens, it is hard
to know which invoice line belongs to which sale order.

This module helps by grouping invoicing lines into sections with the name of the
targeted sale order.
This is only done when an invoice targets multiple sale order.

Also include a commit to fix the `account_invoice_supplier_ref_unique` broken tests