### PR TITLE
[15.0][FIX] account_invoice_date_due: Fix tests. Compare fields with sudo user

### DIFF
--- a/account_invoice_date_due/tests/test_account_invoice_date_due.py
+++ b/account_invoice_date_due/tests/test_account_invoice_date_due.py
@@ -87,10 +87,12 @@ class TestAccountInvoiceDateDue(common.TransactionCase):
         ten_days_from_now = fields.Date.to_string(datetime.today() + timedelta(days=10))
         move_edit_form.invoice_date_due = ten_days_from_now
         self.move = move_edit_form.save()
+        # Read all fields as sudo to get them independently of the user.
+        # Other modules can add security groups in account.move fields
         self.assertEqual(
             self._compare_records(
                 old_move_state,
-                self.move.read()[0],
+                self.move.sudo().read()[0],
                 ignore={"write_uid", "message_is_follower"},
             ),
             # Assert only this field is changed
@@ -125,7 +127,7 @@ class TestAccountInvoiceDateDue(common.TransactionCase):
         self.assertEqual(
             self._compare_records(
                 old_move_state,
-                self.move.read()[0],
+                self.move.sudo().read()[0],
                 ignore={"write_uid", "message_is_follower", "message_ids"},
             ),
             # Assert only this field is changed
@@ -162,7 +164,7 @@ class TestAccountInvoiceDateDue(common.TransactionCase):
         self.assertEqual(
             self._compare_records(
                 old_move_state,
-                self.move.read()[0],
+                self.move.sudo().read()[0],
                 ignore={"write_uid", "message_is_follower", "message_ids"},
             ),
             # Assert only this field is changed


### PR DESCRIPTION
cc @Tecnativa TT40606

ping @pilarvargas-tecnativa @chienandalu 

As the tests use a Form if other module adds a field in account.move model with an extra security group this field in not in Form fields, so crash the tests in a full private CI