### PR TITLE
[FIX] account_invoice_refund_link: index origin_line_id

### DIFF
--- a/account_invoice_refund_link/models/account_move.py
+++ b/account_invoice_refund_link/models/account_move.py
@@ -38,6 +38,7 @@ class AccountInvoiceLine(models.Model):
         string="Original invoice line",
         help="Original invoice line to which this refund invoice line "
         "is referred to",
+        index=True,
         copy=False,
     )
     refund_line_ids = fields.One2many(


### PR DESCRIPTION
When canceling reconciliations, not having this index slows things down too much.

TT28595