### PR TITLE
[13.0][IMP] account_invoice_validation_queued: Avoid m2m table collapse

### DIFF
--- a/account_invoice_validation_queued/README.rst
+++ b/account_invoice_validation_queued/README.rst
@@ -43,6 +43,9 @@ Installation
 This module depends on *queue_job* module that is hosted on
 https://github.com/OCA/queue.
 
+If you are migrating from version 13.0.1.0.0 to 13.0.2.0.0, you need
+`openupgradelib` library.
+
 Configuration
 =============
 

--- a/account_invoice_validation_queued/__manifest__.py
+++ b/account_invoice_validation_queued/__manifest__.py
@@ -1,10 +1,10 @@
-# Copyright 2019 Tecnativa - Pedro M. Baeza
+# Copyright 2019-2020 Tecnativa - Pedro M. Baeza
 # Copyright 2020 Tecnativa - Manuel Calero
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {
     "name": "Enqueue account invoice validation",
-    "version": "13.0.1.0.0",
+    "version": "13.0.2.0.0",
     "category": "Accounting",
     "license": "AGPL-3",
     "author": "Tecnativa, Odoo Community Association (OCA)",

--- a/account_invoice_validation_queued/migrations/13.0.2.0.0/post-migration.py
+++ b/account_invoice_validation_queued/migrations/13.0.2.0.0/post-migration.py
@@ -1,0 +1,33 @@
+# Copyright 2020 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if not openupgrade.table_exists(env.cr, "account_move_queue_job_rel"):
+        return
+    openupgrade.logged_query(
+        env.cr,
+        """
+        INSERT INTO account_move_validation_job_rel
+        (invoice_id, job_id)
+        SELECT rel.invoice_id, rel.job_id
+        FROM account_move_queue_job_rel rel
+        JOIN queue_job qj ON qj.id = rel.job_id
+        WHERE qj.method_name = 'action_invoice_open_job'
+        """,
+    )
+    openupgrade.logged_query(
+        env.cr,
+        """
+        DELETE FROM account_move_queue_job_rel
+        WHERE job_id IN (
+            SELECT rel.id
+            FROM account_move_queue_job_rel rel
+            JOIN queue_job qj ON qj.id = rel.job_id
+            WHERE qj.method_name = 'action_invoice_open_job'
+        )
+        """,
+    )

--- a/account_invoice_validation_queued/models/account_move.py
+++ b/account_invoice_validation_queued/models/account_move.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Tecnativa - Pedro M. Baeza
+# Copyright 2019-2020 Tecnativa - Pedro M. Baeza
 # Copyright 2020 Tecnativa - Manuel Calero
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
@@ -15,6 +15,7 @@ class AccountMove(models.Model):
         column1="invoice_id",
         column2="job_id",
         string="Validation Jobs",
+        relation="account_move_validation_job_rel",
         copy=False,
     )
 

--- a/account_invoice_validation_queued/readme/INSTALL.rst
+++ b/account_invoice_validation_queued/readme/INSTALL.rst
@@ -1,2 +1,5 @@
 This module depends on *queue_job* module that is hosted on
 https://github.com/OCA/queue.
+
+If you are migrating from version 13.0.1.0.0 to 13.0.2.0.0, you need
+`openupgradelib` library.

--- a/account_invoice_validation_queued/static/description/index.html
+++ b/account_invoice_validation_queued/static/description/index.html
@@ -393,6 +393,8 @@ able to enqueue invoices for the same date.</p>
 <h1><a class="toc-backref" href="#id1">Installation</a></h1>
 <p>This module depends on <em>queue_job</em> module that is hosted on
 <a class="reference external" href="https://github.com/OCA/queue">https://github.com/OCA/queue</a>.</p>
+<p>If you are migrating from version 13.0.1.0.0 to 13.0.2.0.0, you need
+<cite>openupgradelib</cite> library.</p>
 </div>
 <div class="section" id="configuration">
 <h1><a class="toc-backref" href="#id2">Configuration</a></h1>


### PR DESCRIPTION
Having other m2m pointing to queue.job will make them to share the same table and get akward results.

We avoid it specifying a table. It includes migration script for moving data from one table to the other.

@Tecnativa TT22079