### PR TITLE
[FIX] account_invoice_fixed_discount

### DIFF
--- a/account_invoice_fixed_discount/models/account_move.py
+++ b/account_invoice_fixed_discount/models/account_move.py
@@ -8,9 +8,7 @@ from odoo.exceptions import ValidationError
 class AccountMove(models.Model):
     _inherit = "account.move"
 
-    def _recompute_tax_lines(
-        self, recompute_tax_base_amount=False, tax_rep_lines_to_recompute=None
-    ):
+    def _recompute_tax_lines(self, recompute_tax_base_amount=False):
         vals = {}
         for line in self.invoice_line_ids.filtered("discount_fixed"):
             vals[line] = {"price_unit": line.price_unit}
@@ -18,7 +16,6 @@ class AccountMove(models.Model):
             line.update({"price_unit": price_unit})
         res = super(AccountMove, self)._recompute_tax_lines(
             recompute_tax_base_amount=recompute_tax_base_amount,
-            tax_rep_lines_to_recompute=tax_rep_lines_to_recompute,
         )
         for line in vals.keys():
             line.update(vals[line])


### PR DESCRIPTION
When creating an invoice, I get the following error:

```
Error:
Odoo Server Error

Traceback (most recent call last):
  File "/opt/odoo/env/lib/python3.8/site-packages/odoo-14.0-py3.8.egg/odoo/addons/base/models/ir_http.py", line 237, in _dispatch
    result = request.dispatch()
  File "/opt/odoo/env/lib/python3.8/site-packages/odoo-14.0-py3.8.egg/odoo/http.py", line 684, in dispatch
    result = self._call_function(**self.params)
  File "/opt/odoo/env/lib/python3.8/site-packages/odoo-14.0-py3.8.egg/odoo/http.py", line 360, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/opt/odoo/env/lib/python3.8/site-packages/odoo-14.0-py3.8.egg/odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "/opt/odoo/env/lib/python3.8/site-packages/odoo-14.0-py3.8.egg/odoo/http.py", line 348, in checked_call
    result = self.endpoint(*a, **kw)
  File "/opt/odoo/env/lib/python3.8/site-packages/odoo-14.0-py3.8.egg/odoo/http.py", line 913, in __call__
    return self.method(*args, **kw)
  File "/opt/odoo/env/lib/python3.8/site-packages/odoo-14.0-py3.8.egg/odoo/http.py", line 532, in response_wrap
    response = f(*args, **kw)
  File "/opt/odoo/odoo/addons/web/controllers/main.py", line 1389, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/opt/odoo/odoo/addons/web/controllers/main.py", line 1381, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/opt/odoo/env/lib/python3.8/site-packages/odoo-14.0-py3.8.egg/odoo/api.py", line 396, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/opt/odoo/env/lib/python3.8/site-packages/odoo-14.0-py3.8.egg/odoo/api.py", line 383, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/opt/odoo/odoo/addons/account/models/account_move.py", line 1116, in onchange
    return super(AccountMove, self.with_context(recursive_onchanges=False)).onchange(values, field_name, field_onchange)
  File "/opt/odoo/env/lib/python3.8/site-packages/odoo-14.0-py3.8.egg/odoo/models.py", line 6240, in onchange
    record._onchange_eval(name, field_onchange[name], result)
  File "/opt/odoo/env/lib/python3.8/site-packages/odoo-14.0-py3.8.egg/odoo/models.py", line 5982, in _onchange_eval
    method_res = method(self)
  File "/opt/odoo/odoo/addons/account/models/account_move.py", line 489, in _onchange_currency
    self._recompute_dynamic_lines(recompute_tax_base_amount=True)
  File "/opt/odoo/odoo/addons/account/models/account_move.py", line 1089, in _recompute_dynamic_lines
    invoice._recompute_tax_lines(recompute_tax_base_amount=True)
  File "/opt/odoo/src/account-invoicing/account_invoice_fixed_discount/models/account_move.py", line 19, in _recompute_tax_lines
    res = super(AccountMove, self)._recompute_tax_lines(
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/odoo/env/lib/python3.8/site-packages/odoo-14.0-py3.8.egg/odoo/http.py", line 640, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/opt/odoo/env/lib/python3.8/site-packages/odoo-14.0-py3.8.egg/odoo/http.py", line 316, in _handle_exception
    raise exception.with_traceback(None) from new_cause
TypeError: _recompute_tax_lines() got an unexpected keyword argument 'tax_rep_lines_to_recompute'
```