### PR TITLE
12.0 add account_invoice_supplierinfo_update_qty_multiplier

### DIFF
--- a/account_invoice_supplierinfo_update_qty_multiplier/__init__.py
+++ b/account_invoice_supplierinfo_update_qty_multiplier/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizard

--- a/account_invoice_supplierinfo_update_qty_multiplier/__manifest__.py
+++ b/account_invoice_supplierinfo_update_qty_multiplier/__manifest__.py
@@ -1,0 +1,24 @@
+# Copyright (C) 2023-Today: GRAP (http://www.grap.coop)
+# @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "Account Invoice - Quantity Multiplier Update",
+    "summary": "In the invoice Supplierinfo wizard,"
+    " allow to change the Quantity Multiplier field",
+    "version": "12.0.1.0.0",
+    "category": "Accounting & Finance",
+    "website": "https://github.com/OCA/account-invoicing",
+    "author": "GRAP,Odoo Community Association (OCA)",
+    "maintainers": ["legalsylvain"],
+    "license": "AGPL-3",
+    "depends": [
+        "account_invoice_supplierinfo_update",
+        "product_supplierinfo_qty_multiplier",
+    ],
+    "installable": True,
+    "auto_install": True,
+    "data": [
+        "wizard/wizard_update_invoice_supplierinfo.xml",
+    ],
+}

--- a/account_invoice_supplierinfo_update_qty_multiplier/i18n/fr.po
+++ b/account_invoice_supplierinfo_update_qty_multiplier/i18n/fr.po
@@ -1,0 +1,37 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#   * account_invoice_supplierinfo_update_qty_multiplier
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-03-08 15:17+0000\n"
+"PO-Revision-Date: 2023-03-08 15:17+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_invoice_supplierinfo_update_qty_multiplier
+#: model:ir.model.fields,field_description:account_invoice_supplierinfo_update_qty_multiplier.field_wizard_update_invoice_supplierinfo_line__current_multiplier_qty
+msgid "Current Multiplier Qty"
+msgstr "Conditionnement"
+
+#. module: account_invoice_supplierinfo_update_qty_multiplier
+#: model:ir.model,name:account_invoice_supplierinfo_update_qty_multiplier.model_account_invoice_line
+msgid "Invoice Line"
+msgstr "Ligne de facture"
+
+#. module: account_invoice_supplierinfo_update_qty_multiplier
+#: model:ir.model.fields,field_description:account_invoice_supplierinfo_update_qty_multiplier.field_wizard_update_invoice_supplierinfo_line__new_multiplier_qty
+msgid "New Multiplier Qty"
+msgstr "Nouveau conditionnement"
+
+#. module: account_invoice_supplierinfo_update_qty_multiplier
+#: model:ir.model,name:account_invoice_supplierinfo_update_qty_multiplier.model_wizard_update_invoice_supplierinfo_line
+msgid "Wizard Line to update supplierinfo"
+msgstr ""
+

--- a/account_invoice_supplierinfo_update_qty_multiplier/models/__init__.py
+++ b/account_invoice_supplierinfo_update_qty_multiplier/models/__init__.py
@@ -1,0 +1,1 @@
+from . import account_invoice_line

--- a/account_invoice_supplierinfo_update_qty_multiplier/models/account_invoice_line.py
+++ b/account_invoice_supplierinfo_update_qty_multiplier/models/account_invoice_line.py
@@ -1,0 +1,17 @@
+# Copyright (C) 2023-Today: GRAP (http://www.grap.coop)
+# @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, models
+
+
+class AccountInvoiceLine(models.Model):
+    _inherit = 'account.invoice.line'
+
+    @api.multi
+    def _prepare_supplier_wizard_line(self, supplierinfo):
+        res = super()._prepare_supplier_wizard_line(supplierinfo)
+        res['current_multiplier_qty'] = res['new_multiplier_qty'] = (
+            supplierinfo and supplierinfo.multiplier_qty
+        )
+        return res

--- a/account_invoice_supplierinfo_update_qty_multiplier/readme/DESCRIPTION.rst
+++ b/account_invoice_supplierinfo_update_qty_multiplier/readme/DESCRIPTION.rst
@@ -1,0 +1,7 @@
+This module is a glue module installed if the following module are installed:
+
+* ``account_invoice_supplierinfo_update`` (same repository)
+* ``product_supplierinfo_qty_multiplier`` (purchase-workflow repository)
+
+It allows to update 'Multiplier Qty' on supplierinfo, when updating supplierinfo
+with the wizard.

--- a/account_invoice_supplierinfo_update_qty_multiplier/tests/__init__.py
+++ b/account_invoice_supplierinfo_update_qty_multiplier/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_module

