### PR TITLE
[FIX] account_invoice_refund_link: Fix foreignkey exception when a credit note invoice has done from sale order.

### DIFF
--- a/account_invoice_refund_link/__init__.py
+++ b/account_invoice_refund_link/__init__.py
@@ -1,4 +1,5 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import models
+from . import wizards
 from .hooks import post_init_hook

--- a/account_invoice_refund_link/models/account_move.py
+++ b/account_invoice_refund_link/models/account_move.py
@@ -16,7 +16,10 @@ class AccountMove(models.Model):
     @api.model
     def _reverse_move_vals(self, default_values, cancel=True):
         move_vals = super()._reverse_move_vals(default_values, cancel)
-        if move_vals["type"] in ("out_refund", "in_refund"):
+        if self.env.context.get("link_origin_line", False) and move_vals["type"] in (
+            "out_refund",
+            "in_refund",
+        ):
             refund_lines_vals = move_vals.get("line_ids", [])
             for i, line in enumerate(self.line_ids):
                 if i + 1 > len(refund_lines_vals):  # pragma: no cover

--- a/account_invoice_refund_link/wizards/__init__.py
+++ b/account_invoice_refund_link/wizards/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import account_move_reversal

--- a/account_invoice_refund_link/wizards/account_move_reversal.py
+++ b/account_invoice_refund_link/wizards/account_move_reversal.py
@@ -1,0 +1,17 @@
+# Copyright 2020 Tecnativa - Sergio Teruel
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class AccountMoveReversal(models.TransientModel):
+    _inherit = "account.move.reversal"
+
+    def reverse_moves(self):
+        """
+        Only link invoice lines with theirs original lines when the reversal
+        move has been done from reversal wizard.
+        """
+        return super(
+            AccountMoveReversal, self.with_context(link_origin_line=True)
+        ).reverse_moves()


### PR DESCRIPTION
With this moduled installed, if you try to do an refund invoice from sale order, the method action_switch_invoice_into_refund_credit_note called from sale order removes all original lines.

see https://github.com/odoo/odoo/blob/bbbb11f3fd10bbb0f1086920f291aa9c7c2052be/addons/account/models/account_move.py#L2409

CC @Tecnativa

ping @carlosdauden @ernestotejeda 