### PR TITLE
[FIX] account_invoice_supplier_self_invoice: Use a smaller logo

### DIFF
--- a/account_invoice_supplier_self_invoice/views/report_self_invoice.xml
+++ b/account_invoice_supplier_self_invoice/views/report_self_invoice.xml
@@ -15,8 +15,8 @@
             <div class="row">
                 <div class="col-6">
                     <img
-                        t-if="o.partner_id.image_1024"
-                        t-att-src="image_data_uri(o.partner_id.image_1024)"
+                        t-if="o.partner_id.image_128"
+                        t-att-src="image_data_uri(o.partner_id.image_128)"
                         alt="Logo"
                     />
                 </div>


### PR DESCRIPTION
Right now, it uses a 1024 logo, and it is too large. With this change, we use a smaller logo

@rafaelbn @Shide 