### PR TITLE
[14.0][IMP] account_move_tier_validation: send invoice validation

### DIFF
--- a/account_move_tier_validation/README.rst
+++ b/account_move_tier_validation/README.rst
@@ -83,6 +83,9 @@ Contributors
 
 * Odoo Perú <info@odooperu.pe>
 * Tharathip Chaweewongphan <tharathipc@ecosoft.co.th>
+* Thierry Ducrest <thierry.ducrest@camptocamp.com>
+* `Trobz <https://trobz.com>`_:
+    * Khoi Vo <khoivha@trobz.com>
 
 Maintainers
 ~~~~~~~~~~~

--- a/account_move_tier_validation/__init__.py
+++ b/account_move_tier_validation/__init__.py
@@ -2,3 +2,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 
 from . import models
+from . import wizard

--- a/account_move_tier_validation/__manifest__.py
+++ b/account_move_tier_validation/__manifest__.py
@@ -12,5 +12,11 @@
     "application": False,
     "installable": True,
     "depends": ["account", "base_tier_validation"],
-    "data": ["views/account_move_view.xml"],
+    "data": [
+        "data/mail_template_data.xml",
+        "security/ir.model.access.csv",
+        "views/account_move_view.xml",
+        "views/tier_definition_view.xml",
+        "wizard/account_invoice_validation_send.xml",
+    ],
 }

--- a/account_move_tier_validation/data/mail_template_data.xml
+++ b/account_move_tier_validation/data/mail_template_data.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" ?>
+<odoo>
+
+  <record id="email_template_validation_invoice" model="mail.template">
+    <field name="name">Account Invoice Validation Request</field>
+    <field name="model_id" ref="account.model_account_move" />
+    <field name="email_from">${(object.company_id.email)}</field>
+    <field
+            name="partner_to"
+        >${object.user_validation_responsible_id.partner_id.id}</field>
+    <field name="subject">Invoice for Approval</field>
+    <!-- The body of the template has not been decided yet, except a button to open the invoice -->
+    <field name="body_html" type="html">
+      <div style="margin: 0px; padding: 0px;">
+        <p style="margin: 0px; padding: 0px; font-size: 13px;">
+          Here is a new vendor invoice to review:
+        </p>
+
+          <table
+                    border="0"
+                    cellpadding="0"
+                    cellspacing="0"
+                    style="background-color:#505050; border:1px solid #353535; border-radius:5px;"
+                >
+            <tr>
+              <td
+                            align="center"
+                            valign="middle"
+                            style="color:#FFFFFF; font-family:Helvetica, Arial, sans-serif; font-size:16px; font-weight:bold; letter-spacing:-.5px; line-height:150%; padding-top:15px; padding-right:30px; padding-bottom:15px; padding-left:30px;"
+                        >
+
+                <a
+                                href="${object.get_web_url()}"
+                                style="color:#FFFFFF; text-decoration:none;"
+                            >Invoice ${object.name}</a>
+              </td>
+            </tr>
+          </table>
+
+      </div>
+    </field>
+    <field name="lang">${object.partner_id.lang}</field>
+    <field name="auto_delete" eval="True" />
+  </record>
+
+</odoo>

--- a/account_move_tier_validation/models/account_move.py
+++ b/account_move_tier_validation/models/account_move.py
@@ -1,7 +1,10 @@
 # Copyright <2020> PESOL <info@pesol.es>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 
-from odoo import models
+
+from werkzeug.urls import url_encode
+
+from odoo import fields, models
 
 
 class AccountMove(models.Model):
@@ -9,3 +12,37 @@ class AccountMove(models.Model):
     _inherit = ["account.move", "tier.validation"]
     _state_from = ["draft"]
     _state_to = ["posted"]
+
+    user_validation_responsible_id = fields.Many2one(
+        comodel_name="res.users", string="Validation Responsible"
+    )
+
+    def button_request_validation(self):
+        for account_move in self:
+            res = super().request_validation()
+            tier_definitions = self.env["tier.definition"].search(
+                [
+                    ("model", "=", "account.move"),
+                    ("open_mail_composer_wizard", "=", True),
+                ]
+            )
+            for td in tier_definitions:
+                if account_move.evaluate_tier(td):
+                    action = self.env.ref(
+                        "account_move_tier_validation.invoice_send_validation_request"
+                    )
+                    return action.read()[0]
+            return res
+
+    def get_web_url(self):
+        self.ensure_one()
+        base_url = self.env["ir.config_parameter"].get_param("web.base.url")
+        url_params = url_encode(
+            {
+                "id": self.id,
+                "view_type": "form",
+                "model": "account.move",
+                "action": self.env.ref("account.action_move_in_invoice_type").id,
+            }
+        )
+        return f"{base_url}/web#{url_params}"

--- a/account_move_tier_validation/models/tier_definition.py
+++ b/account_move_tier_validation/models/tier_definition.py
@@ -1,11 +1,15 @@
 # Copyright <2020> PESOL <info@pesol.es>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 
