### PR TITLE
[13.0][ADD] account_move_tier_validation_approver

### DIFF
--- a/account_move_tier_validation_approver/__init__.py
+++ b/account_move_tier_validation_approver/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/account_move_tier_validation_approver/__manifest__.py
+++ b/account_move_tier_validation_approver/__manifest__.py
@@ -1,0 +1,16 @@
+# Copyright 2021 ForgeFlow, S.L.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+{
+    "name": "Account Move Tier Validation Approver",
+    "version": "13.0.1.0.0",
+    "author": "ForgeFlow, Odoo Community Association (OCA)",
+    "category": "Accounting",
+    "license": "LGPL-3",
+    "depends": ["account_move_tier_validation"],
+    "data": [
+        "views/account_move_views.xml",
+        "views/res_partner_views.xml",
+        "views/res_config_settings_views.xml",
+    ],
+    "installable": True,
+}

--- a/account_move_tier_validation_approver/models/__init__.py
+++ b/account_move_tier_validation_approver/models/__init__.py
@@ -1,0 +1,4 @@
+from . import account_move
+from . import res_partner
+from . import res_config_settings
+from . import res_company

--- a/account_move_tier_validation_approver/models/account_move.py
+++ b/account_move_tier_validation_approver/models/account_move.py
@@ -1,0 +1,31 @@
+# Copyright 2021 ForgeFlow, S.L.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    approver_id = fields.Many2one("res.users", string="Responsible for Approval")
+
+    @api.onchange("partner_id")
+    def _onchange_partner_approver_id(self):
+        if self.partner_id:
+            self.approver_id = self.partner_id.approver_id.id
+
+    def post(self):
+        for move in self:
+            require_approver_in_vendor_bills = (
+                move.company_id.require_approver_in_vendor_bills
+            )
+            if (
+                move.is_purchase_document(include_receipts=True)
+                and require_approver_in_vendor_bills
+                and not move.approver_id
+            ):
+                raise UserError(
+                    _("It is mandatory to indicate a Responsible for Approval")
+                )
+        return super(AccountMove, self).post()

--- a/account_move_tier_validation_approver/models/res_company.py
+++ b/account_move_tier_validation_approver/models/res_company.py
@@ -1,0 +1,15 @@
+# Copyright 2020 ForgeFlow, S.L.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    require_approver_in_vendor_bills = fields.Boolean(
+        string="Require approver in vendor bills"
+    )
+    validation_approver_tier_definition_id = fields.Many2one(
+        comodel_name="tier.definition", string="Bill approval tier definition"
+    )

--- a/account_move_tier_validation_approver/models/res_config_settings.py
+++ b/account_move_tier_validation_approver/models/res_config_settings.py
@@ -1,0 +1,41 @@
+# Copyright 2020 ForgeFlow, S.L.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    require_approver_in_vendor_bills = fields.Boolean(
+        string="Require Approver In Vendor Bills",
+        help="Requires adding an approver before a vendor bill can be posted.",
+        related="company_id.require_approver_in_vendor_bills",
+        readonly=False,
+    )
+
+    def set_values(self):
+        tier_definition = self.company_id.validation_approver_tier_definition_id
+        if not tier_definition:
+            field = self.env["ir.model.fields"].search(
+                [("model", "=", "account.move"), ("name", "=", "approver_id")]
+            )
+            tier_definition = self.env["tier.definition"].create(
+                {
+                    "model_id": self.env["ir.model"]
+                    .search([("model", "=", "account.move")])
+                    .id,
+                    "review_type": "field",
+                    "name": "Validation with Approver field",
+                    "reviewer_field_id": field.id,
+                    "definition_domain": "[('type', '=', 'in_invoice')]",
+                    "approve_sequence": True,
+                    "active": self.require_approver_in_vendor_bills,
+                }
+            )
+            self.company_id.validation_approver_tier_definition_id = tier_definition
+        if self.require_approver_in_vendor_bills:
+            tier_definition.action_unarchive()
+        else:
+            tier_definition.action_archive()
+        return super().set_values()

--- a/account_move_tier_validation_approver/models/res_partner.py
+++ b/account_move_tier_validation_approver/models/res_partner.py
@@ -1,0 +1,10 @@
+# Copyright 2021 ForgeFlow, S.L.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo import fields, models
+
+
+class Partner(models.Model):
+    _inherit = "res.partner"
+
+    approver_id = fields.Many2one("res.users", string="Approver of Vendor Bills")

