### PR TITLE
[13.0][ADD] account_invoice_sale_origin_link

### DIFF
--- a/account_invoice_sale_origin_link/__init__.py
+++ b/account_invoice_sale_origin_link/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/account_invoice_sale_origin_link/__manifest__.py
+++ b/account_invoice_sale_origin_link/__manifest__.py
@@ -1,0 +1,16 @@
+# Copyright 2022 ForgeFlow S.L. (https://www.forgeflow.com)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+{
+    "name": "Account Invoice Sale Origin Link",
+    "summary": "Add link to the Sale Order in invoice source document.",
+    "version": "13.0.1.0.0",
+    "license": "LGPL-3",
+    "website": "https://github.com/OCA/account-invoicing",
+    "author": "ForgeFlow, Odoo Community Association (OCA)",
+    "category": "Accounting & Finance",
+    "depends": ["account_invoice_origin_link"],
+    "data": [],
+    "installable": True,
+    "maintainers": ["OriolVForgeFlow"],
+}

--- a/account_invoice_sale_origin_link/models/__init__.py
+++ b/account_invoice_sale_origin_link/models/__init__.py
@@ -1,0 +1,1 @@
+from . import account_move

--- a/account_invoice_sale_origin_link/models/account_move.py
+++ b/account_invoice_sale_origin_link/models/account_move.py
@@ -1,0 +1,20 @@
+# Copyright 2022 ForgeFlow S.L. (https://www.forgeflow.com)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from odoo import api, models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    def _selection_reference_model(self):
+        res = super()._selection_reference_model() + [("sale.order", "Sale Order")]
+        return res
+
+    @api.depends("invoice_origin")
+    def _compute_source_doc_ref(self):
+        super()._compute_source_doc_ref()
+        for rec in self.filtered(lambda line: line.type == "out_invoice"):
+            so = rec.line_ids.mapped("sale_line_ids.order_id")
+            if len(so) == 1:
+                rec.origin_reference = "{},{}".format(so._name, so.id or 0)

--- a/account_invoice_sale_origin_link/readme/CONTRIBUTORS.rst
+++ b/account_invoice_sale_origin_link/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Oriol Villamayor <oriol.villamayor@forgeflow.com>

--- a/account_invoice_sale_origin_link/readme/DESCRIPTION.rst
+++ b/account_invoice_sale_origin_link/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+This module adds a clickable link to Sale Orders on the Source Document of Invoices.
+It depends on the base module: "account_invoice_origin_link"

--- a/setup/account_invoice_sale_origin_link/odoo/addons/account_invoice_sale_origin_link
+++ b/setup/account_invoice_sale_origin_link/odoo/addons/account_invoice_sale_origin_link
@@ -1,0 +1,1 @@
+../../../../account_invoice_sale_origin_link

--- a/setup/account_invoice_sale_origin_link/setup.py
+++ b/setup/account_invoice_sale_origin_link/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module adds a clickable link to Sale Orders on the Source Document of Invoices.
It depends on the base module: "account_invoice_origin_link"
@ForgeFlow @JordiMForgeFlow 