### PR TITLE
[FIX] account_invoice_fiscal_position_update: Mark to recompute line for taxes when change fpos

### DIFF
--- a/account_invoice_fiscal_position_update/models/account_invoice.py
+++ b/account_invoice_fiscal_position_update/models/account_invoice.py
@@ -48,11 +48,12 @@ class AccountMove(models.Model):
                     taxes = fp.map_tax(taxes)
 
                 line.tax_ids = [(6, 0, taxes.ids)]
+                line._onchange_mark_recompute_taxes()
 
                 line.account_id = account.id
             else:
                 lines_without_product.append(line.name)
-        self._recompute_dynamic_lines(recompute_tax_base_amount=True)
+        self.with_context(check_move_validity=False)._recompute_dynamic_lines()
 
         if lines_without_product:
             res["warning"] = {"title": _("Warning")}

--- a/account_invoice_pricelist/tests/test_account_move_pricelist.py
+++ b/account_invoice_pricelist/tests/test_account_move_pricelist.py
@@ -193,6 +193,7 @@ class TestAccountMovePricelist(common.SavepointCase):
         cls.invoice = cls.AccountMove.create(
             {
                 "partner_id": cls.partner.id,
+                "fiscal_position_id": cls.fiscal_position.id,
                 "type": "out_invoice",
                 "invoice_line_ids": [
                     (


### PR DESCRIPTION
If you have products with taxes, then when change the fpos, the aml taxes lines currently are not change, after this changes we force to create new aml for the correct taxes.