### PR TITLE
[FIX][12.0] account_global_discount: sale order templates compatibility

### DIFF
--- a/account_global_discount/models/account_invoice.py
+++ b/account_global_discount/models/account_invoice.py
@@ -50,7 +50,8 @@ class AccountInvoice(models.Model):
         taxes_keys = {}
         # Perform a sanity check for discarding cases that will lead to
         # incorrect data in discounts
-        for inv_line in self.invoice_line_ids:
+        for inv_line in self.invoice_line_ids.filtered(
+                lambda l: not l.display_type):
             if not inv_line.invoice_line_tax_ids:
                 raise exceptions.UserError(_(
                     "With global discounts, taxes in lines are required."


### PR DESCRIPTION
If you happen to use line sections or notes on invoice lines, you can now avoid the '... taxes in lines are required.' error and actually use global discounts.