### PR TITLE
[12.0][MIG] account_invoice_tier_validation_approver

### DIFF
--- a/account_invoice_tier_validation_approver/__init__.py
+++ b/account_invoice_tier_validation_approver/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/account_invoice_tier_validation_approver/__manifest__.py
+++ b/account_invoice_tier_validation_approver/__manifest__.py
@@ -1,0 +1,16 @@
+# Copyright 2021 ForgeFlow, S.L.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+{
+    "name": "Account Invoice Tier Validation Approver",
+    "version": "12.0.1.0.0",
+    "author": "ForgeFlow, Odoo Community Association (OCA)",
+    "category": "Accounting",
+    "license": "LGPL-3",
+    "depends": ["account_invoice_tier_validation"],
+    "data": [
+        "views/account_invoice_views.xml",
+        "views/res_partner_views.xml",
+        "views/res_config_settings_views.xml",
+    ],
+    "installable": True,
+}

--- a/account_invoice_tier_validation_approver/models/__init__.py
+++ b/account_invoice_tier_validation_approver/models/__init__.py
@@ -1,0 +1,4 @@
+from . import account_invoice
+from . import res_partner
+from . import res_config_settings
+from . import res_company

--- a/account_invoice_tier_validation_approver/models/account_invoice.py
+++ b/account_invoice_tier_validation_approver/models/account_invoice.py
@@ -1,0 +1,42 @@
+# Copyright 2021 ForgeFlow, S.L.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+
+class AccountInvoice(models.Model):
+    _inherit = "account.invoice"
+
+    approver_id = fields.Many2one(
+        comodel_name="res.users",
+        string="Responsible for Approval",
+        track_visibility="onchange",
+    )
+
+    @api.onchange("partner_id")
+    def _onchange_partner_approver_id(self):
+        if self.partner_id:
+            self.approver_id = self.partner_id.approver_id.id
+
+    @api.model
+    def get_purchase_types(self, include_receipts=False):
+        return ['in_invoice', 'in_refund'] + (include_receipts and ['in_receipt'] or [])
+
+    def is_purchase_document(self, include_receipts=False):
+        return self.type in self.get_purchase_types(include_receipts)
+
+    def action_invoice_open(self):
+        for invoice in self:
+            require_approver_in_vendor_bills = (
+                invoice.company_id.require_approver_in_vendor_bills
+            )
+            if (
+                invoice.is_purchase_document(include_receipts=True)
+                and require_approver_in_vendor_bills
+                and not invoice.approver_id
+            ):
+                raise UserError(
+                    _("It is mandatory to indicate a Responsible for Approval")
+                )
+        return super(AccountInvoice, self).action_invoice_open()

--- a/account_invoice_tier_validation_approver/models/res_company.py
+++ b/account_invoice_tier_validation_approver/models/res_company.py
@@ -1,0 +1,16 @@
+# Copyright 2021 ForgeFlow, S.L.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    require_approver_in_vendor_bills = fields.Boolean(
+        string="Require approver in vendor bills"
+    )
+
+    validation_approver_tier_definition_id = fields.Many2one(
+        comodel_name="tier.definition", string="Bill approval tier definition"
+    )

--- a/account_invoice_tier_validation_approver/models/res_config_settings.py
+++ b/account_invoice_tier_validation_approver/models/res_config_settings.py
@@ -1,0 +1,41 @@
+# Copyright 2021 ForgeFlow, S.L.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    require_approver_in_vendor_bills = fields.Boolean(
+        string="Require Approver In Vendor Bills",
+        help="Requires adding an approver before a vendor bill can be posted.",
+        related="company_id.require_approver_in_vendor_bills",
+        readonly=False
+    )
+
+    def set_values(self):
+        tier_definition = self.company_id.validation_approver_tier_definition_id
+        if not tier_definition:
+            field = self.env["ir.model.fields"].search(
+                [("model", "=", "account.invoice"), ("name", "=", "approver_id")]
+            )
+            tier_definition = self.env["tier.definition"].create(
+                {
+                    "model_id": self.env["ir.model"]
+                    .search([("model", "=", "account.invoice")])
+                    .id,
+                    "review_type": "field",
+                    "name": "Validation with Approver field",
+                    "reviewer_field_id": field.id,
+                    "definition_domain": "[('type', '=', 'in_invoice')]",
+                    "approve_sequence": True,
+                    "active": self.require_approver_in_vendor_bills,
+                }
+            )
+            self.company_id.validation_approver_tier_definition_id = tier_definition
+        if self.require_approver_in_vendor_bills:
+            tier_definition.write({"active": True})
+        else:
+            tier_definition.write({"active": False})
+        return super().set_values()

