### PR TITLE
[FIX] account_invoice_supplier_self_invoice: Creation must be set with sudo

### DIFF
--- a/account_invoice_supplier_self_invoice/models/res_partner.py
+++ b/account_invoice_supplier_self_invoice/models/res_partner.py
@@ -43,7 +43,7 @@ class ResPartner(models.Model):
         if not self.self_invoice:
             return False
         if not self.self_invoice_sequence_id:
-            self.self_invoice_sequence_id = (
+            self.sudo().self_invoice_sequence_id = (
                 self.env["ir.sequence"]
                 .sudo()
                 .create(

--- a/account_invoice_supplier_self_invoice/tests/test_self_invoice.py
+++ b/account_invoice_supplier_self_invoice/tests/test_self_invoice.py
@@ -8,6 +8,7 @@ from odoo.tests import common
 class TestSelfInvoice(common.TransactionCase):
     def setUp(self):
         res = super(TestSelfInvoice, self).setUp()
+        self.user = self.env.ref("base.user_admin")
         self.partner = self.env["res.partner"].create(
             {"name": "Partner", "supplier_rank": 1}
         )
@@ -72,6 +73,6 @@ class TestSelfInvoice(common.TransactionCase):
         self.assertTrue(self.invoice.can_self_invoice)
         self.assertTrue(self.invoice.set_self_invoice)
         self.invoice.invoice_date = None
-        self.invoice.action_post()
+        self.invoice.with_user(self.user.id).action_post()
         self.assertTrue(self.invoice.invoice_date)
         self.assertTrue(self.invoice.self_invoice_number)


### PR DESCRIPTION
otherwise, the following error is raised:

![image](https://user-images.githubusercontent.com/28590170/207317653-27939de9-8d42-4357-808f-01c0a9976a3d.png)

TEsted on runboat

@rafaelbn @Shide 