--- a/account_move_tier_validation_approver/readme/CONFIGURE.rst
+++ b/account_move_tier_validation_approver/readme/CONFIGURE.rst
@@ -1,0 +1,8 @@
+To configure this module, you need to:
+
+#. Go to *Settings > Technical > Tier Validations > Tier Definition*.
+#. Create a new tier or edit an existing one.
+#. Set the "Validated by" field to "Field in related record".
+#. Set the "Reviewer field" to "Responsible for Approval".
+
+A default tier validation called "Validation with Approver field" is set with this configuration.

--- a/account_move_tier_validation_approver/readme/CONTRIBUTORS.rst
+++ b/account_move_tier_validation_approver/readme/CONTRIBUTORS.rst
@@ -1,0 +1,2 @@
+* Lois Rilo <lois.rilo@forgeflow.com>
+* Adrià Gil Sorribes <adria.gil@forgeflow.com>

--- a/account_move_tier_validation_approver/readme/DESCRIPTION.rst
+++ b/account_move_tier_validation_approver/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+This module allows to select a Responsible for approval in the partner form. If a tier definition is set and configured
+with the "Responsible for Approval" field, the approver will be the one chosen in the partner form.

--- a/account_move_tier_validation_approver/readme/USAGE.rst
+++ b/account_move_tier_validation_approver/readme/USAGE.rst
@@ -1,0 +1,12 @@
+You can assign a default user for approval associated to a supplier. In the
+partner form view, go to the *Sales and Purchase* tab, and into the *Purchase*
+section, and fill the field *Approver of Vendor Bills*.
+
+When you create a vendor bill the field *Responsible for Approval* will be
+filled in with the partner's default. You can change it if needed.
+
+Be aware that you won't be able to post a vendor bill unless you have indicated
+a Responsible for Approval.
+
+Used in connection with the module *Account Move Tier Validation* you can set
+up approvals specific to a department.

--- a/account_move_tier_validation_approver/views/account_move_views.xml
+++ b/account_move_tier_validation_approver/views/account_move_views.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2021 ForgeFlow, S.L.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). -->
+<odoo>
+    <record id="view_move_form" model="ir.ui.view">
+        <field name="name">account.move.form</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form" />
+        <field name="arch" type="xml">
+            <xpath expr='//field[@name="ref"]' position="after">
+                <field
+                    name="approver_id"
+                    attrs="{'readonly': [('review_ids', '!=', [])], 'invisible': [('type', 'in', ['out_invoice', 'out_refund', 'entry'])]}"
+                />
+            </xpath>
+        </field>
+    </record>
+    <record id="view_account_invoice_filter" model="ir.ui.view">
+        <field name="name">account.move.select - account_move_tier_validation</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_account_invoice_filter" />
+        <field name="arch" type="xml">
+            <field name="invoice_user_id" position="after">
+                <field name="approver_id" />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/account_move_tier_validation_approver/views/res_config_settings_views.xml
+++ b/account_move_tier_validation_approver/views/res_config_settings_views.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="account.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[@id='account_vendor_bills']" position="inside">
+                <div
+                    class="col-12 col-lg-6 o_setting_box"
+                    id="account_config_require_approver_in_vendor_bills"
+                >
+                    <div class="o_setting_left_pane">
+                        <field name="require_approver_in_vendor_bills" />
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label for="require_approver_in_vendor_bills" />
+                        <span
+                            class="fa fa-lg fa-building-o"
+                            title="Values set here are company-specific."
+                            groups="base.group_multi_company"
+                        />
+                        <div class="text-muted">
+                            Require approver before posting vendor bills
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/account_move_tier_validation_approver/views/res_partner_views.xml
+++ b/account_move_tier_validation_approver/views/res_partner_views.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2021 ForgeFlow, S.L. -->
+<!-- License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl) -->
+<odoo>
+    <data>
+        <record id="view_partner_property_form" model="ir.ui.view">
+            <field name="name">res.partner.move_approve.user</field>
+            <field name="model">res.partner</field>
+            <field name="inherit_id" ref="account.view_partner_property_form" />
+            <field name="arch" type="xml">
+                <xpath
+                    expr="//field[@name='property_supplier_payment_term_id']"
+                    position="after"
+                >
+                    <field name="approver_id" />
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/setup/account_move_tier_validation_approver/odoo/addons/account_move_tier_validation_approver
+++ b/setup/account_move_tier_validation_approver/odoo/addons/account_move_tier_validation_approver
@@ -1,0 +1,1 @@
+../../../../account_move_tier_validation_approver

--- a/setup/account_move_tier_validation_approver/setup.py
+++ b/setup/account_move_tier_validation_approver/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module allows to assign a default user for approval associated to a supplier.
cc @LoisRForgeFlow 
