### PR TITLE
[10.0] account_invoice_transmit_method: email is required on invoicing contact when transmitted by email

### DIFF
--- a/account_invoice_transmit_method/views/partner.xml
+++ b/account_invoice_transmit_method/views/partner.xml
@@ -42,6 +42,9 @@ for all users -->
             <attribute name="context" operation="python_dict" key="default_customer_invoice_transmit_method_code">customer_invoice_transmit_method_code</attribute>
             <attribute name="context" operation="python_dict" key="default_supplier_invoice_transmit_method_code">supplier_invoice_transmit_method_code</attribute>
         </field>
+        <xpath expr="//field[@name='child_ids']/form//field[@name='email']" position="attributes">
+            <attribute name="attrs">{'required': [('customer_invoice_transmit_method_code', '=', 'mail'), ('type', '=', 'invoice')]}</attribute>
+        </xpath>
     </field>
 </record>
 


### PR DESCRIPTION
On an invoicing contact, the email field is now required when the customer invoice transmit method is Email.
Small change, but useful for smoother use of Odoo !