### PR TITLE
[IMP][12.0] account_invoice_supplierinfo_update : improve _is_correct_price function

### DIFF
--- a/account_invoice_supplierinfo_update/models/account_invoice_line.py
+++ b/account_invoice_supplierinfo_update/models/account_invoice_line.py
@@ -32,7 +32,9 @@ class AccountInvoiceLine(models.Model):
             are added in supplierinfo. (discount for exemple)
         """
         self.ensure_one()
-        return not float_compare(
+        return (
+            not self.uom_id or self.uom_id == supplierinfo.product_uom
+        ) and not float_compare(
             self._get_unit_price_in_purchase_uom(),
             supplierinfo.price,
             precision_rounding=self.invoice_id.currency_id.rounding,
@@ -57,7 +59,9 @@ class AccountInvoiceLine(models.Model):
             'product_id': self.product_id.id,
             'supplierinfo_id': supplierinfo and supplierinfo.id or False,
             'current_price': supplierinfo and supplierinfo.price or False,
-            'new_price': price_unit,
+            'new_price': self.price_unit,
+            'current_uom_id': supplierinfo and supplierinfo.product_uom.id or False,
+            'new_uom_id': self.uom_id.id,
             'current_min_quantity':
                 supplierinfo and supplierinfo.min_qty or False,
             'new_min_quantity':

--- a/account_invoice_supplierinfo_update/models/account_invoice_line.py
+++ b/account_invoice_supplierinfo_update/models/account_invoice_line.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import api, models
+from odoo.tools import float_compare
 
 
 class AccountInvoiceLine(models.Model):
@@ -31,7 +32,11 @@ class AccountInvoiceLine(models.Model):
             are added in supplierinfo. (discount for exemple)
         """
         self.ensure_one()
-        return self._get_unit_price_in_purchase_uom() == supplierinfo.price
+        return not float_compare(
+            self._get_unit_price_in_purchase_uom(),
+            supplierinfo.price,
+            precision_rounding=self.invoice_id.currency_id.rounding,
+        )
 
     @api.multi
     def _prepare_supplier_wizard_line(self, supplierinfo):

