### PR TITLE
 [FIX] account_invoice_merge: compatibility with account_invoice_margin module (OCA/margin-analysis repository)

### DIFF
--- a/account_invoice_merge/models/account_invoice.py
+++ b/account_invoice_merge/models/account_invoice.py
@@ -28,7 +28,10 @@ class AccountInvoice(models.Model):
             'product_id', 'account_id', 'account_analytic_id',
             'uom_id'
         ]
-        for field in ['sale_line_ids']:
+        for field in [
+                'sale_line_ids',        # odoo/sale
+                'purchase_price',       # OCA/account_invoice_margin
+        ]:
             if field in self.env['account.invoice.line']._fields:
                 fields.append(field)
         return fields


### PR DESCRIPTION
**Context**

When both ``account_invoice_merge`` and ``account_invoice_margin`` (OCA/margin-analysis) are installed, the ``purchase_price`` of ``account.invoice.line`` is lost, when merging invoices, so the invoice (lines) margin are bad.


Ref : apps/deck/#/board/144/card/1401
CC : @quentinDupont 


CC : authors of both modules : @sergio-teruel, @pedrobaeza, @Cedric-Pigeon, @mourad-ehm