### PR TITLE
[13.0][FIX] account_invoice_date_due: restore multi-record handling in write()

### DIFF
--- a/account_invoice_date_due/models/account_move.py
+++ b/account_invoice_date_due/models/account_move.py
@@ -21,10 +21,11 @@ class AccountMove(models.Model):
         res = super().write(vals)
         # Propagate due date to move lines
         # that correspont to the receivable/payable account
-        if "invoice_date_due" in vals and self.state == "posted":
-            payment_term_lines = self.line_ids.filtered(
-                lambda line: line.account_id.user_type_id.type
-                in ("receivable", "payable")
-            )
-            payment_term_lines.write({"date_maturity": vals["invoice_date_due"]})
+        if "invoice_date_due" in vals:
+            for record in self.filtered(lambda r: r.state == "posted"):
+                payment_term_lines = record.line_ids.filtered(
+                    lambda line: line.account_id.user_type_id.type
+                    in ("receivable", "payable")
+                )
+                payment_term_lines.write({"date_maturity": vals["invoice_date_due"]})
         return res


### PR DESCRIPTION
415bb0b4c2eea0435fbd6431dad8b239216c90dd introduced a bug disallowing to `write()` in a multi-record set.
The bug is reproduced when doing mass edits.
This restores that possibility.

@Tecnativa
TT31218

ping @pedrobaeza @victoralmau 