### PR TITLE
[14.0][FIX] account_receipt_print: delete replace label date

### DIFF
--- a/account_receipt_print/views/report_receipt.xml
+++ b/account_receipt_print/views/report_receipt.xml
@@ -22,10 +22,6 @@
                 </h2>
             </xpath>
 
-            <xpath expr="//div[@name='invoice_date']/strong" position="replace">
-                <strong>Receipt Date:</strong>
-            </xpath>
-
             <div name="due_date" position="attributes">
                 <attribute name="style">display: none;</attribute>
             </div>


### PR DESCRIPTION
Before, when you print receipt it will stamp label `Invoice Date`. we will change it to `Receipt Date`
Now, Core odoo change label it to 'Date' -  https://github.com/odoo/odoo/commit/8e36f629ae9de37f5850bb5c0dd40acb3c04dd9f#diff-c85e75bc27fc841662ca0598c09a22670e0a0b4e5120815934c0a50999ff02bfL27

I think this module not need to replace label.