### PR TITLE
[13.0] [FIX] account_invoice_fiscal_position_update: Filter only lines without comments or notes.

### DIFF
--- a/account_invoice_fiscal_position_update/models/account_invoice.py
+++ b/account_invoice_fiscal_position_update/models/account_invoice.py
@@ -26,7 +26,8 @@ class AccountMove(models.Model):
         lines_without_product = []
         fp = self.fiscal_position_id
         inv_type = self.type
-        for line in self.invoice_line_ids:
+        invoice_lines = self.invoice_line_ids.filtered(lambda l: not l.display_type)
+        for line in invoice_lines:
             if line.product_id:
                 account = line._get_computed_account()
                 product = line.with_context(force_company=self.company_id.id).product_id
@@ -55,7 +56,7 @@ class AccountMove(models.Model):
 
         if lines_without_product:
             res["warning"] = {"title": _("Warning")}
-            if len(lines_without_product) == len(self.invoice_line_ids):
+            if len(lines_without_product) == len(invoice_lines):
                 res["warning"]["message"] = _(
                     "The invoice lines were not updated to the new "
                     "Fiscal Position because they don't have products. "

--- a/account_invoice_pricelist/tests/test_account_move_pricelist.py
+++ b/account_invoice_pricelist/tests/test_account_move_pricelist.py
@@ -215,6 +215,11 @@ class TestAccountMovePricelist(common.SavepointCase):
                             "price_unit": 100.00,
                         },
                     ),
+                    (
+                        0,
+                        0,
+                        {"display_type": "line_section", "name": "Test line section"},
+                    ),
                 ],
             }
         )


### PR DESCRIPTION
Here if you create a note or a comment in the invoice lines, and you change the fpos an error occurs.
After this changes only non display type lines are taking into account.