### PR TITLE
[FIX] account_invoice_refund_line_selection: Business fields were missing

### DIFF
--- a/account_invoice_refund_line_selection/wizards/account_move_reversal.py
+++ b/account_invoice_refund_line_selection/wizards/account_move_reversal.py
@@ -38,7 +38,13 @@ class AccountInvoiceRefund(models.TransientModel):
         if self.refund_method == "refund_lines":
             vals = res.copy()
             vals["line_ids"] = [
-                (0, 0, l.copy_data({"move_id": False, "recompute_tax_line": True})[0])
+                (
+                    0,
+                    0,
+                    l.with_context(include_business_fields=True).copy_data(
+                        {"move_id": False, "recompute_tax_line": True}
+                    )[0],
+                )
                 for l in self.line_ids
             ]
             move = self.env["account.move"].new(vals)


### PR DESCRIPTION
When using with sale, sale_order_lines were lost

How to test the issue, create a Sale Order and Invoice it. If you create a refund from the invoice, the sale order lines are marked as to invoice, but it will not happen if using the partial refund