### PR TITLE
[FIX] account_invoice_pricelist: fix unittest by renaming sale module

### DIFF
--- a/account_invoice_pricelist/tests/test_account_move_pricelist.py
+++ b/account_invoice_pricelist/tests/test_account_move_pricelist.py
@@ -6,7 +6,7 @@ import inspect
 from odoo.exceptions import UserError
 from odoo.tests import common
 
-from odoo.addons.sale.models.sale import SaleOrderLine as upstream
+from odoo.addons.sale.models.sale_order_line import SaleOrderLine as upstream
 
 # if this hash fails then the original function it was copied from
 # needs to be checked to see if there are any major changes that


### PR DESCRIPTION
![Captura de pantalla de 2023-04-12 17-28-57](https://user-images.githubusercontent.com/5335402/231607870-4dfad530-8bb1-4f8c-aef2-0db32f89cf87.png)

The reference is wrong since module name is sale_order_line

https://github.com/odoo/odoo/blob/15.0/addons/sale/models/sale_order_line.py