### PR TITLE
[13.0][FIX] account_invoice_fixed_discount: Ensure price_unit is different …

### DIFF
--- a/account_invoice_fixed_discount/models/account_move.py
+++ b/account_invoice_fixed_discount/models/account_move.py
@@ -70,7 +70,7 @@ class AccountMoveLine(models.Model):
         taxes,
         move_type,
     ):
-        if self.discount_fixed != 0:
+        if self.discount_fixed != 0 and price_unit:
             discount = ((self.discount_fixed) / price_unit) * 100 or 0.00
         return super(AccountMoveLine, self)._get_price_total_and_subtotal_model(
             price_unit, quantity, discount, currency, product, partner, taxes, move_type
@@ -109,9 +109,11 @@ class AccountMoveLine(models.Model):
                 prev_discount.append(
                     {"discount_fixed": vals.get("discount_fixed"), "discount": 0.00}
                 )
-                fixed_discount = (
-                    vals.get("discount_fixed") / vals.get("price_unit")
-                ) * 100
+                fixed_discount = 0.0
+                if vals.get("price_unit"):
+                    fixed_discount = (
+                        vals.get("discount_fixed") / vals.get("price_unit")
+                    ) * 100
                 vals.update({"discount": fixed_discount, "discount_fixed": 0.00})
             elif vals.get("discount"):
                 prev_discount.append({"discount": vals.get("discount")})


### PR DESCRIPTION
It could happen that a fixed discount is equal to total line product price. This would lead to Zero-division error when trying to calculate the standard discount based on price_unit.

CC @ForgeFlow 