### PR TITLE
[10.0][FIX] account_invoice_merge: write invoice lines

### DIFF
--- a/account_invoice_merge/models/account_invoice.py
+++ b/account_invoice_merge/models/account_invoice.py
@@ -200,7 +200,7 @@ class AccountInvoice(models.Model):
                              ('invoice_id', '=', new_invoice_id)])
                         if invoice_line:
                             so_line.write(
-                                {'invoice_lines': [(6, 0, invoice_line.ids)]})
+                                {'invoice_lines': [(4, inv.id)for inv in invoice_line]})
 
         # recreate link (if any) between original analytic account line
         # (invoice time sheet for example) and this new invoice


### PR DESCRIPTION
When we partially invoice a sale line and then invoice it again, as the `6` is used to perform the `write`, the relationship of the previously invoiced line is lost, in this way we solve it.