### PR TITLE
[12.0] ADD account_payment_term_date_range

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,10 @@ env:
 
   matrix:
   - LINT_CHECK="1"
-  - TESTS="1" ODOO_REPO="OCA/OCB"
-  - TESTS="1" ODOO_REPO="odoo/odoo" MAKEPOT="1"
+  - TESTS="1" ODOO_REPO="OCA/OCB" EXCLUDE="account_payment_term_date_range"
+  - TESTS="1" ODOO_REPO="OCA/OCB" INCLUDE="account_payment_term_date_range"
+  - TESTS="1" ODOO_REPO="odoo/odoo" MAKEPOT="1" EXCLUDE="account_payment_term_date_range"
+  - TESTS="1" ODOO_REPO="odoo/odoo" MAKEPOT="1" INCLUDE="account_payment_term_date_range"
 
 
 install:

--- a/account_payment_term_date_range/__init__.py
+++ b/account_payment_term_date_range/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/account_payment_term_date_range/__manifest__.py
+++ b/account_payment_term_date_range/__manifest__.py
@@ -1,0 +1,28 @@
+# Copyright 2021 Lorenzo Battistini @ TAKOBI
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+{
+    "name": "Payment term - date ranges",
+    "summary": "Payment terms based on date ranges",
+    "version": "12.0.1.0.0",
+    "development_status": "Beta",
+    "category": "Accounting & Finance",
+    "website": "https://github.com/OCA/account-invoicing",
+    "author": "TAKOBI, Odoo Community Association (OCA)",
+    "maintainers": ["eLBati"],
+    "license": "LGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": [
+        "account",
+    ],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/payment_term_views.xml",
+    ],
+    "demo": [
+        "demo/account_demo.xml",
+    ],
+    "excludes": [
+        "account_payment_term_extension",  # due to its override of "compute"
+    ],
+}

--- a/account_payment_term_date_range/demo/account_demo.xml
+++ b/account_payment_term_date_range/demo/account_demo.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!--
+    1° quarter > 20 May
+    2° quarter > 20 August
+    3° quarter > 20 November
+    4° quarter > 20 February
+    -->
+    <record id="account_payment_term_date_ranges" model="account.payment.term">
+        <field name="name">Term based on date ranges</field>
+        <field name="line_ids" eval="[
+            (0, 0, {'value': 'balance', 'value_amount': 0.0, 'sequence': 10, 'based_on_date_ranges': True, 'date_range_ids': [
+                (0, 0, {
+                    'start_date_day': 1,
+                    'start_date_month': '01',
+                    'end_date_day': 31,
+                    'end_date_month': '03',
+                    'due_date_day': 20,
+                    'due_date_month': '05',
+                }),
+                (0, 0, {
+                    'start_date_day': 1,
+                    'start_date_month': '04',
+                    'end_date_day': 30,
+                    'end_date_month': '06',
+                    'due_date_day': 20,
+                    'due_date_month': '08',
+                }),
+                (0, 0, {
+                    'start_date_day': 1,
+                    'start_date_month': '07',
+                    'end_date_day': 30,
+                    'end_date_month': '09',
+                    'due_date_day': 20,
+                    'due_date_month': '09',
+                }),
+                (0, 0, {
+                    'start_date_day': 1,
+                    'start_date_month': '10',
+                    'end_date_day': 31,
+                    'end_date_month': '12',
+                    'due_date_day': 20,
+                    'due_date_month': '02',
+                }),
+            ]})
+        ]"/>
+    </record>
+</odoo>

