### PR TITLE
[15.0][IMP] account_invoice_transmit_method add active field transmit.method model

### DIFF
--- a/account_invoice_transmit_method/data/transmit_method.xml
+++ b/account_invoice_transmit_method/data/transmit_method.xml
@@ -8,13 +8,16 @@
     <record id="mail" model="transmit.method">
         <field name="code">mail</field>
         <field name="name">E-Mail</field>
+        <field name="active">True</field>
     </record>
     <record id="post" model="transmit.method">
         <field name="code">post</field>
         <field name="name">Post</field>
+        <field name="active">True</field>
     </record>
     <record id="portal" model="transmit.method">
         <field name="code">portal</field>
         <field name="name">Customer Portal</field>
+        <field name="active">True</field>
     </record>
 </odoo>

--- a/account_invoice_transmit_method/models/transmit_method.py
+++ b/account_invoice_transmit_method/models/transmit_method.py
@@ -15,6 +15,7 @@ class TransmitMethod(models.Model):
         help="Do not modify the code of an existing Transmit Method "
         "because it may be used to identify a particular transmit method.",
     )
+    active = fields.Boolean("active", default=True)
     customer_ok = fields.Boolean(string="Selectable on Customers", default=True)
     supplier_ok = fields.Boolean(string="Selectable on Vendors", default=True)
 

--- a/account_invoice_transmit_method/views/transmit_method.xml
+++ b/account_invoice_transmit_method/views/transmit_method.xml
@@ -17,6 +17,7 @@
                     <group name="main">
                         <group name="info">
                             <field name="code" />
+                            <field name="active" invisible="True" />
                         </group>
                         <group name="options">
                             <field name="customer_ok" />
@@ -35,6 +36,7 @@
                 <field name="code" />
                 <field name="customer_ok" />
                 <field name="supplier_ok" />
+                <field name="active" invisible="True" />
             </tree>
         </field>
     </record>
@@ -56,6 +58,11 @@
                     name="supplier_ok"
                     string="Selectable on Vendors"
                     domain="[('supplier_ok', '=', True)]"
+                />
+                <filter
+                    name="active"
+                    string="Archived"
+                    domain="[('active', '=' ,False)]"
                 />
             </search>
         </field>


### PR DESCRIPTION
add an active field on the transmit.method template. This allows the transmission method to be archived.