### PR TITLE
[12.0][FIX] Pickings with same Partner to create Invoice but the Partner to Shipping is different should not be grouping.

### DIFF
--- a/stock_picking_invoicing/wizards/stock_invoice_onshipping.py
+++ b/stock_picking_invoicing/wizards/stock_invoice_onshipping.py
@@ -270,7 +270,10 @@ class StockInvoiceOnshipping(models.TransientModel):
         """
         key = picking
         if self.group in ['partner', 'partner_product']:
-            key = (picking._get_partner_to_invoice(), picking.picking_type_id)
+            # Pickings with same Partner to create Invoice but the
+            # Partner to Shipping is different should not be grouping.
+            key = (picking._get_partner_to_invoice(), picking.picking_type_id,
+                   picking.partner_id)
         return key
 
     @api.multi


### PR DESCRIPTION
Pickings with same Partner to create Invoice but the Partner to Shipping is different should not be grouping.

cc @renatonlima @rvalyi @marcelsavegnago 