### PR TITLE
[FIX] avoid wizard line_ids to directly reference original invoice lines

### DIFF
--- a/account_invoice_refund_line_selection/__manifest__.py
+++ b/account_invoice_refund_line_selection/__manifest__.py
@@ -1,4 +1,5 @@
 # Copyright 2019 Creu Blanca
+# Copyright 2021 César Castañón <cesar.castanon@factorlibre.com>
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
 {

--- a/account_invoice_refund_line_selection/tests/test_refund_line.py
+++ b/account_invoice_refund_line_selection/tests/test_refund_line.py
@@ -1,4 +1,5 @@
 # Copyright 2019 Creu Blanca
+# Copyright 2021 FactorLibre - César Castañón <cesar.castanon@factorlibre.com>
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
 from odoo.tests import common
@@ -13,6 +14,11 @@ class TestInvoiceRefundLine(common.SavepointCase):
         cls.partner = cls.env['res.partner'].create({
             'name': 'Test partner',
         })
+        cls.tax = cls.env['account.tax'].create({
+            'name': 'T1',
+            'amount': 21,
+            'price_include': True
+        })
         default_line_account = cls.env['account.account'].search([
             ('internal_type', '=', 'other'),
             ('deprecated', '=', False),
@@ -21,12 +27,14 @@ class TestInvoiceRefundLine(common.SavepointCase):
         cls.invoice_lines = [(0, False, {
             'name': 'Test description #1',
             'account_id': default_line_account.id,
-            'quantity': 1.0,
+            'quantity': 5.0,
+            'invoice_line_tax_ids': [(6, 0, [cls.tax.id])],
             'price_unit': 100.0,
         }), (0, False, {
             'name': 'Test description #2',
             'account_id': default_line_account.id,
             'quantity': 2.0,
+            'invoice_line_tax_ids': [(6, 0, [cls.tax.id])],
             'price_unit': 25.0,
         })]
         cls.invoice = cls.env['account.invoice'].create({
@@ -36,17 +44,83 @@ class TestInvoiceRefundLine(common.SavepointCase):
         })
         cls.invoice.action_invoice_open()
         cls.refund_reason = 'The refund reason'
+        acc_inv_ref_model = cls.env['account.invoice.refund']
+        fields = [name for name, _ in acc_inv_ref_model._fields.items()]
+        default_vals = acc_inv_ref_model.with_context(
+            active_ids=[cls.invoice.id],
+            active_id=cls.invoice.id
+        ).default_get(fields)
+        default_vals.update({
+            'filter_refund': 'refund_lines',
+            'description': cls.refund_reason,
+        })
         cls.refund = cls.env['account.invoice.refund'].with_context(
-            active_ids=cls.invoice.ids).create({
-                'filter_refund': 'refund_lines',
-                'description': cls.refund_reason,
-                'line_ids': [(6, 0, cls.invoice.invoice_line_ids[0].ids)]
-            })
+            active_ids=[cls.invoice.id],
+            active_id=cls.invoice.id).create(default_vals)
+        cls.refund.update({
+            'line_ids': [
+                (6, 0, cls.refund.selectable_invoice_lines_ids[0].ids)
+            ]
+        })
 
-    def test_refund_line(self):
+    def test_refund_line_unmodified(self):
         self.refund.invoice_refund()
         self.assertTrue(self.invoice.refund_invoice_ids)
         refund = self.invoice.refund_invoice_ids[0]
-        self.assertTrue(len(refund.invoice_line_ids), 1)
-        self.assertTrue(refund.invoice_line_ids[0].name,
-                        self.invoice.invoice_line_ids[0].name)
+        self.assertEqual(
+            len(refund.invoice_line_ids),
+            1,
+            "The line in the refund invoice is missing"
+        )
+        invoice_line = self.invoice.invoice_line_ids[0]
+        refund_invoice_line = refund.invoice_line_ids[0]
+        self.assertEqual(
+            refund.invoice_line_ids[0].name,
+            invoice_line.name,
+            "The refund invoice is not properly linked to it's parent invoice"
+        )
+        fields_to_check = [
+            'name', 'account_id', 'product_id', 'quantity', 'price_unit',
+            'discount', 'invoice_line_tax_ids', 'price_subtotal',
+        ]
+        for attr in fields_to_check:
+            self.assertEqual(
+                getattr(refund_invoice_line, attr),
+                getattr(invoice_line, attr),
+                "Copy data didn't work. Values between invoice line and refund "
+                "line aren't equal"
+            )
+
+    def test_refund_line_mod_qty(self):
+        self.refund.line_ids[0].update({
+            'quantity': 3
+        })
+        self.refund.invoice_refund()
+        self.assertEqual(
+            self.invoice.invoice_line_ids[0].quantity,
+            5,
+            "Quantity should have been updated "
+        )
+        refund_inv_id = self.invoice.refund_invoice_ids[0]
+        self.assertEqual(
+            refund_inv_id.invoice_line_ids[0].quantity,
+            3,
+            "Quantity should have been updated "
+        )
+
+    def test_refund_line_mod_discount(self):
+        self.refund.line_ids[0].update({
+            'discount': 10.0
+        })
+        self.refund.invoice_refund()
+        self.assertEqual(
+            self.invoice.invoice_line_ids[0].discount,
+            0,
+            "Quantity should have been updated "
+        )
+        refund_inv_id = self.invoice.refund_invoice_ids[0]
+        self.assertEqual(
+            refund_inv_id.invoice_line_ids[0].discount,
+            10.0,
+            "Quantity should have been updated "
+        )

--- a/account_invoice_refund_line_selection/wizards/__init__.py
+++ b/account_invoice_refund_line_selection/wizards/__init__.py
@@ -1,1 +1,2 @@
 from . import account_invoice_refund
+from . import account_invoice_refund_line

--- a/account_invoice_refund_line_selection/wizards/account_invoice_refund_line.py
+++ b/account_invoice_refund_line_selection/wizards/account_invoice_refund_line.py
@@ -1,0 +1,65 @@
+# Copyright 2021 FactorLibre - César Castañón <cesar.castanon@factorlibre.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+from odoo.addons import decimal_precision as dp
+
+
+class AccountInvoiceRefundLine(models.TransientModel):
+    _name = 'account.invoice.refund.line'
+
+    name = fields.Char(
+        string="Name",
+    )
+
+    sequence = fields.Integer(
+        default=10,
+    )
+
+    invoice_id = fields.Many2one(
+        comodel_name='account.invoice',
+        string='Account Invoice',
+        readonly=True,
+    )
+
+    product_id = fields.Many2one(
+        comodel_name='product.product',
+        string='Product',
+    )
+
+    quantity = fields.Float(
+        string="Quantity",
+        digits=dp.get_precision('Product Unit of Measure'),
+    )
+
+    price_unit = fields.Float(
+        string="Price Unit",
+        digits=dp.get_precision('Product Unit of Measure'),
+    )
+
+    discount = fields.Float(
+        string="Discount",
+        digits=dp.get_precision('Discount')
+    )
+
+    invoice_line_tax_ids = fields.Many2many(
+        comodel_name='account.tax',
+        string='Invoice Line Tax'
+    )
+
+    price_subtotal = fields.Float(
+        string="Price Subtotal",
+        digits=dp.get_precision('Product Unit of Measure'),
+    )
+
+    refund_invoice_id = fields.Many2one(
+        comodel_name='account.invoice.refund',
+        string='Invoice Refund Reference',
+        ondelete='cascade',
+        index=True,
+    )
+
+    origin_line_id = fields.Many2one(
+        comodel_name='account.invoice.line',
+        string='Original Invoice Line',
+    )

--- a/account_invoice_refund_line_selection/wizards/account_invoice_refund_view.xml
+++ b/account_invoice_refund_line_selection/wizards/account_invoice_refund_view.xml
@@ -3,29 +3,29 @@
     <record id="view_account_invoice_refund_lines" model="ir.ui.view">
         <field name="name">account.invoice.refund.lines.form</field>
         <field name="model">account.invoice.refund</field>
-        <field name="inherit_id" ref="account.view_account_invoice_refund"/>
+        <field name="inherit_id" ref="account.view_account_invoice_refund" />
         <field name="arch" type="xml">
             <xpath expr="//footer" position="before">
                 <notebook attrs="{'invisible': [('filter_refund', '!=', 'refund_lines')]}">
                     <page string="Invoice Lines">
-                        <field name="selectable_invoice_lines_ids" invisible="1"/>
+                        <field name="selectable_invoice_lines_ids" invisible="1" />
                         <field name="line_ids">
-                            <tree string="Invoice Lines">
+                            <tree string="Invoice Lines" editable="bottom" >
                                 <field name="sequence" widget="handle" />
-                                <field name="product_id"/>
-                                <field name="name"/>
-                                <field name="quantity"/>
-                                <field name="discount"/>
-                                <field name="invoice_line_tax_ids"/>
-                                <field name="price_unit"/>
-                                <field name="price_subtotal"/>
+                                <field name="product_id" readonly="1"/>
+                                <field name="name" readonly="1"/>
+                                <field name="quantity" />
+                                <field name="discount" readonly="1" />
+                                <field name="invoice_line_tax_ids" />
+                                <field name="price_unit" readonly="1" />
+                                <field name="price_subtotal" />
                             </tree>
                         </field>
                     </page>
                 </notebook>
             </xpath>
             <xpath expr="//group/div[2]" position="after">
-            <div attrs="{'invisible':['|',('refund_only','=',True),('filter_refund','!=','refund_lines')]}" class="oe_grey" colspan="4">
+                <div attrs="{'invisible':['|',('refund_only','=',True),('filter_refund','!=','refund_lines')]}" class="oe_grey" colspan="4">
                 Use this option if you want to refund only some specific lines in an invoice.
             </div>
             </xpath>


### PR DESCRIPTION
The `account.invoice.refund` wizard allows the user to pick and edit the lines that will be included in the refund invoice, but inadvertedly the user is updating lines from the original invoice. 
PR changes resume:
- Creates a new model (`account.invoice.refund.line`) for the refund wizard lines.
- Blocks edition in the view except for `quantity` field
- Transfer changes made on the wizard to the refund values before invoice
  creation.
- Doesn't change wizard structure or interface, except by adding a new parameter to the method `refund_partial`, created at `account.invoice.refund`.