### PR TITLE
[13.0][FIX] account_invoice_show_currency_rate: Round currency_rate_amount to avoid many decimal places 

### DIFF
--- a/account_invoice_show_currency_rate/models/account_move.py
+++ b/account_invoice_show_currency_rate/models/account_move.py
@@ -34,7 +34,9 @@ class AccountMove(models.Model):
             if item.state == "posted" and lines:
                 amount_currency_positive = sum(lines.mapped("amount_currency"))
                 total_debit = sum(item.line_ids.mapped("debit"))
-                item.currency_rate_amount = amount_currency_positive / total_debit
+                item.currency_rate_amount = item.currency_id.round(
+                    amount_currency_positive / total_debit
+                )
             else:
                 rates = item.currency_id._get_rates(item.company_id, item.date)
                 item.currency_rate_amount = rates.get(item.currency_id.id)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,1 @@
+freezegun


### PR DESCRIPTION
Round currency_rate_amount to avoid many decimal places (1.9974358974358974 for example).

Related to and indirectly discovered at https://github.com/OCA/account-invoicing/pull/1069.

Please @ernestotejeda and @pedrobaeza can you review it?

@Tecnativa