### PR TITLE
[12.0][ADD] New module account_invoice_auto_send_mail

### DIFF
--- a/account_invoice_auto_send_mail/README.rst
+++ b/account_invoice_auto_send_mail/README.rst
@@ -1,0 +1,4 @@
+It will be necessary that at the level of each journal (related to type = sales) we define the fields:
+- Email template: Email template to be used to send each of the invoices
+- Author: If you want to establish it, it will replace the user_id of the invoice
+- Invoice days: Defines the number of days that must pass between the invoice and the current date for them to be sent

--- a/account_invoice_auto_send_mail/README.rst
+++ b/account_invoice_auto_send_mail/README.rst
@@ -1,4 +1,1 @@
-It will be necessary that at the level of each journal (related to type = sales) we define the fields:
-- Email template: Email template to be used to send each of the invoices
-- Author: If you want to establish it, it will replace the user_id of the invoice
-- Invoice days: Defines the number of days that must pass between the invoice and the current date for them to be sent
+Allows you to automate the sending of customer sales invoices and rectifiers to send by email

--- a/account_invoice_auto_send_mail/__init__.py
+++ b/account_invoice_auto_send_mail/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/account_invoice_auto_send_mail/__manifest__.py
+++ b/account_invoice_auto_send_mail/__manifest__.py
@@ -1,0 +1,18 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Account Invoice Auto Send Mail",
+    "version": "12.0.1.0.0",
+    "category": "Sales Management",
+    "website": "https://github.com/OCA/account-invoicing",
+    "author": "Odoo Nodriza Tech (ONT), "
+              "Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "depends": ["account"],
+    "data": [
+        "data/ir_cron.xml",
+        "views/account_journal_view.xml",
+        "views/account_invoice_view.xml"
+    ],
+    "installable": True
+}

--- a/account_invoice_auto_send_mail/data/ir_cron.xml
+++ b/account_invoice_auto_send_mail/data/ir_cron.xml
@@ -1,0 +1,16 @@
+<odoo noupdate="1">
+
+    <record id="cron_account_invoice_auto_send_mail" forcecreate="True" model="ir.cron">
+        <field name="name">Account Invoice Auto Send Mail</field>
+        <field name="active" eval="True"/>
+        <field name="user_id" ref="base.user_root"/>
+        <field name="interval_number">2</field>
+        <field name="interval_type">hours</field>
+        <field name="numbercall">-1</field>
+        <field name="doall" eval="False"/>
+        <field name="model_id" ref="model_account_invoice"/>
+        <field name="state">code</field>
+        <field name="code">model.cron_account_invoice_auto_send_mail()</field>
+    </record>
+
+</odoo>

--- a/account_invoice_auto_send_mail/i18n/account_invoice_auto_send_mail.pot
+++ b/account_invoice_auto_send_mail/i18n/account_invoice_auto_send_mail.pot
@@ -1,0 +1,54 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_invoice_auto_send_mail
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0-20200601\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-13 09:15+0000\n"
+"PO-Revision-Date: 2020-07-13 09:15+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_invoice_auto_send_mail
+#: model:ir.actions.server,name:account_invoice_auto_send_mail.cron_account_invoice_auto_send_mail_ir_actions_server
+#: model:ir.cron,cron_name:account_invoice_auto_send_mail.cron_account_invoice_auto_send_mail
+#: model:ir.cron,name:account_invoice_auto_send_mail.cron_account_invoice_auto_send_mail
+msgid "Account Invoice Auto Send Mail (3 dias)"
+msgstr ""
+
+#. module: account_invoice_auto_send_mail
+#: model:ir.model.fields,field_description:account_invoice_auto_send_mail.field_account_invoice__date_invoice_send_mail
+msgid "Date invoice send mail"
+msgstr ""
+
+#. module: account_invoice_auto_send_mail
+#: model:ir.model,name:account_invoice_auto_send_mail.model_account_invoice
+msgid "Invoice"
+msgstr ""
+
+#. module: account_invoice_auto_send_mail
+#: model:ir.model.fields,field_description:account_invoice_auto_send_mail.field_account_journal__invoice_mail_days
+msgid "Invoice mail days"
+msgstr ""
+
+#. module: account_invoice_auto_send_mail
+#: model:ir.model.fields,field_description:account_invoice_auto_send_mail.field_account_journal__invoice_mail_template_id_author_id
+msgid "Invoice mail template author id"
+msgstr ""
+
+#. module: account_invoice_auto_send_mail
+#: model:ir.model.fields,field_description:account_invoice_auto_send_mail.field_account_journal__invoice_mail_template_id
+msgid "Invoice mail template id"
+msgstr ""
+
+#. module: account_invoice_auto_send_mail
+#: model:ir.model,name:account_invoice_auto_send_mail.model_account_journal
+msgid "Journal"
+msgstr ""
+

