### PR TITLE
[13.0][FIX] stock_picking_return_refund_option: Use Form in tests to avoid crash tests

### DIFF
--- a/stock_picking_return_refund_option/tests/test_stock_picking_return_refund_options.py
+++ b/stock_picking_return_refund_option/tests/test_stock_picking_return_refund_options.py
@@ -1,7 +1,7 @@
 # Copyright 2018 Tecnativa - Sergio Teruel
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import fields
-from odoo.tests.common import SavepointCase, tagged
+from odoo.tests.common import Form, SavepointCase, tagged
 
 
 @tagged("post_install", "-at_install")
@@ -70,13 +70,18 @@ class TestSaleOrderLineInput(SavepointCase):
         cls.picking.action_done()
         cls.order._create_invoices()
 
-    def return_picking_wiz(self, picking):
-        wizard = (
-            self.env["stock.return.picking"]
-            .with_context(active_model="stock.picking", active_id=picking.id)
-            .create({})
+    def get_return_picking_wizard(self, picking):
+        stock_return_picking_form = Form(
+            self.env["stock.return.picking"].with_context(
+                active_ids=picking.ids,
+                active_id=picking.ids[0],
+                active_model="stock.picking",
+            )
         )
-        wizard._onchange_picking_id()
+        return stock_return_picking_form.save()
+
+    def return_picking_wiz(self, picking):
+        wizard = self.get_return_picking_wizard(picking)
         wizard.product_return_moves.write({"quantity": 1.0, "to_refund": False})
         return wizard
 


### PR DESCRIPTION
Crash test due to this Odoo commit
OCA/OCB@8ca10a8
The wizard lines have the field uom_id related to move.product_uom and readonly=False, if you call directly to wiz.onchage_picking_id a write in stock move is executed.

cc @Tecnativa
ping @carlosdauden @CarlosRoca13 