### PR TITLE
[FIX] account_global_discount: compute discounts on create

### DIFF
--- a/account_global_discount/models/account_move.py
+++ b/account_global_discount/models/account_move.py
@@ -262,6 +262,16 @@ class AccountMove(models.Model):
         for record in self:
             record._compute_amount_one()
 
+    @api.model_create_multi
+    def create(self, vals_list):
+        """If we create the invoice with the discounts already set like from
+        a sales order, we must compute the global discounts as well"""
+        moves = super().create(vals_list)
+        move_with_global_discounts = moves.filtered("global_discount_ids")
+        for move in move_with_global_discounts:
+            move.with_context(check_move_validity=False)._onchange_invoice_line_ids()
+        return moves
+
 
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"

--- a/account_global_discount/models/account_move.py
+++ b/account_global_discount/models/account_move.py
@@ -9,6 +9,15 @@ from odoo.tools import config
 class AccountMove(models.Model):
     _inherit = "account.move"
 
+    # HACK: Looks like UI doesn't behave well with Many2many fields and
+    # negative groups when the same field is shown. In this case, we want to
+    # show the readonly version to any not in the global discount group.
+    # TODO: Check if it's fixed in future versions
+    global_discount_ids_readonly = fields.Many2many(
+        string="Invoice Global Discounts (readonly)",
+        related="global_discount_ids",
+        readonly=True,
+    )
     global_discount_ids = fields.Many2many(
         comodel_name="global.discount",
         column1="invoice_id",

--- a/account_global_discount/views/account_invoice_views.xml
+++ b/account_global_discount/views/account_invoice_views.xml
@@ -14,6 +14,14 @@
                     name="global_discount_ids"
                     widget="many2many_tags"
                     placeholder="Discounts..."
+                    groups="base_global_discount.group_global_discount"
+                />
+                <field
+                    string="Invoice Global Discounts"
+                    name="global_discount_ids_readonly"
+                    widget="many2many_tags"
+                    readonly="1"
+                    groups="!base_global_discount.group_global_discount"
                 />
             </xpath>
             <field name="amount_untaxed" position="before">

--- a/account_global_discount/views/global_discount_views.xml
+++ b/account_global_discount/views/global_discount_views.xml
@@ -34,6 +34,7 @@
         id="menu_account_global_discount"
         action="base_global_discount.action_global_discount_tree"
         name="Global Discounts"
+        groups="base_global_discount.group_global_discount"
         parent="account.account_management_menu"
     />
 </odoo>


### PR DESCRIPTION
This PR includes-
- [FIX] When we set the global discount on the create method we must ensure that
the move lines are properly recomputed. This is the case for invoices created from sale orders, like in the module `sale_global_discount`.
- [FW][IMP] account_global_discount: security group 37c9c86c90cbd00c72ad03733bd1af6a1763c8b8
- [x] depends on https://github.com/OCA/server-backend/pull/121

cc @Tecnativa TT26936

please review @pedrobaeza 
