### PR TITLE
[14.0][FW] sale_line_refund_to_invoice_qty: do not change invoiced qty

### DIFF
--- a/sale_line_refund_to_invoice_qty/readme/CONTRIBUTORS.rst
+++ b/sale_line_refund_to_invoice_qty/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Jordi Masvidal <jordi.masvidal@forgeflow.com>
+* Lois Rilo <lois.rilo@forgeflow.com>

--- a/sale_line_refund_to_invoice_qty/tests/test_sale_line_refund_to_invoice_qty.py
+++ b/sale_line_refund_to_invoice_qty/tests/test_sale_line_refund_to_invoice_qty.py
@@ -50,6 +50,7 @@ class TestSaleLineRefundToInvoiceQty(SavepointCase):
         Test that the quantities refunded are not considered as quantities to
         reinvoice in the sales order line, when the boolean is checked.
         """
+        self.assertEqual(self.order.order_line[0].qty_invoiced, 5.0)
         reversal_wizard = self.move_reversal_wiz(self.invoice)
         reversal_wizard.write({"sale_qty_to_reinvoice": False})
         credit_note = self.env["account.move"].browse(
@@ -57,6 +58,7 @@ class TestSaleLineRefundToInvoiceQty(SavepointCase):
         )
         for line in credit_note.line_ids:
             self.assertFalse(line.sale_qty_to_reinvoice)
+        self.assertEqual(self.order.order_line[0].qty_invoiced, 5.0)
         self.assertEqual(self.order.order_line[0].qty_to_invoice, 0.0)
         self.assertEqual(self.order.order_line[0].qty_refunded_not_invoiceable, 5.0)
 
@@ -65,11 +67,13 @@ class TestSaleLineRefundToInvoiceQty(SavepointCase):
         Test that the quantities refunded are considered as quantities to
         reinvoice in the sales order line, when the boolean is left unchecked.
         """
+        self.assertEqual(self.order.order_line[0].qty_invoiced, 5.0)
         reversal_wizard = self.move_reversal_wiz(self.invoice)
         credit_note = self.env["account.move"].browse(
             reversal_wizard.reverse_moves()["res_id"]
         )
         for line in credit_note.line_ids:
             self.assertTrue(line.sale_qty_to_reinvoice)
+        self.assertEqual(self.order.order_line[0].qty_invoiced, 0.0)
         self.assertEqual(self.order.order_line[0].qty_to_invoice, 5.0)
         self.assertEqual(self.order.order_line[0].qty_refunded_not_invoiceable, 0.0)


### PR DESCRIPTION
when you mark a refund to not be reinvoiced, the invoice qty should not be reduced, because it is already invoiced and you won't invoice it again.