### PR TITLE
[15.0][FIX] account_invoice_pricelist: Make tests resilient

### DIFF
--- a/account_invoice_pricelist/tests/test_account_move_pricelist.py
+++ b/account_invoice_pricelist/tests/test_account_move_pricelist.py
@@ -28,6 +28,13 @@ class TestAccountMovePricelist(common.SavepointCase):
         cls.journal_sale = cls.env["account.journal"].create(
             {"name": "Test sale journal", "type": "sale", "code": "TEST_SJ"}
         )
+        # Make sure the currency of the company is USD, as this not always happens
+        # To be removed in V17: https://github.com/odoo/odoo/pull/107113
+        cls.company = cls.env.company
+        cls.env.cr.execute(
+            "UPDATE res_company SET currency_id = %s WHERE id = %s",
+            (cls.env.ref("base.USD").id, cls.company.id),
+        )
         cls.at_receivable = cls.env["account.account.type"].create(
             {
                 "name": "Test receivable account",
@@ -41,14 +48,6 @@ class TestAccountMovePricelist(common.SavepointCase):
                 "code": "TEST_RA",
                 "user_type_id": cls.at_receivable.id,
                 "reconcile": True,
-            }
-        )
-        cls.partner = cls.env["res.partner"].create(
-            {
-                "name": "Test Partner",
-                "property_product_pricelist": 1,
-                "property_account_receivable_id": cls.a_receivable.id,
-                "property_account_position_id": cls.fiscal_position.id,
             }
         )
         cls.product = cls.env["product.template"].create(
@@ -69,6 +68,14 @@ class TestAccountMovePricelist(common.SavepointCase):
                         },
                     )
                 ],
+            }
+        )
+        cls.partner = cls.env["res.partner"].create(
+            {
+                "name": "Test Partner",
+                "property_product_pricelist": cls.sale_pricelist.id,
+                "property_account_receivable_id": cls.a_receivable.id,
+                "property_account_position_id": cls.fiscal_position.id,
             }
         )
         cls.sale_pricelist_fixed_without_discount = cls.ProductPricelist.create(
@@ -248,10 +255,7 @@ class TestAccountMovePricelist(common.SavepointCase):
 
     def test_account_invoice_pricelist(self):
         self.invoice._onchange_partner_id_account_invoice_pricelist()
-        self.assertEqual(
-            self.invoice.pricelist_id,
-            self.invoice.partner_id.property_product_pricelist,
-        )
+        self.assertEqual(self.invoice.pricelist_id, self.sale_pricelist)
 
     def test_account_invoice_change_pricelist(self):
         self.invoice.pricelist_id = self.sale_pricelist.id


### PR DESCRIPTION
Forward-port of #1352

- Depending on the installed set of modules, the company currency may be USD or EUR. If the second case, these tests will fail, so we make sure that the company currency is USD for our tests, doing the change by SQL, as there's a Python constraint that prevents it.
- On contrary, the main pricelist doesn't change its currency, so we can have an incompatible currency.
- The onchange partner test should assert fixed data.

Not needed in v17 due to: https://github.com/odoo/odoo/pull/107113.

@Tecnativa 