### PR TITLE
[FIX] account_invoice_fiscal_position_update: filter `display_type` lines

### DIFF
--- a/account_invoice_fiscal_position_update/models/account_invoice.py
+++ b/account_invoice_fiscal_position_update/models/account_invoice.py
@@ -27,7 +27,8 @@ class AccountInvoice(models.Model):
         lines_without_product = []
         fp = self.fiscal_position_id
         inv_type = self.type
-        for line in self.invoice_line_ids:
+        for line in self.invoice_line_ids.filtered(
+                lambda x: not x.display_type):
             if line.product_id:
                 account = line.get_invoice_line_account(
                     inv_type, line.product_id, fp, self.company_id)


### PR DESCRIPTION
In invoices with notes or sections we'll get an exception if we try to change the fiscal position. This fix solves it

cc @Tecnativa TT27224