### PR TITLE
[15.0][FIX] account_invoice_payment_term_date_due: fix view conflict with ocr

### DIFF
--- a/account_invoice_payment_term_date_due/views/account_move.xml
+++ b/account_invoice_payment_term_date_due/views/account_move.xml
@@ -18,7 +18,7 @@
                     t-translation="off"
                 >
                     <i class="fa fa-arrow-right mx-3" />
-                    <field name="invoice_date_due" force_save="1" readonly="1" />
+                    <field name="invoice_date_due" />
                 </span>
             </field>
         </field>


### PR DESCRIPTION
With this module we have realized that the `readonly` of this view, conflicted with the OCR, when you tried to transfer a pdf invoice to an Odoo invoice. It throws a _traceback_ on depending on which invoices because it would tell you that it was trying to write to the `invoice_date_due` field which is `readonly`.

We don't see a lot of sense in `readonly` and `force_save`. Because with the `text-muted oe_read_only` class of this same view, hides the `invoice_date_due` field from you in edit mode.

With this change, we would fix the traceback error.