### PR TITLE
[13.0][FIX] account_invoice_tax_required: Restore multi-record support in action_post

### DIFF
--- a/account_invoice_tax_required/models/account_move.py
+++ b/account_invoice_tax_required/models/account_move.py
@@ -44,6 +44,8 @@ class AccountMove(models.Model):
                 config["test_enable"],
             )
         )
-        if self.type != "entry" and (force_test or not skip_test):
-            self._test_invoice_line_tax()
+        if force_test or not skip_test:
+            for record in self:
+                if record.is_invoice():
+                    record._test_invoice_line_tax()
         return super().action_post()


### PR DESCRIPTION
`action_post` should be able to accept a recordset. The core function does it and other implementations do it as well:
https://github.com/odoo/odoo/blob/13.0/addons/account/models/account_move.py#L2350
https://github.com/OCA/purchase-workflow/blob/13.0/purchase_work_acceptance/models/account_move.py#L41

This restores that behavior here to solve integration tests.

@Tecnativa

ping @pedrobaeza @sergio-teruel 