### PR TITLE
[13.0] [FIX] account_invoice_check_total: validation error format

### DIFF
--- a/account_invoice_check_total/i18n/account_invoice_check_total.pot
+++ b/account_invoice_check_total/i18n/account_invoice_check_total.pot
@@ -49,8 +49,8 @@ msgstr ""
 #, python-format
 msgid ""
 "Please verify the price of the invoice!\n"
-"The total amount (%s) does not match the Verification Total amount (%s)!\n"
-"There is a difference of %s"
+"The total amount ({total}) does not match the Verification Total amount ({check_total})!\n"
+"There is a difference of {difference}"
 msgstr ""
 
 #. module: account_invoice_check_total

--- a/account_invoice_check_total/i18n/fr.po
+++ b/account_invoice_check_total/i18n/fr.po
@@ -60,12 +60,13 @@ msgstr ""
 #, fuzzy, python-format
 msgid ""
 "Please verify the price of the invoice!\n"
-"The total amount (%s) does not match the Verification Total amount (%s)!\n"
-"There is a difference of %s"
+"The total amount ({total}) does not match the Verification Total amount "
+"({check_total})!\n"
+"There is a difference of {difference}"
 msgstr ""
 "Veuillez vérifier le montant de la facture !\n"
-"                         Le montant de vérification ne correspond pas au "
-"montant calculé. Il y a une difference de %s"
+"Le montant de vérification ({check_total}) ne correspond pas au montant calculé ({total})."
+"Il y a une difference de {difference}"
 
 #. module: account_invoice_check_total
 #: model:ir.model.fields,field_description:account_invoice_check_total.field_account_move__check_total_display_difference

--- a/account_invoice_check_total/models/account_move.py
+++ b/account_invoice_check_total/models/account_move.py
@@ -44,14 +44,13 @@ class AccountMove(models.Model):
                 raise ValidationError(
                     _(
                         "Please verify the price of the invoice!\n"
-                        "The total amount (%s) does not match "
-                        "the Verification Total amount (%s)!\n"
-                        "There is a difference of %s"
-                    )
-                    % (
-                        inv.amount_total,
-                        inv.check_total,
-                        inv.check_total_display_difference,
+                        "The total amount ({total}) does not match "
+                        "the Verification Total amount ({check_total})!\n"
+                        "There is a difference of {difference}"
+                    ).format(
+                        total=inv.amount_total,
+                        check_total=inv.check_total,
+                        difference=inv.check_total_display_difference,
                     )
                 )
         return super().post()


### PR DESCRIPTION
Fixes the following error when raising the `ValidationError`: `TypeError: not all arguments converted during string formatting`.