### PR TITLE
[10.0] account_group_invoice_line: don't overwrite name when not needed

### DIFF
--- a/account_group_invoice_line/models/account_invoice.py
+++ b/account_group_invoice_line/models/account_invoice.py
@@ -17,7 +17,10 @@ class AccountInvoice(models.Model):
         if line.get('invoice_id'):
             inv = self.browse(line['invoice_id'])
             jrl = inv.journal_id
-            if jrl.group_invoice_lines and jrl.group_method == 'account':
+            if (
+                    res.get('product_id') and
+                    jrl.group_invoice_lines and
+                    jrl.group_method == 'account'):
                 res['name'] = '/'
                 res['product_id'] = False
         return res


### PR DESCRIPTION
When group_invoice_lines is true on journal and group_method == 'account', only set 'name' of account.move.line to '/' when needed, not on all lines. That way, move lines with customer and supplier account can continue to carry useful information for example.