### PR TITLE
[13.0][FIX]account_invoice_force_number - unlink constraint

### DIFF
--- a/account_invoice_force_number/models/account_move.py
+++ b/account_invoice_force_number/models/account_move.py
@@ -19,7 +19,7 @@ class AccountMove(models.Model):
 
     def unlink(self):
         for move in self:
-            if move.move_name:
+            if move.move_name and not self.env.context.get("force_delete"):
                 raise UserError(
                     _(
                         """You cannot delete an invoice after it has been validated"""


### PR DESCRIPTION
revert reconciliation from bank statement fails without this fix.