### PR TITLE
[13.0][IMP]account_move_exception&account_move_post_block

### DIFF
--- a/account_move_exception/views/account_view.xml
+++ b/account_move_exception/views/account_view.xml
@@ -44,21 +44,19 @@
                         /></bold>
                 </div>
             </header>
-            <xpath expr="//page[@id='other_tab']" position="inside">
-                <page id="exception_tab" string="Exceptions">
-                    <field
-                        name="ignore_exception"
-                        states="account"
-                        groups='base_exception.group_exception_rule_manager'
-                    />
-                    <field
-                        name="exception_ids"
-                        widget="many2many_tags"
-                        readonly="True"
-                        attrs="{'invisible': [('exception_ids', 'in', [])]}"
-                    />
-                </page>
-            </xpath>
+            <field name="currency_id" position="after">
+                <field
+                    name="ignore_exception"
+                    states="draft"
+                    groups='base_exception.group_exception_rule_manager'
+                />
+                <field
+                    name="exception_ids"
+                    widget="many2many_tags"
+                    readonly="True"
+                    attrs="{'invisible': [('exception_ids', '=', [])]}"
+                />
+            </field>
         </field>
     </record>
     <record id="view_move_tree" model="ir.ui.view">

--- a/account_move_post_block/data/account_exception_data.xml
+++ b/account_move_post_block/data/account_exception_data.xml
@@ -2,8 +2,9 @@
 <odoo>
     <record id="am_excep_post_block" model="exception.rule">
         <field name="name">Post Blocked</field>
-        <field name="description">The post has been blocked,
-                with a Blocking reason.</field>
+        <field
+            name="description"
+        >The post has been blocked with a Blocking reason</field>
         <field name="sequence">100</field>
         <!-- <field name="rule_group">account</field> -->
         <field name="model">account.move</field>


### PR DESCRIPTION
Minor fixes and improvements:

- account_move_exception: fix view display and make them appear directly in the move form, as the exceptions will be only displayed when there are some.
- account_move_post_block: do not break the description of the created exception for better display (sorry for the nitpicking)