### PR TITLE
[14.0][FIX][BUG] Get the current company should be made with self.env.company, module account_billing.

### DIFF
--- a/account_billing/models/account_billing.py
+++ b/account_billing/models/account_billing.py
@@ -171,7 +171,7 @@ class AccountBilling(models.Model):
         )
         if len(currency_ids) > 1:
             raise ValidationError(_("Please select invoices with same currency"))
-        return currency_ids or self.env.user.company_id.currency_id
+        return currency_ids or self.env.company.currency_id
 
     def _compute_invoice_related_count(self):
         self.invoice_related_count = len(self.billing_line_ids)


### PR DESCRIPTION
As reported in OCA maillist after v13 to get the current company should be made by self.env.company and not self.env.user.company_id, reference https://www.odoo.com/documentation/13.0/developer/howtos/company.html, the same was did in module stock_picking_invoicing v13 https://github.com/OCA/account-invoicing/pull/1095 v14 https://github.com/OCA/account-invoicing/pull/1102

By the returned of command 
$ grep -rn 'self.env.user.company_id' --include=\*.py . --color=always

It seems the last one of this repo in version v14

cc @AaronHForgeFlow @legalsylvain @Saran440 