--- a/account_invoice_tier_validation_approver/models/res_partner.py
+++ b/account_invoice_tier_validation_approver/models/res_partner.py
@@ -1,0 +1,10 @@
+# Copyright 2021 ForgeFlow, S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo import fields, models
+
+
+class Partner(models.Model):
+    _inherit = "res.partner"
+
+    approver_id = fields.Many2one("res.users", string="Approver of Vendor Bills",)

--- a/account_invoice_tier_validation_approver/readme/CONFIGURE.rst
+++ b/account_invoice_tier_validation_approver/readme/CONFIGURE.rst
@@ -1,0 +1,8 @@
+To configure this module, you need to:
+
+#. Go to *Settings > Technical > Tier Validations > Tier Definition*.
+#. Create a new tier or edit an existing one.
+#. Set the "Validated by" field to "Field in related record".
+#. Set the "Reviewer field" to "Responsible for Approval".
+
+A default tier validation called "Validation with Approver field" is set with this configuration.

--- a/account_invoice_tier_validation_approver/readme/CONTRIBUTORS.rst
+++ b/account_invoice_tier_validation_approver/readme/CONTRIBUTORS.rst
@@ -1,0 +1,2 @@
+* Lois Rilo <lois.rilo@forgeflow.com>
+* Adrià Gil Sorribes <adria.gil@forgeflow.com>

--- a/account_invoice_tier_validation_approver/readme/DESCRIPTION.rst
+++ b/account_invoice_tier_validation_approver/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+This module allows to select a Responsible for approval in the partner form. If a tier definition is set and configured
+with the "Responsible for Approval" field, the approver will be the one chosen in the partner form.

--- a/account_invoice_tier_validation_approver/readme/USAGE.rst
+++ b/account_invoice_tier_validation_approver/readme/USAGE.rst
@@ -1,0 +1,12 @@
+You can assign a default user for approval associated to a supplier. In the
+partner form view, go to the *Sales and Purchase* tab, and into the *Purchase*
+section, and fill the field *Approver of Vendor Bills*.
+
+When you create a vendor bill the field *Responsible for Approval* will be
+filled in with the partner's default. You can change it if needed.
+
+Be aware that you won't be able to post a vendor bill unless you have indicated
+a Responsible for Approval.
+
+Used in connection with the module *Account Move Tier Validation* you can set
+up approvals specific to a department.

--- a/account_invoice_tier_validation_approver/tests/__init__.py
+++ b/account_invoice_tier_validation_approver/tests/__init__.py
@@ -1,0 +1,3 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from . import test_account_invoice_tier_validation_approver

--- a/account_invoice_tier_validation_approver/tests/test_account_invoice_tier_validation_approver.py
+++ b/account_invoice_tier_validation_approver/tests/test_account_invoice_tier_validation_approver.py
@@ -1,0 +1,81 @@
+# Copyright 2021 ForgeFlow (http://www.forgeflow.com)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from odoo.tests.common import TransactionCase
+
+
+class TestAccountInvoiceTierValidationApprover(TransactionCase):
+    def setUp(self):
+        super(TestAccountInvoiceTierValidationApprover, self).setUp()
+        self.res_partner_1 = self.env["res.partner"].create(
+            {"name": "Wood Corner", "email": "example@yourcompany.com"}
+        )
+        self.product_1 = self.env["product.product"].create(
+            {"name": "Desk Combination"}
+        )
+        self.currency_euro = self.env["res.currency"].search([("name", "=", "EUR")])
+        self.test_user_1 = self.env["res.users"].create(
+            {"name": "User", "login": "test1", "email": "example@yourcompany.com"}
+        )
+        self.test_approver = self.env["res.users"].create(
+            {"name": "Approver", "login": "test2", "email": "example@yourcompany.com"}
+        )
+        self.account_type_receivable = self.env["account.account.type"].create(
+            {"name": "Test Receivable", "type": "receivable"}
+        )
+        self.account_type_regular = self.env["account.account.type"].create(
+            {"name": "Test Regular", "type": "other"}
+        )
+        self.account_receivable = self.env["account.account"].create(
+            {
+                "name": "Test Receivable",
+                "code": "TEST_AR",
+                "user_type_id": self.account_type_receivable.id,
+                "reconcile": True,
+            }
+        )
+        self.invoice_line = self.env["account.invoice.line"].create(
+            {
+                "name": "Line",
+                "price_unit": 1000.0,
+                "account_id": self.account_receivable.id,
+                "quantity": 1,
+            }
+        )
+        self.vendor_bill = self.env["account.invoice"].create(
+            {
+                "name": "Test vendor Bill",
+                "type": "in_invoice",
+                "partner_id": self.res_partner_1.id,
+                "currency_id": self.currency_euro.id,
+                "approver_id": self.test_approver.id,
+                "invoice_line_ids": [(4, self.invoice_line.id)],
+            }
+        )
+        self.model_id = self.env["ir.model"].search(
+            [("name", "=", "Invoice")], limit=1
+        )
+        self.field_id = self.env["ir.model.fields"].search(
+            [("name", "=", "approver_id")], limit=1
+        )
+
+    def test_field_validation_approver(self):
+        tiers = self.env["tier.definition"].search([])
+        for tier in tiers:
+            tier.write({"active": False})
+        self.tier_definition = self.env["tier.definition"].create(
+            {
+                "name": "Test Tier",
+                "model_id": self.model_id.id,
+                "review_type": "field",
+                "reviewer_field_id": self.field_id.id,
+                "definition_type": "domain",
+                "definition_domain": "[('type', '=', 'in_invoice')]",
+            }
+        )
+        record = self.vendor_bill
+        record.sudo(self.test_user_1.id).write({"approver_id": self.test_approver.id})
+        record.sudo(self.test_user_1.id).request_validation()
+        record.invalidate_cache()
+        record.sudo(self.test_approver.id).validate_tier()
+        record.sudo(self.test_user_1.id).action_invoice_open()

