### PR TITLE
[12.0] [IMP] link purchase order lines to new invoice lines 

### DIFF
--- a/account_invoice_merge/wizard/invoice_merge.py
+++ b/account_invoice_merge/wizard/invoice_merge.py
@@ -26,8 +26,8 @@ class InvoiceMerge(models.TransientModel):
         error_msg = {}
         if len(invoices) != len(invoices._get_draft_invoices()):
             error_msg['state'] = (
-                _('Megeable State (ex : %s)') %
-                (invoices and invoices[0].state or _('Draf')))
+                _('Mergeable State (ex : %s)') %
+                (invoices and invoices[0].state or _('Draft')))
         for field in key_fields:
             if len(set(invoices.mapped(field))) > 1:
                 error_msg[field] = invoices._fields[field].string


### PR DESCRIPTION
previous to this commit, sale order lines were updated to link to the newly created invoice lines, but purchase order lines would still refer to the now cancelled invoices. This commit expands this functionality to update purchase order lines to link to the newly created invoice lines.