### PR TITLE
[IMP] account_invoice_refund_line_selection: Line views

### DIFF
--- a/account_invoice_refund_line_selection/__manifest__.py
+++ b/account_invoice_refund_line_selection/__manifest__.py
@@ -10,6 +10,9 @@
     "website": "https://github.com/OCA/account-invoicing",
     "license": "LGPL-3",
     "depends": ["account"],
-    "data": ["wizards/account_move_reversal_view.xml"],
+    "data": [
+        "views/account_move_line_views.xml",
+        "wizards/account_move_reversal_view.xml",
+    ],
     "installable": True,
 }

--- a/account_invoice_refund_line_selection/views/account_move_line_views.xml
+++ b/account_invoice_refund_line_selection/views/account_move_line_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="view_move_line_tree_grouped_sales_purchases" model="ir.ui.view">
+        <field name="name">account.move.line.tree.grouped.sales.purchase</field>
+        <field name="model">account.move.line</field>
+        <field name="mode">primary</field>
+        <field
+            name="inherit_id"
+            ref="account.view_move_line_tree_grouped_sales_purchases"
+        />
+        <field name="arch" type="xml">
+            <tree position="attributes">
+                <attribute name="create">1</attribute>
+            </tree>
+        </field>
+    </record>
+</odoo>

--- a/account_invoice_refund_line_selection/wizards/account_move_reversal_view.xml
+++ b/account_invoice_refund_line_selection/wizards/account_move_reversal_view.xml
@@ -11,22 +11,10 @@
                 >
                     <page string="Invoice Lines">
                         <field name="selectable_invoice_lines_ids" invisible="1" />
-                        <field name="line_ids">
-                            <tree string="Invoice Lines">
-                                <field name="sequence" widget="handle" readonly="1" />
-                                <field name="product_id" readonly="1" />
-                                <field name="name" readonly="1" />
-                                <field name="quantity" readonly="1" />
-                                <field name="discount" readonly="1" />
-                                <field
-                                    name="tax_ids"
-                                    widget="many2many_tags"
-                                    readonly="1"
-                                />
-                                <field name="price_unit" readonly="1" />
-                                <field name="price_subtotal" readonly="1" />
-                            </tree>
-                        </field>
+                        <field
+                            name="line_ids"
+                            context="{'tree_view_ref': 'account_invoice_refund_line_selection.view_move_line_tree_grouped_sales_purchases'}"
+                        />
                     </page>
                 </notebook>
             </xpath>


### PR DESCRIPTION
Tree is removed, it had only sense for the missing create. Now it is here using a new primary tree

On #1115 view was removed due to a misunderstanding. Recovering it

@AaronHForgeFlow @etobella 