### PR TITLE
[FIX] [15.0] account_invoice_supplier_self_invoice: Remove readonly from self_invoice_partner_prefix

### DIFF
--- a/account_invoice_supplier_self_invoice/views/res_partner_views.xml
+++ b/account_invoice_supplier_self_invoice/views/res_partner_views.xml
@@ -10,7 +10,7 @@
                     <field name="self_invoice" widget="boolean_toggle" />
                     <field
                         name="self_invoice_partner_prefix"
-                        attrs="{'invisible': [('self_invoice', '=', False)], 'readonly': [('self_invoice_sequence_id', '!=', False), ('self_invoice_refund_sequence_id', '!=', False)]}"
+                        attrs="{'invisible': [('self_invoice', '=', False)]}"
                     />
                     <button
                         name="action_set_self_invoice"


### PR DESCRIPTION
Remove readonly from `self_invoice_partner_prefix` because throws an error

Fast fix...

@moduon

@rafaelbn @etobella 