--- a/account_payment_term_date_range/i18n/it.po
+++ b/account_payment_term_date_range/i18n/it.po
@@ -1,0 +1,229 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_payment_term_date_range
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-02-18 13:26+0000\n"
+"PO-Revision-Date: 2021-02-18 13:26+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_payment_term_date_range
+#: model_terms:ir.ui.view,arch_db:account_payment_term_date_range.view_payment_term_line_form_dr
+msgid "&amp;nbsp;"
+msgstr ""
+
+#. module: account_payment_term_date_range
+#: model_terms:ir.ui.view,arch_db:account_payment_term_date_range.view_payment_term_line_form_dr
+msgid "> Due date"
+msgstr "> Scadenza"
+
+#. module: account_payment_term_date_range
+#: selection:account.payment.term.line.date.range,due_date_month:0
+#: selection:account.payment.term.line.date.range,end_date_month:0
+#: selection:account.payment.term.line.date.range,start_date_month:0
+msgid "April"
+msgstr "Aprile"
+
+#. module: account_payment_term_date_range
+#: selection:account.payment.term.line.date.range,due_date_month:0
+#: selection:account.payment.term.line.date.range,end_date_month:0
+#: selection:account.payment.term.line.date.range,start_date_month:0
+msgid "August"
+msgstr "Agosto"
+
+#. module: account_payment_term_date_range
+#: model:ir.model.fields,field_description:account_payment_term_date_range.field_account_payment_term_line__based_on_date_ranges
+msgid "Based on date ranges"
+msgstr "Basato su intervalli di date"
+
+#. module: account_payment_term_date_range
+#: model:ir.model.fields,field_description:account_payment_term_date_range.field_account_payment_term_line_date_range__create_uid
+msgid "Created by"
+msgstr "Creato da"
+
+#. module: account_payment_term_date_range
+#: model:ir.model.fields,field_description:account_payment_term_date_range.field_account_payment_term_line_date_range__create_date
+msgid "Created on"
+msgstr "Creato il"
+
+#. module: account_payment_term_date_range
+#: model:ir.model.fields,field_description:account_payment_term_date_range.field_account_payment_term_line__date_range_ids
+msgid "Date ranges for due date"
+msgstr "Intervalli di date per la scadenza"
+
+#. module: account_payment_term_date_range
+#: selection:account.payment.term.line.date.range,due_date_month:0
+#: selection:account.payment.term.line.date.range,end_date_month:0
+#: selection:account.payment.term.line.date.range,start_date_month:0
+msgid "December"
+msgstr "Dicembre"
+
+#. module: account_payment_term_date_range
+#: model:ir.model.fields,field_description:account_payment_term_date_range.field_account_payment_term_line_date_range__display_name
+msgid "Display Name"
+msgstr "Nome visualizzato"
+
+#. module: account_payment_term_date_range
+#: model:ir.model.fields,field_description:account_payment_term_date_range.field_account_payment_term_line_date_range__due_date_day
+msgid "Due date day"
+msgstr "Giorno scadenza"
+
+#. module: account_payment_term_date_range
+#: model:ir.model.fields,field_description:account_payment_term_date_range.field_account_payment_term_line_date_range__due_date_month
+msgid "Due date month"
+msgstr "Mese scadenza"
+
+#. module: account_payment_term_date_range
+#: model:ir.model.fields,field_description:account_payment_term_date_range.field_account_payment_term_line_date_range__end_date_day
+msgid "End date day"
+msgstr "Giorno fine"
+
+#. module: account_payment_term_date_range
+#: model:ir.model.fields,field_description:account_payment_term_date_range.field_account_payment_term_line_date_range__end_date_month
+msgid "End date month"
+msgstr "Mese fine"
+
+#. module: account_payment_term_date_range
+#: selection:account.payment.term.line.date.range,due_date_month:0
+#: selection:account.payment.term.line.date.range,end_date_month:0
+#: selection:account.payment.term.line.date.range,start_date_month:0
+msgid "February"
+msgstr "Febbraio"
+
+#. module: account_payment_term_date_range
+#: model_terms:ir.ui.view,arch_db:account_payment_term_date_range.view_payment_term_line_form_dr
+msgid "From"
+msgstr "Da"
+
+#. module: account_payment_term_date_range
+#: model:ir.model.fields,field_description:account_payment_term_date_range.field_account_payment_term_line_date_range__id
+msgid "ID"
+msgstr ""
+
+#. module: account_payment_term_date_range
+#: selection:account.payment.term.line.date.range,due_date_month:0
+#: selection:account.payment.term.line.date.range,end_date_month:0
+#: selection:account.payment.term.line.date.range,start_date_month:0
+msgid "January"
+msgstr "Gennaio"
+
+#. module: account_payment_term_date_range
+#: selection:account.payment.term.line.date.range,due_date_month:0
+#: selection:account.payment.term.line.date.range,end_date_month:0
+#: selection:account.payment.term.line.date.range,start_date_month:0
+msgid "July"
+msgstr "Luglio"
+
+#. module: account_payment_term_date_range
+#: selection:account.payment.term.line.date.range,due_date_month:0
+#: selection:account.payment.term.line.date.range,end_date_month:0
+#: selection:account.payment.term.line.date.range,start_date_month:0
+msgid "June"
+msgstr "Giugno"
+
+#. module: account_payment_term_date_range
+#: model:ir.model.fields,field_description:account_payment_term_date_range.field_account_payment_term_line_date_range____last_update
+msgid "Last Modified on"
+msgstr "Ultima modifica il"
+
+#. module: account_payment_term_date_range
+#: model:ir.model.fields,field_description:account_payment_term_date_range.field_account_payment_term_line_date_range__write_uid
+msgid "Last Updated by"
+msgstr "Ultimo aggiornamento di"
+
+#. module: account_payment_term_date_range
+#: model:ir.model.fields,field_description:account_payment_term_date_range.field_account_payment_term_line_date_range__write_date
+msgid "Last Updated on"
+msgstr "Ultimo aggiornamento il"
+
+#. module: account_payment_term_date_range
+#: selection:account.payment.term.line.date.range,due_date_month:0
+#: selection:account.payment.term.line.date.range,end_date_month:0
+#: selection:account.payment.term.line.date.range,start_date_month:0
+msgid "March"
+msgstr "Marzo"
+
+#. module: account_payment_term_date_range
+#: selection:account.payment.term.line.date.range,due_date_month:0
+#: selection:account.payment.term.line.date.range,end_date_month:0
+#: selection:account.payment.term.line.date.range,start_date_month:0
+msgid "May"
+msgstr "Maggio"
+
+#. module: account_payment_term_date_range
+#: selection:account.payment.term.line.date.range,due_date_month:0
+#: selection:account.payment.term.line.date.range,end_date_month:0
+#: selection:account.payment.term.line.date.range,start_date_month:0
+msgid "November"
+msgstr "Novembre"
+
+#. module: account_payment_term_date_range
+#: selection:account.payment.term.line.date.range,due_date_month:0
+#: selection:account.payment.term.line.date.range,end_date_month:0
+#: selection:account.payment.term.line.date.range,start_date_month:0
+msgid "October"
+msgstr "Ottobre"
+
+#. module: account_payment_term_date_range
+#: model:ir.model,name:account_payment_term_date_range.model_account_payment_term
+msgid "Payment Terms"
+msgstr "Termini di pagamento"
+
+#. module: account_payment_term_date_range
+#: model:ir.model,name:account_payment_term_date_range.model_account_payment_term_line
+msgid "Payment Terms Line"
+msgstr "Riga termini di pagamento"
+
+#. module: account_payment_term_date_range
+#: model:ir.model.fields,field_description:account_payment_term_date_range.field_account_payment_term_line_date_range__term_line_id
+msgid "Payment term line"
+msgstr "Riga termine di pagamento"
+
+#. module: account_payment_term_date_range
+#: model:ir.model,name:account_payment_term_date_range.model_account_payment_term_line_date_range
+msgid "Payment term line date range"
+msgstr "Intervallo date riga termine di pagamento"
+
+#. module: account_payment_term_date_range
+#: selection:account.payment.term.line.date.range,due_date_month:0
+#: selection:account.payment.term.line.date.range,end_date_month:0
+#: selection:account.payment.term.line.date.range,start_date_month:0
+msgid "September"
+msgstr "Settembre"
+
+#. module: account_payment_term_date_range
+#: model:ir.model.fields,help:account_payment_term_date_range.field_account_payment_term_line__date_range_ids
+msgid "Setting a date range here allows to establish the corresponding due date when payment must be done.\n"
+"Example: from 1 Jan to 31 Mar > due date 20 May"
+msgstr "Impostare qui un intervallo di date permette to stabilire la corrispondente scadenza in cui il pagamento deve essere fatto.\n"
+"Esempio: dal 1 Gen al 31 Mar > scadenza 20 Mag"
+
+#. module: account_payment_term_date_range
+#: model:ir.model.fields,field_description:account_payment_term_date_range.field_account_payment_term_line_date_range__start_date_day
+msgid "Start date day"
+msgstr "Giorno inizio"
+
+#. module: account_payment_term_date_range
+#: model:ir.model.fields,field_description:account_payment_term_date_range.field_account_payment_term_line_date_range__start_date_month
+msgid "Start date month"
+msgstr "Mese inizio"
+
+#. module: account_payment_term_date_range
+#: code:addons/account_payment_term_date_range/models/account_payment_term.py:28
+#, python-format
+msgid "Term %s: every line must have date ranges."
+msgstr "Termine %s: ogni riga deve avere intervalli di date."
+
+#. module: account_payment_term_date_range
+#: model_terms:ir.ui.view,arch_db:account_payment_term_date_range.view_payment_term_line_form_dr
+msgid "To"
+msgstr "A"
+

