### PR TITLE
[13.0][FIX] purchase_stock_picking_return_invoicing: qty_returned is not recomputed…

### DIFF
--- a/purchase_stock_picking_return_invoicing/models/purchase_order.py
+++ b/purchase_stock_picking_return_invoicing/models/purchase_order.py
@@ -153,7 +153,12 @@ class PurchaseOrderLine(models.Model):
                 )
             )
 
-    @api.depends("move_ids.state", "move_ids.returned_move_ids.state")
+    @api.depends(
+        "move_ids.state",
+        "move_ids.product_uom_qty",
+        "move_ids.returned_move_ids.state",
+        "move_ids.returned_move_ids.product_uom_qty",
+    )
     def _compute_qty_returned(self):
         """Made through read_group for not impacting in performance."""
         ProductUom = self.env["uom.uom"]


### PR DESCRIPTION
… when quantity done is modified.

Add missed field in depends and tests.
I use product_uom_qty to minimize not needed computes because the product_uom_qty is sincroniced with quantity_done when state is done.


TT38206