### PR TITLE
[FIX] account_invoice_supplier_ref_unique: Fix Test Script

### DIFF
--- a/account_invoice_supplier_ref_unique/tests/test_account_invoice_supplier_ref_unique.py
+++ b/account_invoice_supplier_ref_unique/tests/test_account_invoice_supplier_ref_unique.py
@@ -5,10 +5,10 @@
 from odoo import fields
 from odoo.exceptions import ValidationError
 
-from odoo.addons.account.tests.invoice_test_common import InvoiceTestCommon
+from odoo.addons.account.tests.account_test_savepoint import AccountTestInvoicingCommon
 
 
-class TestAccountInvoiceSupplierRefUnique(InvoiceTestCommon):
+class TestAccountInvoiceSupplierRefUnique(AccountTestInvoicingCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()


### PR DESCRIPTION
Test script error in account_invoice_supplier_ref_unique module.
Because in the test script, Import InvoiceTestCommon is not available in Odoo, so it must be changed to AccountTestInvoicingCommon.

cc : @kittiu 