--- a/account_invoice_supplierinfo_update/tests/test_account_invoice_supplierinfo_update.py
+++ b/account_invoice_supplierinfo_update/tests/test_account_invoice_supplierinfo_update.py
@@ -31,7 +31,7 @@ class Tests(TransactionCase):
              'date_invoice': '%s-01-01' % datetime.now().year,
              'invoice_line_ids': [(0, 0, {'product_id': self.product1.id,
                                           'name': 'iPad Retina Display',
-                                          'quantity': 10.0,
+                                          'quantity': 12.0,
                                           'price_unit': 400.0,
                                           'uom_id': unit.id,
                                           'account_id': self.prod_account.id,
@@ -104,22 +104,53 @@ class Tests(TransactionCase):
 
     def test_update_pricelist_supplierinfo_uom_conversion(self):
         """ Price is converted to the product's purchase UOM """
-        self.product1.uom_po_id = self.env.ref('uom.product_uom_dozen')
-        invoice_line = self.invoice.invoice_line_ids.filtered(
-            lambda ail: ail.product_id == self.product1)
-        invoice_line.write({'price_unit': 33.0})
+
+        # 1. check supplierinfo with an invoice with 12 Units x 400 $
         wizard = self.wizard_obj.with_context(
             self.invoice.check_supplierinfo()['context']).create({})
-        line = wizard.line_ids.filtered(
-            lambda line: line.product_id == self.product1)
-
-        # Prices are converted to the purchase UOM.
-        # 33 per unit equals 396 per dozen
-        self.assertEquals(line.new_price, 396.0)
-
         wizard.update_supplierinfo()
+
         supplierinfo = self.supplierinfo_obj.search([
             ('name', '=', self.invoice.supplier_partner_id.id),
             ('product_tmpl_id', '=', self.product1.product_tmpl_id.id)])
-        self.assertEquals(supplierinfo.price, 396.0)
-        self.assertTrue(invoice_line._is_correct_price(supplierinfo))
+
+        self.assertEquals(supplierinfo.price, 400.0)
+        self.assertEquals(
+            supplierinfo.product_uom,
+            self.env.ref('uom.product_uom_unit')
+        )
+
+        # 2. check supplierinfo with an invoice with 12 No Uom) 401 $
+        invoice_line = self.invoice.invoice_line_ids.filtered(
+            lambda line: line.product_id == self.product1)
+        invoice_line.write({
+            "uom_id": False,
+            "price_unit": 401,
+        })
+        wizard = self.wizard_obj.with_context(
+            self.invoice.check_supplierinfo()['context']).create({})
+        wizard.update_supplierinfo()
+
+        self.assertEquals(supplierinfo.price, 401.0)
+        self.assertEquals(
+            supplierinfo.product_uom,
+            self.env.ref('uom.product_uom_unit')
+        )
+
+        # 3. check supplierinfo with an invoice with 1 dozen x 4800 $
+        invoice_line = self.invoice.invoice_line_ids.filtered(
+            lambda line: line.product_id == self.product1)
+        invoice_line.write({
+            "quantity": 1,
+            "uom_id": self.env.ref('uom.product_uom_dozen').id,
+            "price_unit": 4812,
+        })
+        wizard = self.wizard_obj.with_context(
+            self.invoice.check_supplierinfo()['context']).create({})
+        wizard.update_supplierinfo()
+
+        self.assertEquals(supplierinfo.price, 4812.0)
+        self.assertEquals(
+            supplierinfo.product_uom,
+            self.env.ref('uom.product_uom_dozen')
+        )

--- a/account_invoice_supplierinfo_update/tests/test_account_invoice_supplierinfo_update.py
+++ b/account_invoice_supplierinfo_update/tests/test_account_invoice_supplierinfo_update.py
@@ -87,8 +87,7 @@ class Tests(TransactionCase):
         ])
         self.assertEquals(len(supplierinfos1), 1)
         self.assertEqual(supplierinfos1.currency_id, self.currency)
-        self.assertEqual(supplierinfos1.min_qty, 6.0)
-
+        self.assertEquals(supplierinfos1.min_qty, 6.0)
         self.assertEquals(supplierinfos1.price, 400.0)
 
         supplierinfos2 = self.supplierinfo_obj.search([

--- a/account_invoice_supplierinfo_update/wizard/wizard_update_invoice_supplierinfo.py
+++ b/account_invoice_supplierinfo_update/wizard/wizard_update_invoice_supplierinfo.py
@@ -33,9 +33,19 @@ class WizardUpdateInvoiceSupplierinfo(models.TransientModel):
             supplierinfo = line.supplierinfo_id
             # Create supplierinfo if not exist
             if not supplierinfo:
-                supplierinfo_obj.create(line._prepare_supplierinfo())
+                vals = line._prepare_supplierinfo()
+                supplierinfo_obj.create(vals)
             else:
-                supplierinfo.write(line._prepare_supplierinfo_update())
+                vals = line._prepare_supplierinfo_update()
+                supplierinfo.write(vals)
+            # Manually write uom_po_id on product
+            # because unfortunately product_uom is a related on supplierinfo
+            # and writing product_uom doesn't change the related field.
+            if (
+                "product_uom" in vals
+                and vals["product_uom"] != line.product_id.uom_po_id.id
+            ):
+                line.product_id.uom_po_id = vals["product_uom"]
 
         # Mark the invoice as checked
         self.invoice_id.write({'supplierinfo_ok': True})

--- a/account_invoice_supplierinfo_update/wizard/wizard_update_invoice_supplierinfo.xml
+++ b/account_invoice_supplierinfo_update/wizard/wizard_update_invoice_supplierinfo.xml
@@ -17,7 +17,9 @@
                         <field name="current_min_quantity" attrs="{'invisible': [('supplierinfo_id', '=', False)]}"/>
                         <field name="new_min_quantity"/>
                         <field name="current_price" attrs="{'invisible': [('supplierinfo_id', '=', False)]}"/>
+                        <field name="current_uom_id" attrs="{'invisible': [('supplierinfo_id', '=', False)]}" groups="uom.group_uom"/>
                         <field name="new_price"/>
+                        <field name="new_uom_id" groups="uom.group_uom"/>
                         <field name="price_variation" attrs="{'invisible': [('price_variation', '=', 0.0)]}"/>
                     </tree>
                 </field>

--- a/account_invoice_supplierinfo_update/wizard/wizard_update_invoice_supplierinfo_line.py
+++ b/account_invoice_supplierinfo_update/wizard/wizard_update_invoice_supplierinfo_line.py
@@ -25,6 +25,15 @@ class WizardUpdateInvoiceSupplierinfoLine(models.TransientModel):
     new_min_quantity = fields.Float(
         string='New Min Quantity', required=True)
 
+    current_uom_id = fields.Many2one(
+        comodel_name="uom.uom",
+        related='supplierinfo_id.product_uom',
+        readonly=True)
+
+    new_uom_id = fields.Many2one(
+        comodel_name="uom.uom",
+        string='New UoM')
+
     current_price = fields.Float(
         related='supplierinfo_id.price',
         digits=dp.get_precision('Product Price'),
@@ -60,8 +69,11 @@ class WizardUpdateInvoiceSupplierinfoLine(models.TransientModel):
 
     def _prepare_supplierinfo_update(self):
         self.ensure_one()
-        return {
+        res = {
             'min_qty': self.new_min_quantity,
             'price': self.new_price,
             'currency_id': self.wizard_id.invoice_id.currency_id.id,
         }
+        if self.new_uom_id:
+            res["product_uom"] = self.new_uom_id.id
+        return res


### PR DESCRIPTION
- [FIX] account_invoice_supplierinfo_update : use float compare to avoid false positive

- [FIX] account_invoice_supplierinfo_update : update supplierinfo min_qty, based on new_min_quantity value on wizard line

- [IMP] account_invoice_supplierinfo_update : Check if the uom of the invoice line is the same as the uom of supplierinfo. If not, allow to change the UoM in the wizard

![image](https://user-images.githubusercontent.com/3407482/222450784-257c8af6-0f4d-441b-ad07-c980984fe2f3.png)
