### PR TITLE
[13.0][FIX] account_invoice_warn_message, calculation when parent has message but partner not

### DIFF
--- a/account_invoice_warn_message/models/account_move.py
+++ b/account_invoice_warn_message/models/account_move.py
@@ -27,7 +27,7 @@ class AccountMove(models.Model):
                     rec.invoice_warn_msg = rec.partner_id.parent_id.invoice_warn_msg
                     if rec.partner_id.invoice_warn == "warning":
                         rec.invoice_warn_msg += "\n%s" % rec.partner_id.invoice_warn_msg
-                        continue
+                    continue
                 elif rec.partner_id.invoice_warn == "warning":
                     rec.invoice_warn_msg = rec.partner_id.invoice_warn_msg
                     continue

--- a/account_invoice_warn_message/tests/test_account_invoice_warn_message.py
+++ b/account_invoice_warn_message/tests/test_account_invoice_warn_message.py
@@ -80,3 +80,30 @@ class TestAccountInvoiceWarnMessage(TransactionCase):
         self.assertEqual(
             invoice.invoice_warn_msg, self.warn_msg_parent + "\n" + self.warn_msg
         )
+
+    def test_compute_invoice_warn_msg_parent_but_not_partner(self):
+        self.partner.update({"invoice_warn": "no-message", "parent_id": self.parent.id})
+        invoice = (
+            self.env["account.move"]
+            .with_context(default_type="out_invoice")
+            .create(
+                {
+                    "type": "out_invoice",
+                    "partner_id": self.partner.id,
+                    "invoice_line_ids": [
+                        (
+                            0,
+                            0,
+                            {
+                                "product_id": self.env.ref(
+                                    "product.product_product_4"
+                                ).id,
+                                "quantity": 1,
+                                "price_unit": 42,
+                            },
+                        ),
+                    ],
+                }
+            )
+        )
+        self.assertEqual(invoice.invoice_warn_msg, self.warn_msg_parent)


### PR DESCRIPTION
Wrong indentation causes the message set to False in case when partner's parent has a message set but the partner itself not.

Should I add a specific test just for that situation? Added.