### PR TITLE
[FIX] stock_picking_return_refund_option: use correct field to_refund when preparing line values

### DIFF
--- a/stock_picking_return_refund_option/__manifest__.py
+++ b/stock_picking_return_refund_option/__manifest__.py
@@ -3,7 +3,7 @@
 {
     'name': 'Stock Picking Return Refund Option',
     'summary': 'Update the refund options in pickings',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.0.1',
     'development_status': 'Beta',
     'category': 'Sales',
     'website': 'https://github.com/OCA/account-invoicing',

--- a/stock_picking_return_refund_option/wizards/stock_return_picking.py
+++ b/stock_picking_return_refund_option/wizards/stock_return_picking.py
@@ -8,5 +8,5 @@ class StockReturnPicking(models.TransientModel):
 
     def _prepare_move_default_values(self, return_line, new_picking):
         vals = super()._prepare_move_default_values(return_line, new_picking)
-        vals.update({'origin_to_refund': return_line.to_refund})
+        vals.update({'to_refund': return_line.to_refund})
         return vals


### PR DESCRIPTION
The addon *stock_account* adds the field *to_refund* in model *stock.return.picking.line*.
This commit fixes the method *_prepare_move_default_values* to use the correct field.