### PR TITLE
[14.0][FIX]  account_invoice_payment_retention: compute_amount on payment wizard

### DIFF
--- a/account_invoice_payment_retention/models/__init__.py
+++ b/account_invoice_payment_retention/models/__init__.py
@@ -3,4 +3,3 @@
 from . import res_config_settings
 from . import res_company
 from . import account_move
-from . import account_payment

--- a/account_invoice_payment_retention/wizard/__init__.py
+++ b/account_invoice_payment_retention/wizard/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import account_payment_register

--- a/account_invoice_payment_retention/wizard/account_payment_register.py
+++ b/account_invoice_payment_retention/wizard/account_payment_register.py
@@ -51,14 +51,14 @@ class AccountPaymentRegister(models.TransientModel):
         "apply_payment_retention",
     )
     def _compute_amount(self):
+        res = super()._compute_amount()
         for rec in self:
             if rec.apply_payment_retention:
                 rec.amount -= rec.retention_amount_currency
                 rec.payment_difference_handling = "reconcile"
                 rec.writeoff_account_id = rec.env.company.retention_account_id
                 rec.writeoff_label = rec.env.company.retention_account_id.name
-            else:
-                super()._compute_amount()
+        return res
 
     def _validate_payment_retention(self):
         """If this payment enforce_payment_retention, after reconciliation


### PR DESCRIPTION
Move on `account_payment.py` (model) to `account_payment_register.py` (wizard)
and Fix compute_amount should be call super() before dos something.