### PR TITLE
[13.0][FIX] account_invoice_pricelist_sale, fix test

### DIFF
--- a/account_invoice_pricelist_sale/tests/test_module.py
+++ b/account_invoice_pricelist_sale/tests/test_module.py
@@ -10,6 +10,7 @@ class TestModule(TransactionCase):
         super(TestModule, self).setUp()
         self.partner = self.env.ref("base.res_partner_12")
         self.product = self.env.ref("product.consu_delivery_01")
+        self.product.invoice_policy = "order"
 
     def test_main(self):
         # Create Pricelist


### PR DESCRIPTION
With error on Travis in https://github.com/OCA/account-invoicing/pull/667
```
  File "/home/travis/build/OCA/account-invoicing/account_invoice_pricelist_sale/tests/test_module.py", line 39, in test_main
    invoice = order._create_invoices()
  File "/home/travis/OCB-13.0/addons/sale/models/sale.py", line 639, in _create_invoices
    raise UserError(_('There is no invoiceable line. If a product has a Delivered quantities invoicing policy, please make sure that a quantity has been delivered.'))
```
So, we ensure the invoice_policy = 'order'