### PR TITLE
[11.0][IMP] account_invoice_change_currency: query

### DIFF
--- a/account_invoice_change_currency/tests/test_account_invoice_change_currency.py
+++ b/account_invoice_change_currency/tests/test_account_invoice_change_currency.py
@@ -268,3 +268,17 @@ class TestAccountInvoiceChangeCurrency(common.TransactionCase):
         self.assertEqual(
             inv.amount_total, before_amount,
             'Amount must remain the same, because None change was made')
+
+    def test_force_custom_rate_no_tracking(self):
+        inv = self.create_simple_invoice(
+            context={'force_rate': True, 'tracking_disable': True},
+        )
+        inv2 = self.create_simple_invoice(context={'tracking_disable': True})
+        self.assertNotEqual(
+            inv.custom_rate, inv2.custom_rate,
+            'Rates must be different!')
+        inv._toggle_forced_rate()
+        inv._onchange_currency_change_rate()
+        self.assertEqual(
+            inv.custom_rate, inv2.custom_rate,
+            'Amount must remain the same, because force rate was disable')


### PR DESCRIPTION
In databases with so many records in `mail_message` table, performing a search over `mail.tracking.value` with ORM takes a while. Replacing it with a query will be significantly faster.