### PR TITLE
[13.0][FIX] *: Change _recompute_tax_lines args according upstream

### DIFF
--- a/account_global_discount/models/account_move.py
+++ b/account_global_discount/models/account_move.py
@@ -53,7 +53,9 @@ class AccountMove(models.Model):
         readonly=True,
     )
 
-    def _recompute_tax_lines(self, recompute_tax_base_amount=False):
+    def _recompute_tax_lines(
+        self, recompute_tax_base_amount=False, tax_rep_lines_to_recompute=None
+    ):
         """Inject the global discounts recomputation if recompute_tax_base_amount is
         false, as on contrary, only the tax_base_amount field is recalculated, not
         affecting global discount computation.
@@ -63,7 +65,10 @@ class AccountMove(models.Model):
         if not recompute_tax_base_amount:
             # TODO: To be changed to invoice_global_discount_id when properly filled
             self.line_ids -= self.line_ids.filtered("global_discount_item")
-        res = super()._recompute_tax_lines(recompute_tax_base_amount)
+        res = super()._recompute_tax_lines(
+            recompute_tax_base_amount,
+            tax_rep_lines_to_recompute=tax_rep_lines_to_recompute,
+        )
         if not recompute_tax_base_amount:
             self._update_tax_lines_for_global_discount()
             self._set_global_discounts_by_tax()

--- a/account_invoice_fixed_discount/models/account_move.py
+++ b/account_invoice_fixed_discount/models/account_move.py
@@ -8,14 +8,17 @@ from odoo.exceptions import ValidationError
 class AccountMove(models.Model):
     _inherit = "account.move"
 
-    def _recompute_tax_lines(self, recompute_tax_base_amount=False):
+    def _recompute_tax_lines(
+        self, recompute_tax_base_amount=False, tax_rep_lines_to_recompute=None
+    ):
         vals = {}
         for line in self.invoice_line_ids.filtered("discount_fixed"):
             vals[line] = {"price_unit": line.price_unit}
             price_unit = line.price_unit - line.discount_fixed
             line.update({"price_unit": price_unit})
         res = super(AccountMove, self)._recompute_tax_lines(
-            recompute_tax_base_amount=recompute_tax_base_amount
+            recompute_tax_base_amount=recompute_tax_base_amount,
+            tax_rep_lines_to_recompute=tax_rep_lines_to_recompute,
         )
         for line in vals.keys():
             line.update(vals[line])

--- a/account_invoice_triple_discount/models/account_move.py
+++ b/account_invoice_triple_discount/models/account_move.py
@@ -13,7 +13,9 @@ class AccountMove(models.Model):
 
     _inherit = "account.move"
 
-    def _recompute_tax_lines(self, recompute_tax_base_amount=False):
+    def _recompute_tax_lines(
+        self, recompute_tax_base_amount=False, tax_rep_lines_to_recompute=None
+    ):
         vals = {}
         for line in self.invoice_line_ids.filtered(
             lambda l: l.discount2 or l.discount3
@@ -23,7 +25,8 @@ class AccountMove(models.Model):
             price_unit = line.price_unit * (1 - aggregated_discount / 100)
             line.update({"price_unit": price_unit, "discount": 0})
         res = super()._recompute_tax_lines(
-            recompute_tax_base_amount=recompute_tax_base_amount
+            recompute_tax_base_amount=recompute_tax_base_amount,
+            tax_rep_lines_to_recompute=tax_rep_lines_to_recompute,
         )
         for line in vals.keys():
             line.update(vals[line])


### PR DESCRIPTION
https://github.com/odoo/odoo/commit/11e7486157692bbbe0c605698ecfb4961f68 has changed the number of arguments on the method `_recompute_tax_lines`, so we need to adapt the overrides to such change.

@Tecnativa