### PR TITLE
[13.0][FIX] purchase_stock_picking_return_invoicing create bill

### DIFF
--- a/purchase_stock_picking_return_invoicing/models/purchase_order.py
+++ b/purchase_stock_picking_return_invoicing/models/purchase_order.py
@@ -91,14 +91,16 @@ class PurchaseOrder(models.Model):
     def action_view_invoice(self):
         """Change super action for displaying only normal invoices."""
         result = super(PurchaseOrder, self).action_view_invoice()
+        create_bill = self.env.context.get("create_bill", False)
         invoices = self.invoice_ids.filtered(lambda x: x.type == "in_invoice")
         # choose the view_mode accordingly
-        if len(invoices) != 1:
+        if len(invoices) != 1 and not create_bill:
             result["domain"] = [("id", "in", invoices.ids)]
         elif len(invoices) == 1:
             res = self.env.ref("account.view_move_form", False)
             result["views"] = [(res and res.id or False, "form")]
-            result["res_id"] = invoices.id
+            if not create_bill:
+                result["res_id"] = invoices.id
         return result
 
 


### PR DESCRIPTION
The context key 'create_bill' is currently ignored in the extension of 'action_view_invoice'.
Therefore it is not possible to create new invoices from a purchase order if it is already linked to one 'in_invoice' invoice.

This is an issue when you receive i.e. half of your order and bill this half.
Then when you receive the other half and want to bill it the 'Create bill' button will open the first invoice rather than a new one.