### PR TITLE
[13.0][FIX+REF] account_global_discount: Include taxes in global discount move lines

### DIFF
--- a/account_global_discount/__manifest__.py
+++ b/account_global_discount/__manifest__.py
@@ -1,9 +1,9 @@
 # Copyright 2019 Tecnativa S.L. - David Vidal
-# Copyright 2020 Tecnativa - Pedro M. Baeza
+# Copyright 2020-2021 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     "name": "Account Global Discount",
-    "version": "13.0.1.1.1",
+    "version": "13.0.2.0.0",
     "category": "Accounting",
     "author": "Tecnativa, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/server-backend",

--- a/account_global_discount/migrations/13.0.2.0.0/post-migration.py
+++ b/account_global_discount/migrations/13.0.2.0.0/post-migration.py
@@ -1,0 +1,46 @@
+# Copyright 2021 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from openupgradelib import openupgrade
+
+from odoo.tools import float_compare
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    """Fill existing global discount entries with the source global discount
+    and missing tax links.
+    """
+    lines = env["account.move.line"].search([("global_discount_item", "=", True)])
+    for line in lines:
+        discount = line.move_id.invoice_global_discount_ids.filtered(
+            lambda x: x.account_id == line.account_id
+            and x.account_analytic_id == line.analytic_account_id
+            and (
+                not float_compare(
+                    x.discount_amount,
+                    line.debit,
+                    precision_rounding=line.move_id.currency_id.rounding,
+                )
+                or not float_compare(
+                    x.discount_amount,
+                    -line.credit,
+                    precision_rounding=line.move_id.currency_id.rounding,
+                )
+            )
+            and x not in line.move_id.line_ids.mapped("invoice_global_discount_id")
+        )[:1]
+        if discount:
+            for tax in line.tax_ids - discount.tax_ids:
+                env.cr.execute(
+                    "DELETE FROM account_move_line_account_tax_rel "
+                    "WHERE account_move_line_id = %s AND account_tax_id = %s ",
+                    (line.id, tax.id),
+                )
+            for tax in discount.tax_ids - line.tax_ids:
+                env.cr.execute(
+                    "INSERT INTO account_move_line_account_tax_rel "
+                    "(account_move_line_id, account_tax_id) VALUES (%s, %s)",
+                    (line.id, tax.id),
+                )
+            # Fill it for existing lines, although this is not working with new ones
+            line.invoice_global_discount_id = discount.id

--- a/account_global_discount/readme/ROADMAP.rst
+++ b/account_global_discount/readme/ROADMAP.rst
@@ -2,3 +2,4 @@
   the generated journal items won't be correct for taxes declarations. An error
   is raised in that cases.
 * Currently, taxes in invoice lines are mandatory with global discounts.
+* No tax tags are populated for the global discount move lines, only `tax_ids`.

--- a/account_global_discount/views/account_invoice_views.xml
+++ b/account_global_discount/views/account_invoice_views.xml
@@ -6,7 +6,9 @@
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_move_form" />
         <field name="arch" type="xml">
+            <!-- For ensuring the storage of these fields -->
             <xpath expr="//field[@name='line_ids']/tree" position="inside">
+                <field name="invoice_global_discount_id" invisible="1" />
                 <field name="global_discount_item" invisible="1" />
             </xpath>
             <xpath expr="//field[@name='invoice_payment_term_id']/.." position="after">
@@ -48,23 +50,19 @@
                     <field
                         name="invoice_global_discount_ids"
                         nolabel="1"
+                        readonly="1"
                         attrs="{'invisible': [('global_discount_ids', '=', [])]}"
                         force_save="1"
                     >
                         <tree create="0" delete="0">
                             <field name="name" />
                             <field name="currency_id" invisible="1" />
-                            <field
-                                name="global_discount_id"
-                                invisible="1"
-                                force_save="1"
-                            />
-                            <field name="discount" invisible="1" force_save="1" />
+                            <field name="global_discount_id" invisible="1" />
+                            <field name="discount" invisible="1" />
                             <field
                                 name="base"
                                 widget="monetary"
                                 options="{'currency_field': 'currency_id'}"
-                                force_save="1"
                             />
                             <field name="discount_display" />
                             <field name="discount_amount" />
@@ -72,16 +70,14 @@
                                 name="base_discounted"
                                 widget="monetary"
                                 options="{'currency_field': 'currency_id'}"
-                                force_save="1"
                             />
-                            <field name="account_id" required="1" force_save="1" />
+                            <field name="account_id" />
                             <field name="tax_ids" widget="many2many_tags" />
                             <field name="company_id" invisible="1" />
                             <field
                                 domain="[('company_id', '=', company_id)]"
                                 name="account_analytic_id"
                                 groups="analytic.group_analytic_accounting"
-                                force_sace="1"
                             />
                         </tree>
                     </field>


### PR DESCRIPTION
Previously, no taxes were populated as base taxes for global discount move lines, which means that the tax reports were incorrect.

The global discount lines + move lines has been injected other way for avoiding inconsistencies, and the rest of the features have been adapted according this.

A migration script is provided as well for filling taxes in existing global discount move lines.

@Tecnativa TT26281