### PR TITLE
[13.0] [FIX] account_invoice_supplier_ref_unique: do not display field on journal entry

### DIFF
--- a/account_invoice_supplier_ref_unique/views/account_move.xml
+++ b/account_invoice_supplier_ref_unique/views/account_move.xml
@@ -7,7 +7,7 @@
             <field name="ref" position="before">
                 <field
                     name="supplier_invoice_number"
-                    attrs="{'invisible': [('type', 'in', ['out_invoice', 'out_refund'])]}"
+                    invisible="context.get('default_type') not in  ('in_invoice','in_refund')"
                 />
             </field>
         </field>


### PR DESCRIPTION
The supplier invoice number field should only be displayed on vendor bills, not on journal entries.