### PR TITLE
[FIX] Stock_Picking_invoicing: ACL if user doesnt have account group.

### DIFF
--- a/stock_picking_invoicing/views/stock_picking.xml
+++ b/stock_picking_invoicing/views/stock_picking.xml
@@ -41,7 +41,12 @@
                     attrs="{'invisible': [('invoice_state', 'in', [False, 'none'])]}"
                 >
                     <group colspan="2">
-                        <field name="invoice_ids" coslpan="2" nolabel="1">
+                        <field
+                            name="invoice_ids"
+                            coslpan="2"
+                            nolabel="1"
+                            groups="account.group_account_invoice"
+                        >
                             <tree>
                                 <field name="partner_id" />
                                 <field name="name" />


### PR DESCRIPTION
# PR Content
This fixes an ACL error when trying to open a picking with attached invoices, when the user doesnt have rights to read the invoices. 

Apparently Odoo still tries to read the field, even though the parent `page` already had `groups=account.group_account_invoice`.

## Trivia

Yesterday I thought this issue lies in [upstream in stock_picking_invoice_link](https://github.com/OCA/stock-logistics-workflow/pull/1167#event-8088373873). 
But upon further testing, I realized, that the `read` call that prompts the ACL error, is issued by the `invoice_ids` subtree in this module. 