--- a/account_invoice_tier_validation_approver/views/account_invoice_views.xml
+++ b/account_invoice_tier_validation_approver/views/account_invoice_views.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2021 ForgeFlow, S.L.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). -->
+<odoo>
+    <record id="invoice_supplier_form" model="ir.ui.view">
+        <field name="name">account.invoice.supplier.form</field>
+        <field name="model">account.invoice</field>
+        <field name="inherit_id" ref="account.invoice_supplier_form"/>
+        <field name="arch" type="xml">
+            <xpath expr='//field[@name="reference"]' position="after">
+                <field
+                    name="approver_id"
+                    attrs="{'readonly': [('review_ids', '!=', [])], 'invisible': [('type', 'in', ['out_invoice', 'out_refund', 'entry'])]}"
+                />
+            </xpath>
+        </field>
+    </record>
+    <record id="view_account_invoice_filter" model="ir.ui.view">
+        <field name="name">account.invoice.select - account_invoice_tier_validation</field>
+        <field name="model">account.invoice</field>
+        <field name="inherit_id" ref="account.view_account_invoice_filter"/>
+        <field name="arch" type="xml">
+            <field name="user_id" position="after">
+                <field name="approver_id"/>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/account_invoice_tier_validation_approver/views/res_config_settings_views.xml
+++ b/account_invoice_tier_validation_approver/views/res_config_settings_views.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="account.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[@id='invoicing_settings']" position="inside">
+                <div
+                    class="col-12 col-lg-6 o_setting_box"
+                    id="account_config_require_approver_in_vendor_bills"
+                >
+                    <div class="o_setting_left_pane">
+                        <field name="require_approver_in_vendor_bills" />
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label for="require_approver_in_vendor_bills" />
+                        <span
+                            class="fa fa-lg fa-building-o"
+                            title="Values set here are company-specific."
+                            groups="base.group_multi_company"
+                        />
+                        <div class="text-muted">
+                            Require approver before posting vendor bills
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/account_invoice_tier_validation_approver/views/res_partner_views.xml
+++ b/account_invoice_tier_validation_approver/views/res_partner_views.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2021 ForgeFlow, S.L. -->
+<!-- License AGPL-3.0 or later (http://www.gnu.org/licenses/lgpl) -->
+<odoo>
+    <data>
+        <record id="view_partner_property_form" model="ir.ui.view">
+            <field name="name">res.partner.move_approve.user</field>
+            <field name="model">res.partner</field>
+            <field name="inherit_id" ref="account.view_partner_property_form" />
+            <field name="arch" type="xml">
+                <xpath
+                    expr="//field[@name='property_supplier_payment_term_id']"
+                    position="after"
+                >
+                    <field name="approver_id" />
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
This module allows to assign a default user for approval associated to a supplier.
Backport of https://github.com/OCA/account-invoicing/pull/977
cc @LoisRForgeFlow