### PR TITLE
[12.0][FIX] Invoice price_unit

### DIFF
--- a/stock_picking_invoicing/wizards/stock_invoice_onshipping.py
+++ b/stock_picking_invoicing/wizards/stock_invoice_onshipping.py
@@ -383,7 +383,7 @@ class StockInvoiceOnshipping(models.TransientModel):
         return grouped_moves.values()
 
     @api.multi
-    def _simulate_invoice_line_onchange(self, values):
+    def _simulate_invoice_line_onchange(self, values, price_unit=None):
         """
         Simulate onchange for invoice line
         :param values: dict
@@ -392,6 +392,8 @@ class StockInvoiceOnshipping(models.TransientModel):
         line = self.env['account.invoice.line'].new(values.copy())
         line._onchange_product_id()
         new_values = line._convert_to_write(line._cache)
+        if price_unit:
+            new_values['price_unit'] = price_unit
         # Ensure basic values are not updated
         values.update(new_values)
         return values
@@ -464,7 +466,7 @@ class StockInvoiceOnshipping(models.TransientModel):
         if hasattr(move, 'sale_line_id'):
             if move.sale_line_id:
                 values['sale_line_ids'] = [(6, 0, [move.sale_line_id.id])]
-        values = self._simulate_invoice_line_onchange(values)
+        values = self._simulate_invoice_line_onchange(values, price_unit=price)
         values.update({'name': name})
         return values
 


### PR DESCRIPTION
When we create an invoice from picking, there is a method called _get_price_unit_invoice to be overwrite by other modules to define a price_unit for invoice line but this method does not work because after it was called the price_unit is lost in _simulate_invoice_line_onchange call