### PR TITLE
[13.0][IMP]sale_line_refund_to_invoice_qty: do not use negative booleans

### DIFF
--- a/sale_line_refund_to_invoice_qty/__manifest__.py
+++ b/sale_line_refund_to_invoice_qty/__manifest__.py
@@ -4,7 +4,7 @@
     "name": "Sale Line Refund To Invoice Qty",
     "summary": """Allow deciding whether refunded quantity should be considered
                 as quantity to reinvoice""",
-    "version": "13.0.1.0.1",
+    "version": "13.0.1.1.1",
     "category": "Sales",
     "website": "https://github.com/OCA/account-invoicing",
     "author": "ForgeFlow, Odoo Community Association (OCA)",

--- a/sale_line_refund_to_invoice_qty/migrations/13.0.1.1.1/post-migration.py
+++ b/sale_line_refund_to_invoice_qty/migrations/13.0.1.1.1/post-migration.py
@@ -1,0 +1,31 @@
+# Copyright 2021 ForgeFlow <http://www.forgeflow.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+
+def sale_qty_to_reinvoice_swapping(env):
+    openupgrade.logged_query(
+        env.cr,
+        """
+            UPDATE account_move_line aml
+            SET sale_qty_to_reinvoice = true
+            WHERE aml.{} = false
+        """.format(
+            openupgrade.get_legacy_name("sale_qty_not_to_reinvoice")
+        ),
+    )
+    openupgrade.logged_query(
+        env.cr,
+        """
+            UPDATE account_move_line aml
+            SET sale_qty_to_reinvoice = false
+            WHERE aml.{} = true
+        """.format(
+            openupgrade.get_legacy_name("sale_qty_not_to_reinvoice")
+        ),
+    )
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    sale_qty_to_reinvoice_swapping(env)

--- a/sale_line_refund_to_invoice_qty/migrations/13.0.1.1.1/pre-migration.py
+++ b/sale_line_refund_to_invoice_qty/migrations/13.0.1.1.1/pre-migration.py
@@ -1,0 +1,12 @@
+# Copyright 2021 ForgeFlow <http://www.forgeflow.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+_column_copies = {
+    "account_move_line": [("sale_qty_not_to_reinvoice", None, None)],
+}
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.copy_columns(env.cr, _column_copies)

--- a/sale_line_refund_to_invoice_qty/models/account.py
+++ b/sale_line_refund_to_invoice_qty/models/account.py
@@ -7,22 +7,21 @@ class AccountMove(models.Model):
     _inherit = "account.move"
 
     def _reverse_move_vals(self, default_values, cancel=True):
-        # Set the sale_qty_not_to_reinvoice based on the boolean from the
+        # Set the sale_qty_to_reinvoice based on the boolean from the
         # reversal wizard
         move_vals = super(AccountMove, self)._reverse_move_vals(
             default_values, cancel=cancel
         )
-        if self.env.context.get("sale_qty_not_to_reinvoice", False):
+        if self.env.context.get("sale_qty_to_reinvoice", False):
             for vals in move_vals["line_ids"]:
-                vals[2].update({"sale_qty_not_to_reinvoice": True})
+                vals[2].update({"sale_qty_to_reinvoice": True})
         return move_vals
 
 
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
 
-    sale_qty_not_to_reinvoice = fields.Boolean(
-        string="Sale qty not to reinvoice",
-        help="If marked, the quantity in this move line will not be considered "
-        "as quantity to be reinvoiced in the related sales order line.",
+    sale_qty_to_reinvoice = fields.Boolean(
+        string="Sale qty to reinvoice",
+        help="Leave it marked if you will reinvoice the same sale order line",
     )

--- a/sale_line_refund_to_invoice_qty/models/sale.py
+++ b/sale_line_refund_to_invoice_qty/models/sale.py
@@ -19,7 +19,7 @@ class SaleOrderLine(models.Model):
         "order_id.state",
         "invoice_lines.move_id.state",
         "invoice_lines.quantity",
-        "invoice_lines.sale_qty_not_to_reinvoice",
+        "invoice_lines.sale_qty_to_reinvoice",
     )
     def _get_to_invoice_qty(self):
         super()._get_to_invoice_qty()
@@ -29,7 +29,7 @@ class SaleOrderLine(models.Model):
                 if (
                     invoice_line.move_id.state != "cancel"
                     and invoice_line.move_id.type == "out_refund"
-                    and invoice_line.sale_qty_not_to_reinvoice
+                    and not invoice_line.sale_qty_to_reinvoice
                 ):
                     qty_to_invoice -= invoice_line.product_uom_id._compute_quantity(
                         invoice_line.quantity, line.product_uom
@@ -40,7 +40,7 @@ class SaleOrderLine(models.Model):
         "product_uom_qty",
         "invoice_lines.move_id.state",
         "invoice_lines.quantity",
-        "invoice_lines.sale_qty_not_to_reinvoice",
+        "invoice_lines.sale_qty_to_reinvoice",
     )
     def _compute_qty_refunded_not_invoiceable(self):
         for line in self:
