### PR TITLE
[11.0][FIX] Queue Job import now inside a try/except block

### DIFF
--- a/account_invoice_validation_queued/wizards/account_invoice_confirm.py
+++ b/account_invoice_validation_queued/wizards/account_invoice_confirm.py
@@ -2,7 +2,13 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import _, exceptions, models
-from odoo.addons.queue_job.job import identity_exact
+
+try:  # the try/except statements can be removed on v12
+    from odoo.addons.queue_job.job import identity_exact
+except ImportError:
+    import logging
+
+    logging.getLogger(__name__).debug("Can't `import queue_job`.")
 
 
 class AccountInvoiceConfirm(models.TransientModel):


### PR DESCRIPTION
- Fixes an issue where `ImportError: No module named 'queue_job'` appears even if the `account_invoice_validation_queued` module is not installed.
- A similar approach is used in this same module here: https://github.com/OCA/account-invoicing/blob/11.0/account_invoice_validation_queued/models/account_invoice.py#L6