### PR TITLE
[14.0][ENH] account_invoice_payment_retention: add retention computation method

### DIFF
--- a/account_invoice_payment_retention/models/res_company.py
+++ b/account_invoice_payment_retention/models/res_company.py
@@ -14,6 +14,14 @@ class ResCompany(models.Model):
         domain=[("user_type_id.type", "=", "other")],
         help="Retention account used for case payment retention",
     )
+    retention_method = fields.Selection(
+        selection=[("untax", "Untaxed Amount"), ("total", "Total")],
+        default="untax",
+        string="Retention Method",
+        help="Method for computing the retention\n"
+        "- Untaxed Amount: The retention compute from the untaxed amount\n"
+        "- Total: The retention compute from the total amount",
+    )
 
     @api.constrains("retention_account_id")
     def _check_retention_account_id(self):

--- a/account_invoice_payment_retention/models/res_config_settings.py
+++ b/account_invoice_payment_retention/models/res_config_settings.py
@@ -18,3 +18,12 @@ class ResConfigSettings(models.TransientModel):
         readonly=False,
         help="Retention account used for case payment retention",
     )
+    retention_method = fields.Selection(
+        selection=[("untax", "Untaxed Amount"), ("total", "Total")],
+        related="company_id.retention_method",
+        string="Retention Method",
+        readonly=False,
+        help="Method for computing the retention\n"
+        "- Untaxed Amount: The retention compute from the untaxed amount\n"
+        "- Total: The retention compute from the total amount",
+    )

--- a/account_invoice_payment_retention/views/account_move_views.xml
+++ b/account_invoice_payment_retention/views/account_move_views.xml
@@ -23,6 +23,11 @@
                     />
                     <field
                         class="oe_edit_only"
+                        name="retention_method"
+                        attrs="{'invisible': [('payment_retention', '!=', 'percent')], 'required': [('payment_retention', '=', 'percent')]}"
+                    />
+                    <field
+                        class="oe_edit_only"
                         name="amount_retention"
                         placeholder="Amount"
                         attrs="{'invisible': [('payment_retention', '=', False)]}"

--- a/account_invoice_payment_retention/views/res_config_settings_views.xml
+++ b/account_invoice_payment_retention/views/res_config_settings_views.xml
@@ -5,7 +5,10 @@
         <field name="model">res.config.settings</field>
         <field name="arch" type="xml">
             <div id="account_vendor_bills" position="inside">
-                <div class="col-12 col-lg-6 o_setting_box">
+                <div
+                    class="col-12 col-lg-6 o_setting_box"
+                    id="group_payment_retention_setting"
+                >
                     <div class="o_setting_left_pane">
                         <field name="group_payment_retention" />
                     </div>
@@ -27,6 +30,28 @@
                                 <field
                                     name="retention_account_id"
                                     attrs="{'required': [('group_payment_retention', '=', True)]}"
+                                />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div
+                    class="col-12 col-lg-6 o_setting_box"
+                    id="retention_method_setting"
+                >
+                    <div class="o_setting_left_pane">
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label for="retention_method" string="Retention Method" />
+                        <div class="text-muted">
+                            Default your retention method
+                        </div>
+                        <div class="content-group">
+                            <div class="mt16">
+                                <field
+                                    name="retention_method"
+                                    class="o_light_label"
+                                    widget="radio"
                                 />
                             </div>
                         </div>


### PR DESCRIPTION
This PR adds the retention computation method. In case compute retention by percent, you can select the retention method for retention computation.

- If you select **Untexed Amount**,  the retention amount will compute from the _untaxed amount._
- If you select **Total**,  the retention amount will compute from the _total amount_.

![Screenshot from 2022-05-26 16-25-51](https://user-images.githubusercontent.com/51266019/170459952-d14d9ecd-dfc1-47a0-ab01-72d1b42d2108.png)