--- a/account_invoice_supplierinfo_update_qty_multiplier/tests/test_module.py
+++ b/account_invoice_supplierinfo_update_qty_multiplier/tests/test_module.py
@@ -1,0 +1,62 @@
+# Copyright (C) 2023 - Today: GRAP (http://www.grap.coop)
+# @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from datetime import datetime
+from odoo.tests.common import TransactionCase
+
+
+class TestModule(TransactionCase):
+
+    def setUp(self):
+        super().setUp()
+        self.AccountInvoice = self.env['account.invoice']
+        self.WizardUpdate = self.env['wizard.update.invoice.supplierinfo']
+        self.SupplierInfo = self.env['product.supplierinfo']
+
+        self.product1 = self.env.ref('product.product_product_4b')
+        unit = self.env.ref('uom.product_uom_unit')
+        account_id = self.env['account.account'].search(
+            [('user_type_id.type', '=', 'payable')], limit=1).id
+        journal_id = self.env['account.journal'].search(
+            [('type', '=', 'purchase')], limit=1).id
+        product_account_id = self.env.ref(
+            'account.demo_coffee_machine_account').id
+
+        self.invoice = self.AccountInvoice.create({
+            'journal_id': journal_id,
+            'partner_id': self.env.ref('base.res_partner_12').id,
+            'account_id': account_id,
+            'date_invoice': '%s-01-01' % datetime.now().year,
+            'invoice_line_ids': [(0, 0, {
+                'product_id': self.product1.id,
+                'name': 'iPad Retina Display',
+                'quantity': 10.0,
+                'price_unit': 400.0,
+                'uom_id': unit.id,
+                'account_id': product_account_id,
+            })],
+        })
+
+    # Test Section
+    def test_wizard(self):
+        # Launch and confirm Wizard
+        lines_for_update = self.invoice._get_update_supplierinfo_lines()
+        wizard = self.WizardUpdate.with_context(
+            default_line_ids=lines_for_update,
+            default_invoice_id=self.invoice.id).create({})
+        wizard.line_ids[0].new_multiplier_qty = 55
+        wizard.update_supplierinfo()
+
+        # Check Regressions
+        supplierinfo = self.SupplierInfo.search([
+            ('product_tmpl_id', '=', self.product1.product_tmpl_id.id),
+            ('name', '=', self.invoice.partner_id.id)])
+
+        self.assertEqual(
+            len(supplierinfo), 1,
+            "Regression : Confirming wizard should have create a supplierinfo")
+
+        self.assertEqual(
+            supplierinfo.multiplier_qty, 55,
+            "Confirming wizard should have update Multiplier Qty field.")

--- a/account_invoice_supplierinfo_update_qty_multiplier/wizard/__init__.py
+++ b/account_invoice_supplierinfo_update_qty_multiplier/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import wizard_update_invoice_supplierinfo_line

--- a/account_invoice_supplierinfo_update_qty_multiplier/wizard/wizard_update_invoice_supplierinfo.xml
+++ b/account_invoice_supplierinfo_update_qty_multiplier/wizard/wizard_update_invoice_supplierinfo.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <record id="view_wizard_update_invoice_supplierinfo_form" model="ir.ui.view">
+        <field name="model">wizard.update.invoice.supplierinfo</field>
+        <field name="inherit_id" ref="account_invoice_supplierinfo_update.view_wizard_update_invoice_supplierinfo_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='line_ids']/tree/field[@name='new_min_quantity']" position="after">
+                <field name="current_multiplier_qty" attrs="{
+                    'invisible': [('supplierinfo_id', '=', False)],
+                }"
+                    />
+                <field name="new_multiplier_qty"/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/account_invoice_supplierinfo_update_qty_multiplier/wizard/wizard_update_invoice_supplierinfo_line.py
+++ b/account_invoice_supplierinfo_update_qty_multiplier/wizard/wizard_update_invoice_supplierinfo_line.py
@@ -1,0 +1,25 @@
+# Copyright (C) 2023-Today: GRAP (http://www.grap.coop)
+# @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, fields, models
+
+
+class WizardUpdateInvoiceSupplierinfoLine(models.TransientModel):
+    _inherit = 'wizard.update.invoice.supplierinfo.line'
+
+    current_multiplier_qty = fields.Float(
+        string='Current Multiplier Qty',
+        readonly=True
+    )
+
+    new_multiplier_qty = fields.Float(
+        string='New Multiplier Qty',
+        required=True
+    )
+
+    @api.multi
+    def _prepare_supplierinfo_update(self):
+        res = super()._prepare_supplierinfo_update()
+        res['multiplier_qty'] = self.new_multiplier_qty
+        return res

--- a/setup/account_invoice_supplierinfo_update_qty_multiplier/odoo/addons/account_invoice_supplierinfo_update_qty_multiplier
+++ b/setup/account_invoice_supplierinfo_update_qty_multiplier/odoo/addons/account_invoice_supplierinfo_update_qty_multiplier
@@ -1,0 +1,1 @@
+../../../../account_invoice_supplierinfo_update_qty_multiplier

--- a/setup/account_invoice_supplierinfo_update_qty_multiplier/setup.py
+++ b/setup/account_invoice_supplierinfo_update_qty_multiplier/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module is a glue module installed if the following module are installed:

* ``account_invoice_supplierinfo_update`` (same repository)
* ``product_supplierinfo_qty_multiplier`` (purchase-workflow repository)

It allows to update 'Multiplier Qty' on supplierinfo, when updating supplierinfo
with the wizard.