### PR TITLE
[14.0][FIX] account_invoice_section_sale_order: Fix import in test_invoice_group_by_sale_order

### DIFF
--- a/account_invoice_section_sale_order/tests/test_invoice_group_by_sale_order.py
+++ b/account_invoice_section_sale_order/tests/test_invoice_group_by_sale_order.py
@@ -1,6 +1,9 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from odoo.exceptions import UserError
 from odoo.tests.common import SavepointCase


### PR DESCRIPTION
Fix import in test_invoice_group_by_sale_order causing issue while executing in only python3 environment