### PR TITLE
[14.0] [IMP] account_invoice_date_due: enable multi-line edit on list view

### DIFF
--- a/account_invoice_date_due/models/account_move.py
+++ b/account_invoice_date_due/models/account_move.py
@@ -37,10 +37,13 @@ class AccountMove(models.Model):
         res = super().write(vals)
         # Propagate due date to move lines
         # that correspont to the receivable/payable account
-        if "invoice_date_due" in vals and self.state == "posted":
-            payment_term_lines = self.line_ids.filtered(
+        if "invoice_date_due" in vals:
+            payment_term_lines = self.filtered(
+                lambda move: move.state == "posted"
+            ).line_ids.filtered(
                 lambda line: line.account_id.user_type_id.type
                 in ("receivable", "payable")
             )
-            payment_term_lines.write({"date_maturity": vals["invoice_date_due"]})
+            if payment_term_lines:
+                payment_term_lines.write({"date_maturity": vals["invoice_date_due"]})
         return res

--- a/account_invoice_date_due/readme/CONTRIBUTORS.rst
+++ b/account_invoice_date_due/readme/CONTRIBUTORS.rst
@@ -1,5 +1,6 @@
 * Luis González <lgonzalez@vauxoo.com>
 * Luis Torres <luis_t@vauxoo.com>
+* Graeme Gellatly <graeme@o4sb.com>
 * `Tecnativa <https://www.tecnativa.com>`_:
 
   * João Marques

--- a/account_invoice_date_due/readme/USAGE.rst
+++ b/account_invoice_date_due/readme/USAGE.rst
@@ -8,6 +8,8 @@ To edit the invoice's due date, we have several scenarios:
 * No Payment Term is set, and the due date is set manually. In this case, the
   due date is editable while in draft, as with the standard Odoo flow. However,
   once posted, the field will remain editable.
+* In a list view, multi edit has been enabled, allowing the update for multiple
+  invoices at once.
 
 (All the above are considering the user belongs to the security group refered in
 "Configuration")

--- a/account_invoice_date_due/views/account_move_date_due.xml
+++ b/account_invoice_date_due/views/account_move_date_due.xml
@@ -28,4 +28,29 @@
             </field>
         </field>
     </record>
+
+    <record id="view_invoice_tree" model="ir.ui.view">
+        <field name="name">account.invoice.tree</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_invoice_tree" />
+        <field name="arch" type="xml">
+            <xpath expr="//tree" position="attributes">
+                <attribute name="multi_edit">1</attribute>
+            </xpath>
+            <xpath expr="//field[@name='invoice_date_due']" position="attributes">
+                <attribute
+                    name="groups"
+                >!account_invoice_date_due.allow_to_change_due_date</attribute>
+            </xpath>
+            <field name="invoice_date_due" position="after">
+                <field
+                    name="invoice_date_due"
+                    string="Due Date"
+                    optional="show"
+                    groups="account_invoice_date_due.allow_to_change_due_date"
+                    attrs="{'readonly': [('state', 'not in', ['posted', 'draft'])]}"
+                />
+            </field>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
Before this commit, this module would only work on a single record.

We enable the Odoo multi edit functionality to update the due date
of multiple invoices at once.