### PR TITLE
[12.0][REM] Relation with Purchase/Sale fail in Group Picking cases

### DIFF
--- a/stock_picking_invoicing/wizards/stock_invoice_onshipping.py
+++ b/stock_picking_invoicing/wizards/stock_invoice_onshipping.py
@@ -345,9 +345,7 @@ class StockInvoiceOnshipping(models.TransientModel):
             'journal_id': journal.id,
             'picking_ids': [(4, p.id, False) for p in pickings],
         })
-        # HACK: using hasattr for not depending on Purchase
-        if hasattr(picking, 'purchase_id'):
-            values['purchase_id'] = picking.purchase_id.id
+
         invoice, values = self._simulate_invoice_onchange(values)
         return invoice, values
 
@@ -459,13 +457,7 @@ class StockInvoiceOnshipping(models.TransientModel):
             'move_line_ids': move_line_ids,
             'invoice_id': invoice.id,
         })
-        # HACK: using hasattr for not depending on Purchase
-        if hasattr(move, 'purchase_line_id'):
-            values['purchase_line_id'] = move.purchase_line_id.id
-        # HACK: using hasattr for not depending on Sale
-        if hasattr(move, 'sale_line_id'):
-            if move.sale_line_id:
-                values['sale_line_ids'] = [(6, 0, [move.sale_line_id.id])]
+
         values = self._simulate_invoice_line_onchange(values, price_unit=price)
         values.update({'name': name})
         return values


### PR DESCRIPTION
Relation with fields purchase_id, purchase_line_id and sale_line_id will fail in Group Pickings cases, because in this case the code get the FIRST Picking https://github.com/OCA/account-invoicing/blob/12.0/stock_picking_invoicing/wizards/stock_invoice_onshipping.py#L316 and Move https://github.com/OCA/account-invoicing/blob/12.0/stock_picking_invoicing/wizards/stock_invoice_onshipping.py#L408 so the relation will be made with just one line or purchase what is wrong.

For now I think the module don't should solve this problem, it was made for just create Invoice from Picking, so the  implementation should be made in another module, for example in localizations modules because in some cases by Fiscal Position/Operation or different Prices the Group Picking not be possible and can be restrict https://github.com/OCA/account-invoicing/blob/12.0/stock_picking_invoicing/wizards/stock_invoice_onshipping.py#L480

cc @renatonlima @rvalyi @marcelsavegnago @josepmy @mileo @gabrielcardoso21