### PR TITLE
[13.0][IMP]sale_line_refund_to_invoice_qty: add refund option explanation for usability and only display on credit notes

### DIFF
--- a/sale_line_refund_to_invoice_qty/wizards/account_move_reversal_view.xml
+++ b/sale_line_refund_to_invoice_qty/wizards/account_move_reversal_view.xml
@@ -6,13 +6,17 @@
             <field name="model">account.move.reversal</field>
             <field name="inherit_id" ref="account.view_account_move_reversal" />
             <field name="arch" type="xml">
-                <field name="date" position="after">
-                    <field name="move_id" invisible="1" />
-                    <field
-                        name="sale_qty_not_to_reinvoice"
-                        attrs="{'invisible': [('move_id', '=', False)]}"
-                    />
-                </field>
+                <xpath expr="//field[@name='journal_id']/.." position="after">
+                    <group
+                        name="sale_line_refund_qty"
+                        attrs="{'invisible': [('move_type', '!=', 'out_invoice')]}"
+                    >
+                        <field name="sale_qty_not_to_reinvoice" />
+                        <div class="oe_grey" colspan="4">
+                            If the credit note is created to reverse a wrong invoice, leave the checkbox empty.
+                        </div>
+                    </group>
+                </xpath>
             </field>
         </record>
     </data>


### PR DESCRIPTION
Add explanation to enhance user comprehension of the feature and prevent displaying the checkbox when refund is not performed for customer invoice.