### PR TITLE
[14.0][FIX][BUG] Get the current company should be made with self.env.company

### DIFF
--- a/stock_picking_invoicing/models/stock_move.py
+++ b/stock_picking_invoicing/models/stock_move.py
@@ -24,7 +24,7 @@ class StockMove(models.Model):
             taxes = product.taxes_id
         else:
             taxes = product.supplier_taxes_id
-        company_id = self.env.context.get("force_company", self.env.user.company_id.id)
+        company_id = self.env.context.get("force_company", self.env.company.id)
         my_taxes = taxes.filtered(lambda r: r.company_id.id == company_id)
         return fiscal_position.map_tax(my_taxes)
 

--- a/stock_picking_invoicing/wizards/stock_invoice_onshipping.py
+++ b/stock_picking_invoicing/wizards/stock_invoice_onshipping.py
@@ -206,7 +206,7 @@ class StockInvoiceOnshipping(models.TransientModel):
         default_journal = self.env["account.journal"].search(
             [
                 ("type", "=", journal_type),
-                ("company_id", "=", self.env.user.company_id.id),
+                ("company_id", "=", self.env.company.id),
             ],
             limit=1,
         )
@@ -359,7 +359,7 @@ class StockInvoiceOnshipping(models.TransientModel):
             payment_term = partner.property_payment_term_id.id
         else:
             payment_term = partner.property_supplier_payment_term_id.id
-        company = self.env.user.company_id
+        company = self.env.company
         currency = company.currency_id
         if partner:
             code = picking.picking_type_id.code
@@ -521,7 +521,7 @@ class StockInvoiceOnshipping(models.TransientModel):
         """
         pickings = self._load_pickings()
         company = pickings.mapped("company_id")
-        if company and company != self.env.user.company_id:
+        if company and company != self.env.company:
             raise UserError(_("All pickings are not related to your company!"))
         pick_list = self._group_pickings(pickings)
         invoices = self.env["account.move"].browse()


### PR DESCRIPTION
As reported in OCA maillist after v13 to get the current company should be made by self.env.company and not self.env.user.company_id, reference https://www.odoo.com/documentation/13.0/developer/howtos/company.html, the same was did in v13 https://github.com/OCA/account-invoicing/pull/1095

cc @rvalyi @AaronHForgeFlow 