### PR TITLE
[FIX] purchase_stock_picking_return_invoicing: consider context properly

### DIFF
--- a/purchase_stock_picking_return_invoicing/models/purchase_order.py
+++ b/purchase_stock_picking_return_invoicing/models/purchase_order.py
@@ -92,6 +92,8 @@ class PurchaseOrder(models.Model):
     def action_view_invoice(self):
         """Change super action for displaying only normal invoices."""
         result = super(PurchaseOrder, self).action_view_invoice()
+        if self.env.context.get("create_bill", False):
+            return result
         invoices = self.invoice_ids.filtered(
             lambda x: x.type == 'in_invoice'
         )


### PR DESCRIPTION
The top invoicing button uses a context to check if we want to create an
invoice or to view the current ones.

cc @Tecnativa TT30418

please review @pedrobaeza @joao-p-marques 