### PR TITLE
[13.0][FIX] account_invoice_pricelist, fix test currency rate

### DIFF
--- a/account_invoice_pricelist/tests/test_account_move_pricelist.py
+++ b/account_invoice_pricelist/tests/test_account_move_pricelist.py
@@ -218,6 +218,20 @@ class TestAccountMovePricelist(common.SavepointCase):
                 ],
             }
         )
+        # Fix currency rate of EUR -> USD to 1.5289
+        usd_currency = cls.env["res.currency"].search([("name", "=", "USD")])
+        usd_rates = cls.env["res.currency.rate"].search(
+            [("currency_id", "=", usd_currency.id)]
+        )
+        usd_rates.unlink()
+        cls.env["res.currency.rate"].create(
+            {
+                "currency_id": usd_currency.id,
+                "rate": 1.5289,
+                "create_date": "2010-01-01",
+                "write_date": "2010-01-01",
+            }
+        )
 
     def test_account_invoice_pricelist(self):
         self.invoice._onchange_partner_id_account_invoice_pricelist()


### PR DESCRIPTION
Test was failed due to wrong USD currency rate (which I think is the problem of core odoo).

![image](https://user-images.githubusercontent.com/1973598/109747548-e72d7d00-7c09-11eb-94f3-187972740974.png)

![image](https://user-images.githubusercontent.com/1973598/109747561-edbbf480-7c09-11eb-8e1d-132578989f33.png)

This PR ensure that unit test will be using the correct rate.
