### PR TITLE
[15.0][FIX] account_invoice_fiscal_position_update: avoid error in tests (greenify repo)

### DIFF
--- a/account_invoice_fiscal_position_update/tests/test_inv_fiscal_pos_update.py
+++ b/account_invoice_fiscal_position_update/tests/test_inv_fiscal_pos_update.py
@@ -70,9 +70,8 @@ class TestProductIdChange(AccountTestInvoicingCommon):
                 "property_account_income_id": self.account_revenue.id,
             }
         )
-        product = self.product_model.create(
-            {"product_tmpl_id": product_tmpl.id, "standard_price": "12000"}
-        )
+        product = product_tmpl.product_variant_id
+        product.standard_price = 12000
         fp = self.fiscal_position_model.create(
             {"name": "fiscal position export", "sequence": 1}
         )


### PR DESCRIPTION
Don't create new variant, just use the default one.

Avoids:
![Selection_462](https://user-images.githubusercontent.com/25005517/176404914-aaac6152-8951-42d4-a32b-91eabf1132ef.png)

