### PR TITLE
[13.0][FIX] sale_order_invoicing_grouping_criteria:

### DIFF
--- a/sale_order_invoicing_grouping_criteria/models/sale_order.py
+++ b/sale_order_invoicing_grouping_criteria/models/sale_order.py
@@ -7,6 +7,16 @@ from odoo import models
 class SaleOrder(models.Model):
     _inherit = "sale.order"
 
+    def _get_grouping_partner(self):
+        """
+        Get the partner who contains the grouping criteria.
+        On sale.order, the default should be the invoice address.
+        If not set, use the partner_id.
+        :return: res.partner recordset
+        """
+        self.ensure_one()
+        return self.partner_invoice_id or self.partner_id
+
     def _get_sale_invoicing_group_key(self):
         """Prepare extended grouping criteria for sales orders."""
         self.ensure_one()
@@ -15,8 +25,9 @@ class SaleOrder(models.Model):
             self.partner_invoice_id.id,
             self.currency_id.id,
         ]
+        partner = self._get_grouping_partner()
         criteria = (
-            self.partner_id.sale_invoicing_grouping_criteria_id
+            partner.sale_invoicing_grouping_criteria_id
             or self.company_id.default_sale_invoicing_grouping_criteria_id
         )
         for field in criteria.field_ids:

--- a/sale_order_invoicing_grouping_criteria/tests/test_sale_order_invoicing_group_criteria.py
+++ b/sale_order_invoicing_grouping_criteria/tests/test_sale_order_invoicing_group_criteria.py
@@ -8,6 +8,7 @@ class TestSaleOrderInvoicingGroupingCriteria(SavepointCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
         cls.partner = cls.env["res.partner"].create({"name": "Test partner"})
         cls.partner2 = cls.env["res.partner"].create({"name": "Other partner"})
         cls.product = cls.env["product.product"].create(


### PR DESCRIPTION
Minor **issue** on `sale_order_invoicing_grouping_criteria`:
- The partner to get the grouping criteria should be the invoice address (if set) as this one will be used to create the invoice;
- Extract this part into a function to have a over-writable point.

**Bonus:**
- Little improvement into unit test: disable tracking.