### PR TITLE
[FIX][14.0][account_invoice_section_sale_order] fix passing default_journal_id when invoicing

### DIFF
--- a/account_invoice_section_sale_order/models/sale_order.py
+++ b/account_invoice_section_sale_order/models/sale_order.py
@@ -42,6 +42,10 @@ class SaleOrder(models.Model):
                                 "name": group._get_invoice_section_name(),
                                 "display_type": "line_section",
                                 "sequence": sequence,
+                                # see test: test_create_invoice_with_default_journal
+                                # forcing the account_id is needed to avoid
+                                # incorrect default value
+                                "account_id": False,
                             },
                         )
                     )

--- a/account_invoice_section_sale_order/tests/test_invoice_group_by_sale_order.py
+++ b/account_invoice_section_sale_order/tests/test_invoice_group_by_sale_order.py
@@ -109,6 +109,13 @@ class TestInvoiceGroupBySaleOrder(SavepointCase):
             self.assertEqual(line.name, result[line.sequence][0])
             self.assertEqual(line.display_type, result[line.sequence][1])
 
+    def test_create_invoice_with_default_journal(self):
+        """Using a specific journal for the invoice should not be broken"""
+        journal = self.env["account.journal"].search([("type", "=", "sale")], limit=1)
+        (self.order1_p1 + self.order2_p1).with_context(
+            default_journal_id=journal.id
+        )._create_invoices()
+
     def test_create_invoice_no_section(self):
         """Check invoice for only one sale order
 


### PR DESCRIPTION
If an other module pass in the context a specific journal for the invoice (passing default_journal_id in the context).
The invoice generation is broken.
Indeed the line created do not have any account_id specify and odoo will add it with the default_get method (in account/model/move.py). So it will try to create a line_section with an account and the sql constraint will raise an error.

Fix this incompatibility and add a test
