### PR TITLE
[FIX] None as a possible value for _state_to?

### DIFF
--- a/account_move_tier_validation/models/account_move.py
+++ b/account_move_tier_validation/models/account_move.py
@@ -8,4 +8,4 @@ class AccountMove(models.Model):
     _name = "account.move"
     _inherit = ["account.move", "tier.validation"]
     _state_from = ["draft"]
-    _state_to = ["posted", None]
+    _state_to = ["posted"]


### PR DESCRIPTION
I don't understand why None is needed as a value for state_to. I have tested the module without that value and it works.