-from odoo import api, models
+from odoo import api, fields, models
 
 
 class TierDefinition(models.Model):
     _inherit = "tier.definition"
+
+    open_mail_composer_wizard = fields.Boolean(
+        "Open Mail Composer Wizard when Requesting Validation",
+    )
 
     @api.model
     def _get_tier_validation_model_names(self):

--- a/account_move_tier_validation/readme/CONTRIBUTORS.rst
+++ b/account_move_tier_validation/readme/CONTRIBUTORS.rst
@@ -1,2 +1,5 @@
 * Odoo Perú <info@odooperu.pe>
 * Tharathip Chaweewongphan <tharathipc@ecosoft.co.th>
+* Thierry Ducrest <thierry.ducrest@camptocamp.com>
+* `Trobz <https://trobz.com>`_:
+    * Khoi Vo <khoivha@trobz.com>

--- a/account_move_tier_validation/security/ir.model.access.csv
+++ b/account_move_tier_validation/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_account_invoice_send_validation,access_account_invoice_send_validation,model_account_invoice_send_validation,,1,1,1,1

--- a/account_move_tier_validation/static/description/index.html
+++ b/account_move_tier_validation/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Account Move Tier Validation</title>
 <style type="text/css">
 
@@ -432,6 +432,15 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <ul class="simple">
 <li>Odoo Perú &lt;<a class="reference external" href="mailto:info&#64;odooperu.pe">info&#64;odooperu.pe</a>&gt;</li>
 <li>Tharathip Chaweewongphan &lt;<a class="reference external" href="mailto:tharathipc&#64;ecosoft.co.th">tharathipc&#64;ecosoft.co.th</a>&gt;</li>
+<li>Thierry Ducrest &lt;<a class="reference external" href="mailto:thierry.ducrest&#64;camptocamp.com">thierry.ducrest&#64;camptocamp.com</a>&gt;</li>
+<li><dl class="first docutils">
+<dt><a class="reference external" href="https://trobz.com">Trobz</a>:</dt>
+<dd><ul class="first last">
+<li>Khoi Vo &lt;<a class="reference external" href="mailto:khoivha&#64;trobz.com">khoivha&#64;trobz.com</a>&gt;</li>
+</ul>
+</dd>
+</dl>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/account_move_tier_validation/tests/__init__.py
+++ b/account_move_tier_validation/tests/__init__.py
@@ -2,3 +2,4 @@
 
 from . import common
 from . import test_tier_validation
+from . import test_account_move_tier_validation

--- a/account_move_tier_validation/tests/test_account_move_tier_validation.py
+++ b/account_move_tier_validation/tests/test_account_move_tier_validation.py
@@ -1,0 +1,28 @@
+# Copyright 2021 Camptocamp SA
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl)
+from odoo.tests import SavepointCase
+
+
+class TestAccountMoveTierValidation(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.user = cls.env.ref("base.user_demo")
+        cls.invoice = cls.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "user_validation_responsible_id": cls.user.id,
+            }
+        )
+
+        cls.wizard = (
+            cls.env["account.invoice.send.validation"]
+            .with_context({"active_ids": cls.invoice.ids})
+            .create({})
+        )
+
+    def test_wizard(self):
+        """Check the wizard works."""
+        self.assertEqual(self.wizard.composition_mode, "mass_mail")
+        self.assertTrue(self.user.partner_id in self.wizard.partner_ids)

--- a/account_move_tier_validation/views/account_move_view.xml
+++ b/account_move_tier_validation/views/account_move_view.xml
@@ -9,7 +9,7 @@
         <field name="arch" type="xml">
             <button name="action_post" position="before">
                 <button
-                    name="request_validation"
+                    name="button_request_validation"
                     string="Request Validation"
                     attrs="{'invisible': ['|','|',('need_validation', '!=', True),('rejected','=',True),('state','not in',['draft'])]}"
                     type="object"
@@ -79,6 +79,15 @@
                     widget="tier_validation"
                     attrs="{'invisible':[('review_ids', '=', [])]}"
                 />
+            </xpath>
+            <xpath expr="//group[@id='other_tab_group']" position="inside">
+                <group
+                    string="Validation"
+                    name="tier_validation"
+                    attrs="{'invisible': [('move_type', 'not in', ('in_invoice', 'in_refund'))]}"
+                >
+                <field name="user_validation_responsible_id" />
+                </group>
             </xpath>
         </field>
     </record>

--- a/account_move_tier_validation/views/tier_definition_view.xml
+++ b/account_move_tier_validation/views/tier_definition_view.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="tier_definition_view_form_inherit" model="ir.ui.view">
+        <field name="name">tier.definition.view.form.inherit</field>
+        <field name="model">tier.definition</field>
+        <field name="inherit_id" ref="base_tier_validation.tier_definition_view_form" />
+        <field name="arch" type="xml">
+            <field name="has_comment" position="after">
+                <field
+                    name="open_mail_composer_wizard"
+                    attrs="{'invisible':[('model','!=','account.move')]}"
+                />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/account_move_tier_validation/wizard/__init__.py
+++ b/account_move_tier_validation/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import account_invoice_validation_send