@@ -49,7 +49,7 @@ class SaleOrderLine(models.Model):
                 if (
                     invoice_line.move_id.state != "cancel"
                     and invoice_line.move_id.type == "out_refund"
-                    and invoice_line.sale_qty_not_to_reinvoice
+                    and not invoice_line.sale_qty_to_reinvoice
                 ):
                     qty_ref_not_inv += invoice_line.product_uom_id._compute_quantity(
                         invoice_line.quantity, line.product_uom

--- a/sale_line_refund_to_invoice_qty/tests/test_sale_line_refund_to_invoice_qty.py
+++ b/sale_line_refund_to_invoice_qty/tests/test_sale_line_refund_to_invoice_qty.py
@@ -50,12 +50,12 @@ class TestSaleLineRefundToInvoiceQty(SavepointCase):
         reinvoice in the sales order line, when the boolean is checked.
         """
         reversal_wizard = self.move_reversal_wiz(self.invoice)
-        reversal_wizard.write({"sale_qty_not_to_reinvoice": True})
+        reversal_wizard.write({"sale_qty_to_reinvoice": False})
         credit_note = self.env["account.move"].browse(
             reversal_wizard.reverse_moves()["res_id"]
         )
         for line in credit_note.line_ids:
-            self.assertTrue(line.sale_qty_not_to_reinvoice)
+            self.assertFalse(line.sale_qty_to_reinvoice)
         self.assertEqual(self.order.order_line[0].qty_to_invoice, 0.0)
         self.assertEqual(self.order.order_line[0].qty_refunded_not_invoiceable, 5.0)
 
@@ -69,6 +69,6 @@ class TestSaleLineRefundToInvoiceQty(SavepointCase):
             reversal_wizard.reverse_moves()["res_id"]
         )
         for line in credit_note.line_ids:
-            self.assertFalse(line.sale_qty_not_to_reinvoice)
+            self.assertTrue(line.sale_qty_to_reinvoice)
         self.assertEqual(self.order.order_line[0].qty_to_invoice, 5.0)
         self.assertEqual(self.order.order_line[0].qty_refunded_not_invoiceable, 0.0)

--- a/sale_line_refund_to_invoice_qty/views/account_move_views.xml
+++ b/sale_line_refund_to_invoice_qty/views/account_move_views.xml
@@ -10,7 +10,7 @@ License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html). -->
             <field name="arch" type="xml">
                 <field name="quantity" position="after">
                     <field
-                        name="sale_qty_not_to_reinvoice"
+                        name="sale_qty_to_reinvoice"
                         attrs="{'column_invisible': [('parent.type', '!=', 'out_refund')]}"
                         optional="show"
                     />

--- a/sale_line_refund_to_invoice_qty/wizards/account_move_reversal.py
+++ b/sale_line_refund_to_invoice_qty/wizards/account_move_reversal.py
@@ -6,14 +6,15 @@ from odoo import fields, models
 class AccountMoveReversal(models.TransientModel):
     _inherit = "account.move.reversal"
 
-    sale_qty_not_to_reinvoice = fields.Boolean(
-        string="Not reinvoice refunded quantity",
-        help="If marked, the quantities refunded in the credit notes will not "
-        "be considered as quantities to be reinvoiced in the related Sales Orders",
+    sale_qty_to_reinvoice = fields.Boolean(
+        string="This credit note will be reinvoiced",
+        default="True",
+        help="Leave it marked if you will reinvoice the same sale order line "
+        "(standard behaviour)",
     )
 
     def reverse_moves(self):
         return super(
             AccountMoveReversal,
-            self.with_context(sale_qty_not_to_reinvoice=self.sale_qty_not_to_reinvoice),
+            self.with_context(sale_qty_to_reinvoice=self.sale_qty_to_reinvoice),
         ).reverse_moves()

--- a/sale_line_refund_to_invoice_qty/wizards/account_move_reversal_view.xml
+++ b/sale_line_refund_to_invoice_qty/wizards/account_move_reversal_view.xml
@@ -11,9 +11,9 @@
                         name="sale_line_refund_qty"
                         attrs="{'invisible': [('move_type', '!=', 'out_invoice')]}"
                     >
-                        <field name="sale_qty_not_to_reinvoice" />
+                        <field name="sale_qty_to_reinvoice" />
                         <div class="oe_grey" colspan="4">
-                            If the credit note is created to reverse a wrong invoice, leave the checkbox empty.
+                            Leave it marked when other customer invoices are expected for the quantities in the credit note.
                         </div>
                     </group>
                 </xpath>


### PR DESCRIPTION
Negative booleans (need to mark the boolean to be "False") confuse users. Converting the field to be positive.

cc @ForgeFlow @JordiMForgeFlow 