### PR TITLE
[13.0][FIX] sale_line_refund_to_invoice_qty: do not change invoiced qty

### DIFF
--- a/sale_line_refund_to_invoice_qty/models/sale.py
+++ b/sale_line_refund_to_invoice_qty/models/sale.py
@@ -13,28 +13,27 @@ class SaleOrderLine(models.Model):
     )
 
     @api.depends(
-        "qty_invoiced",
-        "qty_delivered",
-        "product_uom_qty",
-        "order_id.state",
         "invoice_lines.move_id.state",
         "invoice_lines.quantity",
         "invoice_lines.sale_qty_to_reinvoice",
     )
-    def _get_to_invoice_qty(self):
-        super()._get_to_invoice_qty()
+    def _get_invoice_qty(self):
+        res = super()._get_invoice_qty()
+        # Revert effect of refunds in invoice_qty when `sale_qty_to_reinvoice`
+        # is not set.
         for line in self:
-            qty_to_invoice = line.qty_to_invoice
+            qty_invoiced = line.qty_invoiced
             for invoice_line in line.invoice_lines:
                 if (
                     invoice_line.move_id.state != "cancel"
                     and invoice_line.move_id.type == "out_refund"
                     and not invoice_line.sale_qty_to_reinvoice
                 ):
-                    qty_to_invoice -= invoice_line.product_uom_id._compute_quantity(
+                    qty_invoiced += invoice_line.product_uom_id._compute_quantity(
                         invoice_line.quantity, line.product_uom
                     )
-            line.qty_to_invoice = qty_to_invoice
+            line.qty_invoiced = qty_invoiced
+        return res
 
     @api.depends(
         "product_uom_qty",

--- a/sale_line_refund_to_invoice_qty/readme/CONTRIBUTORS.rst
+++ b/sale_line_refund_to_invoice_qty/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Jordi Masvidal <jordi.masvidal@forgeflow.com>
+* Lois Rilo <lois.rilo@forgeflow.com>

--- a/sale_line_refund_to_invoice_qty/tests/test_sale_line_refund_to_invoice_qty.py
+++ b/sale_line_refund_to_invoice_qty/tests/test_sale_line_refund_to_invoice_qty.py
@@ -49,6 +49,7 @@ class TestSaleLineRefundToInvoiceQty(SavepointCase):
         Test that the quantities refunded are not considered as quantities to
         reinvoice in the sales order line, when the boolean is checked.
         """
+        self.assertEqual(self.order.order_line[0].qty_invoiced, 5.0)
         reversal_wizard = self.move_reversal_wiz(self.invoice)
         reversal_wizard.write({"sale_qty_to_reinvoice": False})
         credit_note = self.env["account.move"].browse(
@@ -56,6 +57,7 @@ class TestSaleLineRefundToInvoiceQty(SavepointCase):
         )
         for line in credit_note.line_ids:
             self.assertFalse(line.sale_qty_to_reinvoice)
+        self.assertEqual(self.order.order_line[0].qty_invoiced, 5.0)
         self.assertEqual(self.order.order_line[0].qty_to_invoice, 0.0)
         self.assertEqual(self.order.order_line[0].qty_refunded_not_invoiceable, 5.0)
 
@@ -64,11 +66,13 @@ class TestSaleLineRefundToInvoiceQty(SavepointCase):
         Test that the quantities refunded are considered as quantities to
         reinvoice in the sales order line, when the boolean is left unchecked.
         """
+        self.assertEqual(self.order.order_line[0].qty_invoiced, 5.0)
         reversal_wizard = self.move_reversal_wiz(self.invoice)
         credit_note = self.env["account.move"].browse(
             reversal_wizard.reverse_moves()["res_id"]
         )
         for line in credit_note.line_ids:
             self.assertTrue(line.sale_qty_to_reinvoice)
+        self.assertEqual(self.order.order_line[0].qty_invoiced, 0.0)
         self.assertEqual(self.order.order_line[0].qty_to_invoice, 5.0)
         self.assertEqual(self.order.order_line[0].qty_refunded_not_invoiceable, 0.0)


### PR DESCRIPTION
when you mark a refund to not be reinvoiced, the invoice qty should not be reduced, because it is already invoiced and you won't invoice it again.

@ForgeFlow