### PR TITLE
[12.0][IMP] account_global_discount: Set to zero global discount.

### DIFF
--- a/account_global_discount/models/account_invoice.py
+++ b/account_global_discount/models/account_invoice.py
@@ -54,6 +54,8 @@ class AccountInvoice(models.Model):
         """
         self.ensure_one()
         if not self.global_discount_ids:
+            self.amount_global_discount = 0.0
+            self.amount_untaxed_before_global_discounts = 0.0
             return
         invoice_global_discounts = self.env['account.invoice.global.discount']
         taxes_keys = {}
@@ -131,7 +133,9 @@ class AccountInvoice(models.Model):
         return self._onchange_invoice_line_ids()
 
     def _compute_amount_one(self):
-        if not self.invoice_global_discount_ids:
+        if not self.global_discount_ids:
+            self.amount_global_discount = 0.0
+            self.amount_untaxed_before_global_discounts = 0.0
             return
         round_curr = self.currency_id.round
         self.amount_global_discount = sum(


### PR DESCRIPTION
invoice_global_discount_ids is correctly emptied but amount_global_discount and amount_untaxed_before_global_discounts are not being recomputed or set to zero, so the global discount amount is staying on invoice causing incorrect amount.