--- a/account_invoice_auto_send_mail/i18n/es.po
+++ b/account_invoice_auto_send_mail/i18n/es.po
@@ -1,0 +1,54 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_invoice_auto_send_mail
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0-20200601\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-13 09:15+0000\n"
+"PO-Revision-Date: 2020-07-13 09:15+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_invoice_auto_send_mail
+#: model:ir.actions.server,name:account_invoice_auto_send_mail.cron_account_invoice_auto_send_mail_ir_actions_server
+#: model:ir.cron,cron_name:account_invoice_auto_send_mail.cron_account_invoice_auto_send_mail
+#: model:ir.cron,name:account_invoice_auto_send_mail.cron_account_invoice_auto_send_mail
+msgid "Account Invoice Auto Send Mail (3 dias)"
+msgstr ""
+
+#. module: account_invoice_auto_send_mail
+#: model:ir.model.fields,field_description:account_invoice_auto_send_mail.field_account_invoice__date_invoice_send_mail
+msgid "Date invoice send mail"
+msgstr ""
+
+#. module: account_invoice_auto_send_mail
+#: model:ir.model,name:account_invoice_auto_send_mail.model_account_invoice
+msgid "Invoice"
+msgstr "Factura"
+
+#. module: account_invoice_auto_send_mail
+#: model:ir.model.fields,field_description:account_invoice_auto_send_mail.field_account_journal__invoice_mail_days
+msgid "Invoice mail days"
+msgstr "Días para enviar factura"
+
+#. module: account_invoice_auto_send_mail
+#: model:ir.model.fields,field_description:account_invoice_auto_send_mail.field_account_journal__invoice_mail_template_id_author_id
+msgid "Invoice mail template author id"
+msgstr "Autor de la plantilla de email de facturas"
+
+#. module: account_invoice_auto_send_mail
+#: model:ir.model.fields,field_description:account_invoice_auto_send_mail.field_account_journal__invoice_mail_template_id
+msgid "Invoice mail template id"
+msgstr "Plantilla de email de factura"
+
+#. module: account_invoice_auto_send_mail
+#: model:ir.model,name:account_invoice_auto_send_mail.model_account_journal
+msgid "Journal"
+msgstr "Diario"
+

--- a/account_invoice_auto_send_mail/models/__init__.py
+++ b/account_invoice_auto_send_mail/models/__init__.py
@@ -1,0 +1,2 @@
+from . import account_journal
+from . import account_invoice

--- a/account_invoice_auto_send_mail/models/account_invoice.py
+++ b/account_invoice_auto_send_mail/models/account_invoice.py
@@ -19,7 +19,6 @@ class AccountInvoice(models.Model):
             _('Operations account_invoice_auto_send_mail_item_real invoice %s')
             % self.id
         )
-
         vals = {
             'author_id': self.user_id.partner_id.id,
             'record_name': self.number,
@@ -35,7 +34,6 @@ class AccountInvoice(models.Model):
             'account.invoice',
             self.id
         )
