### PR TITLE
[12.0][FIX] account.journal type values in wizard's constant

### DIFF
--- a/stock_picking_invoicing/wizards/stock_invoice_onshipping.py
+++ b/stock_picking_invoicing/wizards/stock_invoice_onshipping.py
@@ -7,11 +7,11 @@ from odoo.exceptions import UserError
 
 JOURNAL_TYPE_MAP = {
     ('outgoing', 'customer'): ['sale'],
-    ('outgoing', 'supplier'): ['purchase_refund'],
-    ('outgoing', 'transit'): ['sale', 'purchase_refund'],
+    ('outgoing', 'supplier'): ['purchase'],
+    ('outgoing', 'transit'): ['sale', 'purchase'],
     ('incoming', 'supplier'): ['purchase'],
-    ('incoming', 'customer'): ['sale_refund'],
-    ('incoming', 'transit'): ['purchase', 'sale_refund'],
+    ('incoming', 'customer'): ['sale'],
+    ('incoming', 'transit'): ['purchase', 'sale'],
 }
 
 


### PR DESCRIPTION
Fix account.journal.type selection values in wizard, in Odoo 12.0 version there aren't the values 'sale_refund', 'purchase_refund', https://github.com/odoo/odoo/blob/12.0/addons/account/models/account.py#L423