### PR TITLE
[11.0][FIX] account_global_discount: Missing decorator @api.one

### DIFF
--- a/account_global_discount/models/account_invoice.py
+++ b/account_global_discount/models/account_invoice.py
@@ -120,12 +120,7 @@ class AccountInvoice(models.Model):
         """Trigger global discount lines to recompute all"""
         return self._onchange_invoice_line_ids()
 
-    @api.depends('invoice_line_ids.price_subtotal', 'tax_line_ids.amount',
-                 'tax_line_ids.amount_rounding', 'currency_id', 'company_id',
-                 'date_invoice', 'type',
-                 'invoice_global_discount_ids', 'global_discount_ids')
-    def _compute_amount(self):
-        super()._compute_amount()
+    def _compute_amount_one(self):
         if not self.invoice_global_discount_ids:
             return
         round_curr = self.currency_id.round
@@ -149,6 +144,15 @@ class AccountInvoice(models.Model):
         self.amount_total_company_signed = amount_total_company_signed * sign
         self.amount_total_signed = self.amount_total * sign
         self.amount_untaxed_signed = amount_untaxed_signed * sign
+
+    @api.depends('invoice_line_ids.price_subtotal', 'tax_line_ids.amount',
+                 'tax_line_ids.amount_rounding', 'currency_id', 'company_id',
+                 'date_invoice', 'type',
+                 'invoice_global_discount_ids', 'global_discount_ids')
+    def _compute_amount(self):
+        super()._compute_amount()
+        for record in self:
+            record._compute_amount_one()
 
     def get_taxes_values(self):
         """Override this computation for adding global discount to taxes."""


### PR DESCRIPTION
The _compute_amount method does not have the `api.one`, so when
it is executed on more than one record, a singleton error occurs.