### PR TITLE
[IMP] account_invoice_supplierinfo_update_*_discount : Do not display discounts column if all the values are null

### DIFF
--- a/account_invoice_supplierinfo_update_discount/wizard/__init__.py
+++ b/account_invoice_supplierinfo_update_discount/wizard/__init__.py
@@ -1,2 +1,2 @@
-
+from . import wizard_update_invoice_supplierinfo
 from . import wizard_update_invoice_supplierinfo_line

--- a/account_invoice_supplierinfo_update_discount/wizard/wizard_update_invoice_supplierinfo.py
+++ b/account_invoice_supplierinfo_update_discount/wizard/wizard_update_invoice_supplierinfo.py
@@ -1,0 +1,21 @@
+# Copyright (C) 2023-Today: GRAP (http://www.grap.coop)
+# @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, fields, models
+
+
+class WizardUpdateInvoiceSupplierinfo(models.TransientModel):
+    _inherit = 'wizard.update.invoice.supplierinfo'
+
+    display_discount = fields.Boolean(
+        compute="_compute_display_discount",
+    )
+
+    @api.depends("line_ids.current_discount", "line_ids.new_discount")
+    def _compute_display_discount(self):
+        for wizard in self:
+            wizard.display_discount = (
+                any(wizard.mapped("line_ids.current_discount"))
+                or any(wizard.mapped("line_ids.new_discount"))
+            )

--- a/account_invoice_supplierinfo_update_discount/wizard/wizard_update_invoice_supplierinfo.xml
+++ b/account_invoice_supplierinfo_update_discount/wizard/wizard_update_invoice_supplierinfo.xml
@@ -5,9 +5,18 @@
         <field name="model">wizard.update.invoice.supplierinfo</field>
         <field name="inherit_id" ref="account_invoice_supplierinfo_update.view_wizard_update_invoice_supplierinfo_form" />
         <field name="arch" type="xml">
+            <field name="state" position="after">
+                <field name="display_discount" invisible="1"/>
+            </field>
             <xpath expr="//field[@name='line_ids']/tree/field[@name='price_variation']" position="after">
-                <field name="current_discount" attrs="{'invisible': [('supplierinfo_id', '=', False)]}"/>
-                <field name="new_discount"/>
+                <field name="current_discount" attrs="{
+                    'invisible': [('supplierinfo_id', '=', False)],
+                    'column_invisible': [('parent.display_discount', '=', False)],
+                }"
+                    />
+                <field name="new_discount"  attrs="{
+                    'column_invisible': [('parent.display_discount', '=', False)],
+                }"/>
             </xpath>
         </field>
     </record>

--- a/account_invoice_supplierinfo_update_triple_discount/wizard/__init__.py
+++ b/account_invoice_supplierinfo_update_triple_discount/wizard/__init__.py
@@ -1,1 +1,2 @@
+from . import wizard_update_invoice_supplierinfo
 from . import wizard_update_invoice_supplierinfo_line

--- a/account_invoice_supplierinfo_update_triple_discount/wizard/wizard_update_invoice_supplierinfo.py
+++ b/account_invoice_supplierinfo_update_triple_discount/wizard/wizard_update_invoice_supplierinfo.py
@@ -1,0 +1,33 @@
+# Copyright (C) 2023-Today: GRAP (http://www.grap.coop)
+# @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, fields, models
+
+
+class WizardUpdateInvoiceSupplierinfo(models.TransientModel):
+    _inherit = 'wizard.update.invoice.supplierinfo'
+
+    display_discount2 = fields.Boolean(
+        compute="_compute_display_discount2",
+    )
+
+    display_discount3 = fields.Boolean(
+        compute="_compute_display_discount3",
+    )
+
+    @api.depends("line_ids.current_discount2", "line_ids.new_discount2")
+    def _compute_display_discount2(self):
+        for wizard in self:
+            wizard.display_discount2 = (
+                any(wizard.mapped("line_ids.current_discount2"))
+                or any(wizard.mapped("line_ids.new_discount2"))
+            )
+
+    @api.depends("line_ids.current_discount3", "line_ids.new_discount3")
+    def _compute_display_discount3(self):
+        for wizard in self:
+            wizard.display_discount3 = (
+                any(wizard.mapped("line_ids.current_discount3"))
+                or any(wizard.mapped("line_ids.new_discount3"))
+            )

--- a/account_invoice_supplierinfo_update_triple_discount/wizard/wizard_update_invoice_supplierinfo.xml
+++ b/account_invoice_supplierinfo_update_triple_discount/wizard/wizard_update_invoice_supplierinfo.xml
@@ -10,11 +10,25 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         <field name="model">wizard.update.invoice.supplierinfo</field>
         <field name="inherit_id" ref="account_invoice_supplierinfo_update_discount.view_wizard_update_invoice_supplierinfo_form" />
         <field name="arch" type="xml">
+            <field name="display_discount" position="after">
+                <field name="display_discount2" invisible="1"/>
+                <field name="display_discount3" invisible="1"/>
+            </field>
             <xpath expr="//field[@name='line_ids']/tree/field[@name='new_discount']" position="after">
-                <field name="current_discount2" attrs="{'invisible': [('supplierinfo_id', '=', False)]}"/>
-                <field name="new_discount2"/>
-                <field name="current_discount3" attrs="{'invisible': [('supplierinfo_id', '=', False)]}"/>
-                <field name="new_discount3"/>
+                <field name="current_discount2" attrs="{
+                    'invisible': [('supplierinfo_id', '=', False)],
+                    'column_invisible': [('parent.display_discount2', '=', False)],
+                }"/>
+                <field name="new_discount2" attrs="{
+                    'column_invisible': [('parent.display_discount2', '=', False)],
+                }"/>
+                <field name="current_discount3" attrs="{
+                    'invisible': [('supplierinfo_id', '=', False)],
+                    'column_invisible': [('parent.display_discount3', '=', False)],
+                }"/>
+                <field name="new_discount3" attrs="{
+                    'column_invisible': [('parent.display_discount3', '=', False)],
+                }"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
**Rational :**
purchase_discount and purchase_triple_discount exists to handle invoices of some suppliers that apply up to 3 levels of discounts.
But in most cases, suppliers doesn't provide discounts level, so, the display of column with null value is useless.

This trivial PR hide discount column if no discount is applied.