### PR TITLE
[13.0][FIX] account_menu_invoice_refund : development_status

### DIFF
--- a/account_menu_invoice_refund/__manifest__.py
+++ b/account_menu_invoice_refund/__manifest__.py
@@ -12,6 +12,6 @@
     "depends": ["account"],
     "data": ["views/account_invoice_view.xml"],
     "installable": True,
-    "development_status": "beta",
+    "development_status": "Beta",
     "maintainers": ["kittiu"],
 }


### PR DESCRIPTION
fix Manifest key development_status "beta" not allowed in pre-commit