-
         vals = {
             'author_id': vals['author_id'],
             'template_id': mail_template_id.id,
@@ -61,13 +59,12 @@ class AccountInvoice(models.Model):
     def cron_account_invoice_auto_send_mail_item(self):
         self.ensure_one()
         if self.type in ['out_invoice', 'out_refund'] \
-            and not self.date_invoice_send_mail \
+                and not self.date_invoice_send_mail \
                 and self.state in ['open', 'paid']:
-            current_date = fields.Date.context_today(self)
-            days_difference = (
-                current_date -
-                fields.Date.from_string(self.date_invoice)
-            ).days
+            c_date = fields.Date.context_today(self)
+            days_difference = (c_date - fields.Date.from_string(
+                self.date_invoice
+            )).days
             # send_invoice
             send_invoice = False
             if self.state == 'paid':

--- a/account_invoice_auto_send_mail/models/account_invoice.py
+++ b/account_invoice_auto_send_mail/models/account_invoice.py
@@ -1,0 +1,110 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+import logging
+
+from odoo import api, fields, models, _
+from datetime import datetime
+_logger = logging.getLogger(__name__)
+
+
+class AccountInvoice(models.Model):
+    _inherit = 'account.invoice'
+
+    date_invoice_send_mail = fields.Datetime(
+        string='Date invoice send mail'
+    )
+
+    def account_invoice_auto_send_mail_item_real(self, mail_template_id, author_id):
+        self.ensure_one()
+        _logger.info(
+            _('Operations account_invoice_auto_send_mail_item_real invoice %s')
+            % self.id
+        )
+
+        vals = {
+            'author_id': self.user_id.partner_id.id,
+            'record_name': self.number,
+        }
+        # Author_id (journal_id)
+        if author_id:
+            vals['author_id'] = author_id.id
+
+        mail_compose_message_obj = self.env['mail.compose.message'].sudo().create(vals)
+        res = mail_compose_message_obj.onchange_template_id(
+            mail_template_id.id,
+            'comment',
+            'account.invoice',
+            self.id
+        )
+
+        vals = {
+            'author_id': vals['author_id'],
+            'template_id': mail_template_id.id,
+            'composition_mode': 'comment',
+            'model': 'account.invoice',
+            'res_id': self.id,
+            'body': res['value']['body'],
+            'subject': res['value']['subject'],
+            'email_from': res['value']['email_from'],
+            'record_name': self.number,
+            'no_auto_thread': False,
+        }
+        # attachment_ids
+        if 'attachment_ids' in res['value']:
+            vals['attachment_ids'] = res['value']['attachment_ids']
+        # update
+        mail_compose_message_obj.update(vals)
+        # send_mail_action
+        mail_compose_message_obj.send_mail()
+        # other
+        self.date_invoice_send_mail = datetime.today()
+
+    def cron_account_invoice_auto_send_mail_item(self):
+        self.ensure_one()
+        if self.type in ['out_invoice', 'out_refund'] \
+            and not self.date_invoice_send_mail \
+                and self.state in ['open', 'paid']:
+            current_date = fields.Date.context_today(self)
+            days_difference = (
+                current_date -
+                fields.Date.from_string(self.date_invoice)
+            ).days
+            # send_invoice
+            send_invoice = False
+            if self.state == 'paid':
+                send_invoice = True
+            else:
+                if days_difference >= self.journal_id.invoice_mail_days:
+                    send_invoice = True
+            # send_invoice
+            if send_invoice:
+                self.account_invoice_auto_send_mail_item_real(
+                    self.journal_id.invoice_mail_template_id,
+                    self.journal_id.invoice_mail_author_id.partner_id
+                )
+
+    @api.model
+    def cron_account_invoice_auto_send_mail(self):
+        invoices = self.env['account.invoice'].search(
+            [
+                ('state', 'in', ('open', 'paid')),
+                ('type', 'in', ('out_invoice', 'out_refund')),
+                ('journal_id.invoice_mail_template_id', '!=', False),
+                ('date_invoice_send_mail', '=', False)
+            ],
+            order="date_invoice asc",
+            limit=200
+        )
+        if invoices:
+            count = 0
+            for invoice in invoices:
+                count += 1
+                # cron_account_invoice_auto_send_mail_item
+                invoice.cron_account_invoice_auto_send_mail_item()
+                # logger_percent
+                percent = (float(count) / float(len(invoices))) * 100
+                percent = "{0:.2f}".format(percent)
+                _logger.info("%s (%s / %s)" % (
+                    percent,
+                    count,
+                    len(invoices)
+                ))

--- a/account_invoice_auto_send_mail/models/account_journal.py
+++ b/account_invoice_auto_send_mail/models/account_journal.py
@@ -1,0 +1,20 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class AccountJournal(models.Model):
+    _inherit = 'account.journal'
+
+    invoice_mail_template_id = fields.Many2one(
+        comodel_name='mail.template',
+        domain=[('model_id.model', '=', 'account.invoice')],
+        string='Invoice mail template id'
+    )
+    invoice_mail_author_id = fields.Many2one(
+        comodel_name='res.users',
+        string='Invoice mail template author id'
+    )
+    invoice_mail_days = fields.Integer(
+        string='Invoice mail days'
+    )

--- a/account_invoice_auto_send_mail/readme/CONTRIBUTORS.rst
+++ b/account_invoice_auto_send_mail/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* Odoo Nodriza Tech <info@nodrizatech.com>
+* Víctor Martínez <victor.martinez@nodrizatech.com>
+

--- a/account_invoice_auto_send_mail/readme/CONTRIBUTORS.rst
+++ b/account_invoice_auto_send_mail/readme/CONTRIBUTORS.rst
@@ -1,3 +1,2 @@
 * Odoo Nodriza Tech <info@nodrizatech.com>
 * Víctor Martínez <victor.martinez@nodrizatech.com>
-

--- a/account_invoice_auto_send_mail/readme/DESCRIPTION.rst
+++ b/account_invoice_auto_send_mail/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+Allows you to automate the sending of customer sales invoices and rectifiers to send by email

--- a/account_invoice_auto_send_mail/readme/USAGE.rst
+++ b/account_invoice_auto_send_mail/readme/USAGE.rst
@@ -2,4 +2,3 @@ It will be necessary that at the level of each journal (related to type = sales)
 - Email template: Email template to be used to send each of the invoices
 - Author: If you want to establish it, it will replace the user_id of the invoice
 - Invoice days: Defines the number of days that must pass between the invoice and the current date for them to be sent
-

--- a/account_invoice_auto_send_mail/readme/USAGE.rst
+++ b/account_invoice_auto_send_mail/readme/USAGE.rst
@@ -1,0 +1,5 @@
+It will be necessary that at the level of each journal (related to type = sales) we define the fields:
+- Email template: Email template to be used to send each of the invoices
+- Author: If you want to establish it, it will replace the user_id of the invoice
+- Invoice days: Defines the number of days that must pass between the invoice and the current date for them to be sent
+

--- a/account_invoice_auto_send_mail/views/account_invoice_view.xml
+++ b/account_invoice_auto_send_mail/views/account_invoice_view.xml
@@ -1,0 +1,15 @@
+<odoo>
+
+    <record id="account_invoice_auto_send_mail_form" model="ir.ui.view">
+        <field name="name">account.invoice.auto.send.mail.form</field>
+        <field name="model">account.invoice</field>
+        <field name="inherit_id" ref="account.invoice_form" />
+        <field name="priority" eval="20"/>
+        <field name="arch" type="xml">
+            <field name="date_invoice" position="after">
+                <field name="date_invoice_send_mail"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>

--- a/account_invoice_auto_send_mail/views/account_journal_view.xml
+++ b/account_invoice_auto_send_mail/views/account_journal_view.xml
@@ -1,0 +1,17 @@
+<odoo>
+
+    <record id="account_journal_auto_send_mail_form" model="ir.ui.view">
+        <field name="name">account.journal.auto.send.mail.form</field>
+        <field name="model">account.journal</field>
+        <field name="inherit_id" ref="account.view_account_journal_form" />
+        <field name="priority" eval="20"/>
+        <field name="arch" type="xml">
+            <field name="account_control_ids" position="after">
+                <field name="invoice_mail_template_id" options='{"no_create": True, "no_create_edit": True}' attrs="{'invisible': [('type','not in', ('sale'))]}"/>
+                <field name="invoice_mail_author_id" options='{"no_create": True, "no_create_edit": True}' attrs="{'invisible': [('type','not in', ('sale'))]}"/>
+                <field name="invoice_mail_days" attrs="{'invisible': [('type','not in', ('sale'))]}"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Allows you to automate the sending of customer sales invoices and rectifiers to send by email.

It will be necessary that at the level of each newspaper (related to type = sales) we define the fields:

- **Email template**: Email template to be used to send each of the invoices
- **Author**: If you want to establish it, it will replace the user_id of the invoice
- **Invoice days**: Defines the number of days that must pass between the invoice and the current date for them to be sent.