### PR TITLE
[13.0][FIX] account_invoice_refund_reason: refund and new draft invoice

### DIFF
--- a/account_invoice_refund_reason/wizard/account_move_reversal.py
+++ b/account_invoice_refund_reason/wizard/account_move_reversal.py
@@ -17,6 +17,5 @@ class AccountMoveReversal(models.TransientModel):
 
     def reverse_moves(self):
         res = super().reverse_moves()
-        credit_note = self.env["account.move"].browse(res["res_id"])
-        credit_note.write({"reason_id": self.reason_id})
+        self.move_id.reversal_move_id.write({"reason_id": self.reason_id})
         return res


### PR DESCRIPTION
Issue:
When creating a credit note with the method _Full refund and new draft invoice_ the refund reason will be added to the new draft invoice. 

Fix:
This happens since when using this method the window action returned is for the new draft invoice. 
Using the existing link reversal_move_id on the original invoice to locate the invoice credit note we will cover all credit note methods. 