### PR TITLE
[14.0][FIX] account_invoice_transmit_method: fix partner form view inheritance

### DIFF
--- a/account_invoice_transmit_method/views/partner.xml
+++ b/account_invoice_transmit_method/views/partner.xml
@@ -43,15 +43,15 @@
                     operation="python_dict"
                     key="default_supplier_invoice_transmit_method_code"
                 >supplier_invoice_transmit_method_code</attribute>
-            <xpath
-                    expr="//field[@name='child_ids']/form//field[@name='email']"
-                    position="attributes"
-                > <!-- TODO for some strange reasons, this attrs has no effect -->
-            <attribute
-                        name="attrs"
-                    >{'required': [('customer_invoice_transmit_method_code', '=', 'mail'), ('type', '=', 'invoice')]}</attribute>
-            </xpath>
             </field>
+            <xpath
+                expr="//field[@name='child_ids']/form//field[@name='email']"
+                position="attributes"
+            >
+            <attribute
+                    name="attrs"
+                >{'required': [('customer_invoice_transmit_method_code', '=', 'mail'), ('type', '=', 'invoice')]}</attribute>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
The last block of the inherit of the partner form view was not working, due to a bad position of a closing tag. This fix is already integrated in my migration to v15 cf https://github.com/OCA/account-invoicing/pull/1064