### PR TITLE
[IMP] faster SQL hook, avoids memory limit reached for large datasets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,26 +34,21 @@ repos:
           - requirements.txt
           - --header
           - "# generated from manifests external_dependencies"
-  - repo: https://github.com/OCA/mirrors-flake8
-    rev: v3.4.1
+  - repo: https://github.com/PyCQA/flake8
+    rev: 3.8.3
     hooks:
       - id: flake8
-        name: flake8 excluding __init__.py
-        exclude: __init__\.py
-  - repo: https://github.com/pre-commit/mirrors-pylint
-    rev: v2.5.3
+        name: flake8
+        additional_dependencies: ["flake8-bugbear==20.1.4"]
+  - repo: https://github.com/OCA/pylint-odoo
+    rev: 7.0.2
     hooks:
-      - id: pylint
+      - id: pylint_odoo
         name: pylint with optional checks
         args:
           - --rcfile=.pylintrc
           - --exit-zero
         verbose: true
-        additional_dependencies: &pylint_deps
-          - pylint-odoo==3.5.0
-      - id: pylint
-        name: pylint with mandatory checks
+      - id: pylint_odoo
         args:
           - --rcfile=.pylintrc-mandatory
-        additional_dependencies: *pylint_deps
-

--- a/account_invoice_merge/models/account_invoice.py
+++ b/account_invoice_merge/models/account_invoice.py
@@ -160,7 +160,8 @@ class AccountInvoice(models.Model):
         old_invoices = self.env['account.invoice']
         qty_prec = self.env['decimal.precision'].precision_get(
             'Product Unit of Measure')
-        for invoice_key, (invoice_data, old_ids) in new_invoices.items():
+        # _invoice_key never used , varname starts with underscore for linter
+        for _invoice_key, (invoice_data, old_ids) in new_invoices.items():
             # skip merges with only one invoice
             if len(old_ids) < 2:
                 allinvoices += (old_ids or [])


### PR DESCRIPTION
On a customer implementation : 90K invoices. 1.2Million invoice lines. 2 GB of system memory, the module was uninstallable due to memory limits reached.
This version inits the sequence fields with a quick SQL operation, reducing install time drastically and avoiding the memory problem.