### PR TITLE
[FIX] account_invoice_section_sale: fix invoice total when using currency

### DIFF
--- a/account_invoice_section_sale_order/models/sale_order.py
+++ b/account_invoice_section_sale_order/models/sale_order.py
@@ -46,6 +46,11 @@ class SaleOrder(models.Model):
                                 # forcing the account_id is needed to avoid
                                 # incorrect default value
                                 "account_id": False,
+                                # see test: test_create_invoice_with_currency
+                                # if the currency is not set with the right value
+                                # the total amount will be wrong
+                                # because all line do not have the same currency
+                                "currency_id": invoice.currency_id.id,
                             },
                         )
                     )

--- a/account_invoice_section_sale_order/tests/test_invoice_group_by_sale_order.py
+++ b/account_invoice_section_sale_order/tests/test_invoice_group_by_sale_order.py
@@ -109,6 +109,17 @@ class TestInvoiceGroupBySaleOrder(SavepointCase):
             self.assertEqual(line.name, result[line.sequence][0])
             self.assertEqual(line.display_type, result[line.sequence][1])
 
+    def test_create_invoice_with_currency(self):
+        """Check invoice is generated with a correct total amount"""
+        eur = self.env.ref("base.EUR")
+        pricelist = self.env["product.pricelist"].create(
+            {"name": "Europe pricelist", "currency_id": eur.id}
+        )
+        orders = self.order1_p1 | self.order2_p1
+        orders.write({"pricelist_id": pricelist.id})
+        invoices = orders._create_invoices()
+        self.assertEqual(invoices.amount_total, 80)
+
     def test_create_invoice_with_default_journal(self):
         """Using a specific journal for the invoice should not be broken"""
         journal = self.env["account.journal"].search([("type", "=", "sale")], limit=1)


### PR DESCRIPTION
In case that you invoice sale order that are not in the same currency of the company the total amount on the invoice is wrong.

Indeed lines do not have the same currency (section line have the company currency) and so odoo will show as total the total in the company currency instead of the total in the invoice currency

see logic here : https://github.com/odoo/odoo/blob/01d4cefd20961a6518b6d20b88f0f42638fa16a1/addons/account/models/account_move.py#L1421