### PR TITLE
[FIX] account_invoice_supplierinfo_update: rounding

### DIFF
--- a/account_invoice_supplierinfo_update/models/account_invoice_line.py
+++ b/account_invoice_supplierinfo_update/models/account_invoice_line.py
@@ -22,9 +22,7 @@ class AccountInvoiceLine(models.Model):
         if not self.product_id:
             return self.price_unit
         uom = self.uom_id or self.product_id.uom_id
-        return self.invoice_id.currency_id.round(
-            uom._compute_price(
-                self.price_unit, self.product_id.uom_po_id))
+        return uom._compute_price(self.price_unit, self.product_id.uom_po_id)
 
     @api.multi
     def _is_correct_price(self, supplierinfo):


### PR DESCRIPTION
We shouldn't roung the price unit, as we'd lose precision when writing
back to the supplierinfo from the original unit price item which is the
one we want to update. For example:

- We buy an item at 1,2345 (decimal precision of 4 digits for product
price)
- The product is correctly invoiced at 1,2345 (rounded in subtotal)
- We should update the item supplierinfo at that same price. Otherwise,
if we round to the currency digits (usally 2) we'd get something like:
1,23 in the supplierinfo and in the next purchase we'd be losing those
decimal which in large amounts of units translates into a lot of money.

cc @Tecnativa TT32538

ping @sergio-teruel @legalsylvain 