--- a/account_payment_term_date_range/models/__init__.py
+++ b/account_payment_term_date_range/models/__init__.py
@@ -1,0 +1,1 @@
+from . import account_payment_term

--- a/account_payment_term_date_range/models/account_payment_term.py
+++ b/account_payment_term_date_range/models/account_payment_term.py
@@ -1,0 +1,115 @@
+from odoo import _, api, exceptions, fields, models
+from datetime import datetime
+
+MONTHS_SELECTION = [
+    ('01', 'January'), ('02', 'February'), ('03', 'March'), ('04', 'April'),
+    ('05', 'May'), ('06', 'June'), ('07', 'July'), ('08', 'August'),
+    ('09', 'September'), ('10', 'October'), ('11', 'November'), ('12', 'December')
+]
+
+
+class PaymentTerm(models.Model):
+    _inherit = "account.payment.term"
+
+    def date_ranges_are_present(self):
+        for line in self.line_ids:
+            if line.based_on_date_ranges and line.date_range_ids:
+                return True
+        return False
+
+    @api.multi
+    @api.constrains("line_ids")
+    def _check_date_ranges(self):
+        for term in self:
+            if term.date_ranges_are_present():
+                for line in term.line_ids:
+                    if not line.date_range_ids:
+                        raise exceptions.ValidationError(
+                            _("Term %s: every line must have date ranges."))
+
+    @api.one
+    def compute(self, value, date_ref=False):
+        if not self.date_ranges_are_present():
+            # we must use [0] because of api.one
+            return super(PaymentTerm, self).compute(value, date_ref)[0]
+        date_ref = date_ref or fields.Date.today()
+        amount = value
+        sign = value < 0 and -1 or 1
+        result = []
+        if self.env.context.get('currency_id'):
+            currency = self.env['res.currency'].browse(self.env.context['currency_id'])
+        else:
+            currency = self.env.user.company_id.currency_id
+        for line in self.line_ids:
+            if line.value == 'fixed':
+                amt = sign * currency.round(line.value_amount)
+            elif line.value == 'percent':
+                amt = currency.round(value * (line.value_amount / 100.0))
+            elif line.value == 'balance':
+                amt = currency.round(amount)
+            if amt:
+                next_date = fields.Date.from_string(date_ref)
+                next_date = line.apply_date_ranges_days(next_date)
+                result.append((fields.Date.to_string(next_date), amt))
+                amount -= amt
+        amount = sum(amt for _, amt in result)
+        dist = currency.round(value - amount)
+        if dist:
+            last_date = result and result[-1][0] or fields.Date.today()
+            result.append((last_date, dist))
+        return result
+
+
+class AccountPaymentTermLine(models.Model):
+    _inherit = "account.payment.term.line"
+
+    date_range_ids = fields.One2many(
+        "account.payment.term.line.date.range", "term_line_id",
+        "Date ranges for due date",
+        help="Setting a date range here allows to establish the corresponding due "
+             "date when payment must be done.\nExample: "
+             "from 1 Jan to 31 Mar > due date 20 May")
+    based_on_date_ranges = fields.Boolean("Based on date ranges")
+
+    def apply_date_ranges_days(self, date):
+        """Calculate the new date acording to date ranges"""
+        for dr in self.date_range_ids:
+            due_date = dr.get_appliable_due_date(date)
+            if due_date:
+                return due_date
+        return date
+
+
+class AccountPaymentTermLineDateRange(models.Model):
+    _name = "account.payment.term.line.date.range"
+    _description = "Payment term line date range"
+    _rec_name = "due_date_month"
+
+    due_date_day = fields.Integer("Due date day", required=True)
+    due_date_month = fields.Selection(
+        MONTHS_SELECTION, "Due date month", required=True)
+    start_date_day = fields.Integer("Start date day", required=True, default=1)
+    start_date_month = fields.Selection(
+        MONTHS_SELECTION, "Start date month", required=True, default="01")
+    end_date_day = fields.Integer("End date day", required=True)
+    end_date_month = fields.Selection(
+        MONTHS_SELECTION, "End date month", required=True)
+    term_line_id = fields.Many2one(
+        "account.payment.term.line", "Payment term line", ondelete="cascade")
+
+    def get_appliable_due_date(self, date):
+        current_year = date.year
+        start_date = datetime(
+            current_year, int(self.start_date_month), self.start_date_day).date()
+        end_date = datetime(
+            current_year, int(self.end_date_month), self.end_date_day).date()
+        if end_date >= date >= start_date:
+            due_date = datetime(
+                current_year, int(self.due_date_month), self.due_date_day).date()
+            if due_date < date:
+                due_date = datetime(
+                    current_year + 1, int(self.due_date_month), self.due_date_day
+                ).date()
+            return due_date
+        else:
+            return False

