### PR TITLE
[FIX] account_invoice_pricelist: float division by zero

### DIFF
--- a/account_invoice_pricelist/models/account_move.py
+++ b/account_invoice_pricelist/models/account_move.py
@@ -155,6 +155,8 @@ class AccountMoveLine(models.Model):
         return product[field_name] * uom_factor * cur_factor, currency_id
 
     def _calculate_discount(self, base_price, final_price):
+        if not base_price:
+            return 0.0
         discount = (base_price - final_price) / base_price * 100
         if (discount < 0 and base_price > 0) or (discount > 0 and base_price < 0):
             discount = 0.0

--- a/account_invoice_pricelist/tests/test_account_move_pricelist.py
+++ b/account_invoice_pricelist/tests/test_account_move_pricelist.py
@@ -3,7 +3,7 @@
 import hashlib
 import inspect
 
-from odoo.tests import common
+from odoo.tests import Form, common
 
 from odoo.addons.sale.models.sale import SaleOrderLine as upstream
 
@@ -52,6 +52,9 @@ class TestAccountMovePricelist(common.SavepointCase):
         )
         cls.product = cls.env["product.template"].create(
             {"name": "Product Test", "list_price": 100.00}
+        )
+        cls.product_0 = cls.env["product.template"].create(
+            {"name": "Product Test 2", "list_price": 0.00}
         )
         cls.sale_pricelist = cls.ProductPricelist.create(
             {
@@ -316,3 +319,9 @@ class TestAccountMovePricelist(common.SavepointCase):
         func = inspect.getsource(upstream._get_real_price_currency).encode()
         func_hash = hashlib.md5(func).hexdigest()
         self.assertIn(func_hash, VALID_HASHES)
+
+    def test_add_line_price_0(self):
+        inv_form = Form(self.invoice)
+        with inv_form.invoice_line_ids.new() as inv_line:
+            inv_line.product_id = self.product_0.product_variant_ids[0]
+            self.assertEqual(inv_line.discount, 0.0)


### PR DESCRIPTION
When adding a product line with sale price 0.0 you get a division by zero error. I think we can simply avoid this case by returning 0.0 when `base_price` argument is 0.