### PR TITLE
[14.0][FIX] account_invoice_check_total: Proper tagging of unittests

### DIFF
--- a/account_invoice_check_total/tests/test_account_invoice.py
+++ b/account_invoice_check_total/tests/test_account_invoice.py
@@ -2,11 +2,12 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo.exceptions import ValidationError
-from odoo.tests import Form, SavepointCase
+from odoo.tests import Form, SavepointCase, tagged
 
 from ..models.account_move import GROUP_AICT
 
 
+@tagged("post_install", "-at_install")
 class TestAccountInvoice(SavepointCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
After this change the tests will also run successful 
If you do only
`odoo -i account_account_invoice_check_total  --stop-after-init --test-enable`

Now they fail because of missing account.journal entries

This was also done for https://github.com/OCA/contract/pull/876