### PR TITLE
[FIX] Pre-commit flake8 repo gitlab->github

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -113,7 +113,7 @@ repos:
           - requirements.txt
           - --header
           - "# generated from manifests external_dependencies"
-  - repo: https://gitlab.com/PyCQA/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 3.8.3
     hooks:
       - id: flake8


### PR DESCRIPTION
According to https://flake8.pycqa.org/en/latest/user/using-hooks.html the Flake8 pre-commit hook now lives on github. 

The gitlab repo runs into a 404. 