--- a/account_payment_term_date_range/readme/CONFIGURE.rst
+++ b/account_payment_term_date_range/readme/CONFIGURE.rst
@@ -1,0 +1,3 @@
+- Open a payment term
+- Add a line selecting "Based on date ranges"
+- Set date range and due date

--- a/account_payment_term_date_range/readme/CONTRIBUTORS.rst
+++ b/account_payment_term_date_range/readme/CONTRIBUTORS.rst
@@ -1,0 +1,5 @@
+* `TAKOBI <https://takobi.online/>`_:
+
+  * Lorenzo Battistini
+
+* `Advanced informatics & Research <https://www.air.co.it>`_

--- a/account_payment_term_date_range/readme/DESCRIPTION.rst
+++ b/account_payment_term_date_range/readme/DESCRIPTION.rst
@@ -1,0 +1,10 @@
+This module extends the payment terms computation allowing to base them on date ranges.
+
+The typical use case:
+
+- Date in 1° quarter --> due date in specific day of May
+- Date in 2° quarter --> due date in specific day of August
+- Date in 3° quarter --> due date in specific day of November
+- Date in 4° quarter --> due date in specific day of February (next year)
+
+See demo data for the example.

--- a/account_payment_term_date_range/security/ir.model.access.csv
+++ b/account_payment_term_date_range/security/ir.model.access.csv
@@ -1,0 +1,4 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_account_payment_term_line_date_range,account.payment.term.line_date_range,model_account_payment_term_line_date_range,account.group_account_user,1,0,0,0
+access_account_payment_term_line_date_range_manager,account.payment.term.line_date_range,model_account_payment_term_line_date_range,account.group_account_manager,1,1,1,1
+access_account_payment_term_line_date_range_partner_manager,account.payment.term.line_date_range partner manager,model_account_payment_term_line_date_range,base.group_user,1,0,0,0

