### PR TITLE
[13.0][FIX] purchase_stock_picking_return_invoicing: Limit update scope

### DIFF
--- a/purchase_stock_picking_return_invoicing/models/purchase_order.py
+++ b/purchase_stock_picking_return_invoicing/models/purchase_order.py
@@ -27,6 +27,7 @@ class PurchaseOrder(models.Model):
                 else line.qty_received,
                 precision_digits=precision,
             )
+            == 1
             for line in self.order_line
         )
 


### PR DESCRIPTION
Previous to this commit, every time there's a difference between the expected quantities (ordered/received vs invoiced), the invoice status was overwritten, not allowing other modules like `purchase_force_invoiced` to act.

Now, we limit the scope of the update to only the condition that this module is adding: when ordered/received is lower than the invoiced quantity.

@Tecnativa TT38533