--- a/account_move_tier_validation/wizard/account_invoice_validation_send.py
+++ b/account_move_tier_validation/wizard/account_invoice_validation_send.py
@@ -1,0 +1,59 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError, ValidationError
+from odoo.fields import first
+
+
+class AccountInvoiceSendValidation(models.TransientModel):
+    _name = "account.invoice.send.validation"
+    _inherits = {"mail.compose.message": "composer_id"}
+    _description = "Account Invoice Send Validation Request"
+
+    invoice_id = fields.Many2one("account.move", string="Invoice")
+    composer_id = fields.Many2one(
+        "mail.compose.message",
+        string="Composer",
+        required=True,
+        ondelete="cascade",
+    )
+    template_id = fields.Many2one(
+        "mail.template", index=True, domain="[('model', '=', 'account.move')]"
+    )
+
+    @api.model
+    def default_get(self, fields):
+        res = super().default_get(fields)
+        res_ids = self._context.get("active_ids")
+        invoice = first(self.env["account.move"].browse(res_ids))
+        if not invoice:
+            raise UserError(_("Invoice to request validation for has not been found"))
+        composer = self.env["mail.compose.message"].create({})
+        values = {
+            "composition_mode": "mass_mail",
+            "invoice_id": invoice.id,
+            "composer_id": composer.id,
+        }
+        if invoice.user_validation_responsible_id:
+            values["partner_ids"] = [
+                (4, invoice.user_validation_responsible_id.partner_id.id, 0)
+            ]
+        if hasattr(invoice, "attachment_ids") and invoice.attachment_ids:
+            values["attachment_ids"] = invoice.attachment_ids.ids
+        res.update(values)
+        return res
+
+    @api.onchange("template_id")
+    def onchange_template_id(self):
+        for wizard in self:
+            if wizard.composer_id:
+                wizard.composer_id.template_id = wizard.template_id.id
+                wizard.composer_id.onchange_template_id_wrapper()
+
+    def send_action(self):
+        self.ensure_one()
+        if not self.partner_ids:
+            raise ValidationError(_("An email recipient is required."))
+        self.composer_id.send_mail()
+        return {"type": "ir.actions.act_window_close"}

--- a/account_move_tier_validation/wizard/account_invoice_validation_send.xml
+++ b/account_move_tier_validation/wizard/account_invoice_validation_send.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+  <record id="account_invoice_send_validation_form" model="ir.ui.view">
+    <field name="name">account.invoice.send.validation.form</field>
+    <field name="model">account.invoice.send.validation</field>
+    <field name="groups_id" eval="[(4,ref('base.group_user'))]" />
+    <field name="arch" type="xml">
+      <form string="Invoice send validation request">
+        <field name="composition_mode" invisible="1" />
+        <field name="invoice_id" invisible="1" />
+        <field name="email_from" invisible="1" />
+        <field name="mail_server_id" invisible="1" />
+        <field name="template_id" invisible="1" />
+        <div name="mail_form">
+          <div>
+            <group>
+              <field
+                                name="partner_ids"
+                                widget="many2many_tags_email"
+                                string="Recipients"
+                                placeholder="Add contacts to notify..."
+                            />
+              <field name="subject" placeholder="Subject..." />
+            </group>
+            <field name="body" style="border:none;" options="{'style-inline': true}" />
+          </div>
+          <group>
+            <field
+                            name="attachment_ids"
+                            widget="many2many_binary"
+                            string="Attach a file"
+                            nolabel="1"
+                            colspan="2"
+                        />
+          </group>
+        </div>
+        <footer>
+          <button
+                        string="Send"
+                        name="send_action"
+                        type="object"
+                        class="send btn-primary o_mail_send"
+                    />
+          <button string="Cancel" class="btn-secondary" special="cancel" />
+        </footer>
+      </form>
+    </field>
+  </record>
+
+  <record id="invoice_send_validation_request" model="ir.actions.act_window">
+      <field name="name">Send Validation Request</field>
+      <field name="res_model">account.invoice.send.validation</field>
+      <field name="binding_model_id" ref="model_account_move" />
+      <field name="binding_view_types">form</field>
+      <field name="view_mode">form</field>
+      <field name="target">new</field>
+      <field name="groups_id" eval="[(4, ref('account.group_account_invoice'))]" />
+      <field
+            name="context"
+            eval="{
+        'default_template_id': ref('account_move_tier_validation.email_template_validation_invoice'),
+       }"
+        />
+  </record>
+
+</odoo>


### PR DESCRIPTION
On requesting a validation by clicking on the button. A wizard is open to send an email to the responsible for the validation set on the invoice. The wizards allow to change the email generated before sending it.

The user responsible for the validation can be selected in the `Other Info` tab of the invoice.