--- a/account_payment_term_date_range/tests/__init__.py
+++ b/account_payment_term_date_range/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_payment_term_date_ranges

--- a/account_payment_term_date_range/tests/test_payment_term_date_ranges.py
+++ b/account_payment_term_date_range/tests/test_payment_term_date_ranges.py
@@ -1,0 +1,83 @@
+import odoo.tests.common as common
+from odoo import fields, exceptions
+
+
+class TestAccountPaymentTermDateRanges(common.TransactionCase):
+
+    def setUp(self):
+        super(TestAccountPaymentTermDateRanges, self).setUp()
+        self.invoice_model = self.env['account.invoice']
+        journal_model = self.env['account.journal']
+        self.journal = journal_model.search([('type', '=', 'purchase')])
+        self.partner = self.env.ref('base.res_partner_3')
+        self.product = self.env.ref('product.product_product_5')
+        self.prod_account = self.env.ref('account.demo_coffee_machine_account')
+        self.inv_account = self.env.ref('account.demo_sale_of_land_account')
+        self.payment_term = self.env.ref(
+            "account_payment_term_date_range.account_payment_term_date_ranges")
+
+    def test_invoice_normal_payment_term(self):
+
+        invoice = self.invoice_model.create(
+            {'journal_id': self.journal.id,
+             'partner_id': self.partner.id,
+             'account_id': self.inv_account.id,
+             'payment_term_id': self.payment_term.id,
+             'date_invoice': '%s-01-01' % fields.datetime.now().year,
+             'type': 'in_invoice',
+             'invoice_line_ids': [(0, 0, {'product_id': self.product.id,
+                                          'name': 'Test',
+                                          'quantity': 10.0,
+                                          'price_unit': 100.00,
+                                          'account_id': self.prod_account.id,
+                                          })],
+             })
+        invoice.action_invoice_open()
+        self.assertEqual(
+            invoice.date_due,
+            fields.Date.to_date('%s-05-20' % fields.datetime.now().year))
+
+        invoice = self.invoice_model.create(
+            {'journal_id': self.journal.id,
+             'partner_id': self.partner.id,
+             'account_id': self.inv_account.id,
+             'payment_term_id': self.payment_term.id,
+             'date_invoice': '%s-06-30' % fields.datetime.now().year,
+             'type': 'in_invoice',
+             'invoice_line_ids': [(0, 0, {'product_id': self.product.id,
+                                          'name': 'Test',
+                                          'quantity': 10.0,
+                                          'price_unit': 100.00,
+                                          'account_id': self.prod_account.id,
+                                          })],
+             })
+        invoice.action_invoice_open()
+        self.assertEqual(
+            invoice.date_due,
+            fields.Date.to_date('%s-08-20' % fields.datetime.now().year))
+
+        invoice = self.invoice_model.create(
+            {'journal_id': self.journal.id,
+             'partner_id': self.partner.id,
+             'account_id': self.inv_account.id,
+             'payment_term_id': self.payment_term.id,
+             'date_invoice': '%s-11-30' % fields.datetime.now().year,
+             'type': 'in_invoice',
+             'invoice_line_ids': [(0, 0, {'product_id': self.product.id,
+                                          'name': 'Test',
+                                          'quantity': 10.0,
+                                          'price_unit': 100.00,
+                                          'account_id': self.prod_account.id,
+                                          })],
+             })
+        invoice.action_invoice_open()
+        self.assertEqual(
+            invoice.date_due,
+            fields.Date.to_date('%s-02-20' % (fields.datetime.now().year + 1)))
+
+        with self.assertRaises(exceptions.ValidationError):
+            self.payment_term.line_ids = [
+                (0, 0, {
+                    'value': 'percent', 'value_amount': 30.0, 'sequence': 5,
+                    'days': 0, 'option': 'day_after_invoice_date'})
+            ]

