### PR TITLE
[14.0][FIX] account_invoice_triple_discount: Loss of decimals with discounts in taxes

### DIFF
--- a/account_invoice_triple_discount/models/account_move.py
+++ b/account_invoice_triple_discount/models/account_move.py
@@ -15,6 +15,8 @@ class AccountMove(models.Model):
         simulate a multiple discount by changing the unit price. Values are
         restored after the original process is done
         """
+        original_digits = self.line_ids._fields["price_unit"]._digits
+        self.line_ids._fields["price_unit"]._digits = (16, 8)
         old_values_by_line_id = {}
         for line in self.line_ids:
             aggregated_discount = line._compute_aggregated_discount(line.discount)
@@ -24,6 +26,7 @@ class AccountMove(models.Model):
             }
             price_unit = line.price_unit * (1 - aggregated_discount / 100)
             line.update({"price_unit": price_unit, "discount": 0})
+        self.line_ids._fields["price_unit"]._digits = original_digits
         res = super(AccountMove, self)._recompute_tax_lines(**kwargs)
         for line in self.line_ids:
             if line.id not in old_values_by_line_id:

--- a/account_invoice_triple_discount/readme/CONTRIBUTORS.rst
+++ b/account_invoice_triple_discount/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * David Vidal <david.vidal@tecnativa.com>
 * Pedro M. Baeza <pedro.baeza@tecnativa.com>
 * Nikul Chaudhary <nikulchaudhary2112@gmail.com>
+* Isaac Gallart <igallart@puntsistemes.es>


### PR DESCRIPTION
When you have invoice lines with discounts, it not calculate good
the taxes due to the loss of decimals.

Example:

Invoice customer with two lines and price_unit configured with two decimals:

1 - 25000 * 0.27 and 5% discount -> 6412.50
2 - 25000 * 0.27 and 5% discount -> 6412.50

Result total Taxes (21%):
6412.50 * 2 = 12825
21% = 2693.25

But Odoo says:
2730

With this commit the taxes are corrects:
2693.25