### PR TITLE
[FIX] account_invoice_supplier_self_invoice: Set ref as self_invoice_number

### DIFF
--- a/account_invoice_supplier_self_invoice/__manifest__.py
+++ b/account_invoice_supplier_self_invoice/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Purchase Self Invoice",
-    "version": "13.0.1.1.0",
+    "version": "13.0.1.1.1",
     "author": "Creu Blanca, " "Odoo Community Association (OCA)",
     "category": "Accounting & Finance",
     "website": "https://github.com/OCA/account-invoicing",

--- a/account_invoice_supplier_self_invoice/migrations/13.0.1.1.1/post-migration.py
+++ b/account_invoice_supplier_self_invoice/migrations/13.0.1.1.1/post-migration.py
@@ -1,0 +1,14 @@
+# Copyright 2021 Creu Blanca - Alba Riera
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE account_move
+        SET ref = self_invoice_number
+        WHERE ref IS NULL AND self_invoice_number IS NOT NULL""",
+    )

--- a/account_invoice_supplier_self_invoice/models/account_move.py
+++ b/account_invoice_supplier_self_invoice/models/account_move.py
@@ -30,6 +30,8 @@ class AccountMove(models.Model):
                 invoice.self_invoice_number = sequence.with_context(
                     ir_sequence_date=invoice.date
                 ).next_by_id()
+                if not invoice.ref:
+                    invoice.ref = invoice.self_invoice_number
         return res
 
     @api.model


### PR DESCRIPTION
Without this change if a self invoice was created, no ref was defined. That was a problem when using account_payment_order, as it required a communication text.


A migration script is added in order to fix old data.