--- a/account_payment_term_date_range/views/payment_term_views.xml
+++ b/account_payment_term_date_range/views/payment_term_views.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_payment_term_line_form_dr" model="ir.ui.view">
+        <field name="name">view_payment_term_line_form_dr</field>
+        <field name="model">account.payment.term.line</field>
+        <field name="inherit_id" ref="account.view_payment_term_line_form"/>
+        <field name="arch" type="xml">
+            <field name="sequence" position="after">
+                <label for="based_on_date_ranges"/><field name="based_on_date_ranges"/>
+            </field>
+            <xpath expr="/form/div[1]" position="attributes">
+                <attribute name="attrs">{'invisible': [('based_on_date_ranges', '=', True)]}</attribute>
+            </xpath>
+            <xpath expr="/form/div[2]" position="attributes">
+                <attribute name="attrs">{'invisible': ['|', ('option','!=', 'day_after_invoice_date'), ('based_on_date_ranges', '=', True)]}</attribute>
+            </xpath>
+            <xpath expr="/form/div[2]" position="after">
+                <div colspan="2" attrs="{'invisible': [('based_on_date_ranges', '=', False)]}">
+                    <field name="date_range_ids">
+                        <tree>
+                            <field name="due_date_day"/>
+                            <field name="due_date_month"/>
+                        </tree>
+                        <form>
+                            <group>
+                                <label string="From"/>
+                                <div><field name="start_date_day" class="oe_inline" style="max-width:30px;"/>&amp;nbsp;<field name="start_date_month" class="oe_inline" style="height:26px;"/></div>
+                                <label string="To"/>
+                                <div><field name="end_date_day" class="oe_inline" style="max-width:30px;"/>&amp;nbsp;<field name="end_date_month" class="oe_inline" style="height:26px;"/></div>
+                                <label string=" > Due date"/>
+                                <div><field name="due_date_day" class="oe_inline" style="max-width:30px;"/>&amp;nbsp;<field name="due_date_month" class="oe_inline" style="height:26px;"/></div>
+                            </group>
+                        </form>
+                    </field>
+                </div>
+            </xpath>
+        </field>
+    </record>
+    <record id="view_payment_term_line_tree_dr" model="ir.ui.view">
+        <field name="name">view_payment_term_line_tree_dr</field>
+        <field name="model">account.payment.term.line</field>
+        <field name="inherit_id" ref="account.view_payment_term_line_tree"/>
+        <field name="arch" type="xml">
+            <field name="value_amount" position="after">
+                <field name="based_on_date_ranges"/>
+            </field>
+            <field name="days" position="attributes">
+                <attribute name="attrs">{'invisible': [('based_on_date_ranges', '=', True)]}</attribute>
+            </field>
+            <field name="option" position="attributes">
+                <attribute name="attrs">{'invisible': [('based_on_date_ranges', '=', True)]}</attribute>
+            </field>
+            <field name="day_of_the_month" position="attributes">
+                <attribute name="attrs">{'invisible': [('based_on_date_ranges', '=', True)]}</attribute>
+            </field>
+        </field>
+    </record>
+
+</odoo>

--- a/setup/account_payment_term_date_range/odoo/addons/account_payment_term_date_range
+++ b/setup/account_payment_term_date_range/odoo/addons/account_payment_term_date_range
@@ -1,0 +1,1 @@
+../../../../account_payment_term_date_range

--- a/setup/account_payment_term_date_range/setup.py
+++ b/setup/account_payment_term_date_range/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module extends the payment terms computation allowing to base them on date ranges.

The typical use case:

- Date in 1° quarter --> due date in specific day of May
- Date in 2° quarter --> due date in specific day of August
- Date in 3° quarter --> due date in specific day of November
- Date in 4° quarter --> due date in specific day of February (next year)

See demo data for the example.