### PR TITLE
[13.0][FIX] account_global_discount: wrong tax move line discounts on invoice post

### DIFF
--- a/account_global_discount/models/account_move.py
+++ b/account_global_discount/models/account_move.py
@@ -43,8 +43,13 @@ class AccountMove(models.Model):
 
     def _recompute_tax_lines(self, recompute_tax_base_amount=False):
         super()._recompute_tax_lines(recompute_tax_base_amount)
-        # if recompute_tax_base_amount:
-        self._update_tax_lines_for_global_discount()
+        # If recompute_tax_base_amount is True, only the tax_base_amount
+        # field is recalculated, therefore the debit and debit fields
+        # will not be recalculated and it doesn't make sense to apply
+        # the global discount to the taxes move lines by calling the
+        # _update_tax_lines_for_global_discount method.
+        if not recompute_tax_base_amount:
+            self._update_tax_lines_for_global_discount()
 
     def _update_tax_lines_for_global_discount(self):
         """ Update tax_base_amount and taxes debits."""


### PR DESCRIPTION
Cc @Tecnativa TT26281

Fixes: https://github.com/OCA/account-invoicing/issues/839