### PR TITLE
[14.0][IMP]Account_invoice_triple_discount: For in invoice_line_ids and not in line_ids

### DIFF
--- a/account_invoice_triple_discount/models/account_move.py
+++ b/account_invoice_triple_discount/models/account_move.py
@@ -16,9 +16,9 @@ class AccountMove(models.Model):
         restored after the original process is done
         """
         old_values_by_line_id = {}
-        digits = self.line_ids._fields["price_unit"]._digits
-        self.line_ids._fields["price_unit"]._digits = (16, 16)
-        for line in self.line_ids:
+        digits = self.invoice_line_ids._fields["price_unit"]._digits
+        self.invoice_line_ids._fields["price_unit"]._digits = (16, 16)
+        for line in self.invoice_line_ids:
             aggregated_discount = line._compute_aggregated_discount(line.discount)
             old_values_by_line_id[line.id] = {
                 "price_unit": line.price_unit,
@@ -26,9 +26,9 @@ class AccountMove(models.Model):
             }
             price_unit = line.price_unit * (1 - aggregated_discount / 100)
             line.update({"price_unit": price_unit, "discount": 0})
-        self.line_ids._fields["price_unit"]._digits = digits
+        self.invoice_line_ids._fields["price_unit"]._digits = digits
         res = super(AccountMove, self)._recompute_tax_lines(**kwargs)
-        for line in self.line_ids:
+        for line in self.invoice_line_ids:
             if line.id not in old_values_by_line_id:
                 continue
             line.update(old_values_by_line_id[line.id])

--- a/account_invoice_triple_discount/models/account_move.py
+++ b/account_invoice_triple_discount/models/account_move.py
@@ -12,12 +12,13 @@ class AccountMove(models.Model):
     def _recompute_tax_lines(self, **kwargs):
         """
         As the taxes are recalculated based on a single discount, we need to
-        simulate a multiple discount by changing the unit price. Values are
-        restored after the original process is done
+        simulate a multiple discount by changing temporarily the first discount
+        with the aggregated discount.
+        Values are restored after the original process is done
         """
+        old_values_by_line_id = {}
         digits = self.line_ids._fields["discount"]._digits
         self.line_ids._fields["discount"]._digits = (16, 16)
-        old_values_by_line_id = {}
         for line in self.line_ids:
             aggregated_discount = line._compute_aggregated_discount(line.discount)
             old_values_by_line_id[line.id] = {

--- a/account_invoice_triple_discount/tests/test_invoice_triple_discount.py
+++ b/account_invoice_triple_discount/tests/test_invoice_triple_discount.py
@@ -196,12 +196,13 @@ class TestInvoiceTripleDiscount(SavepointCase):
             line_form.quantity = 10
             line_form.price_unit = -2.00
         invoice_form.save()
-        for line in invoice.invoice_line_ids:
+        for line in invoice.line_ids:
             line.with_context(check_move_validity=False).update(
                 {"price_unit": -line.price_unit}
             )
         invoice.with_context(check_move_validity=False)._recompute_dynamic_lines(
-            recompute_all_taxes=True
+            recompute_all_taxes=True,
         )
+        invoice._check_balanced()
         self.assertEqual(invoice.move_type, "in_refund")
         self.assertEqual(round(invoice.amount_total, 2), 23.0)

--- a/account_invoice_triple_discount/tests/test_invoice_triple_discount.py
+++ b/account_invoice_triple_discount/tests/test_invoice_triple_discount.py
@@ -41,9 +41,7 @@ class TestInvoiceTripleDiscount(SavepointCase):
     @classmethod
     def _create_refund(cls, tax=False, date=False, in_type=False):
         refund_form = Form(
-            cls.env["account.move"].with_context(
-                default_move_type="in_refund"
-            )
+            cls.env["account.move"].with_context(default_move_type="in_refund")
         )
         # refund_form.partner_id = partner
         refund_form.name = "Test Refund for Triple Discount"
@@ -188,7 +186,7 @@ class TestInvoiceTripleDiscount(SavepointCase):
 
     def test_05_refund_negative_taxes(self):
         """
-        Tests refund negative taxes 
+        Tests refund negative taxes
         """
         invoice = self._create_refund(0)
         invoice_form = Form(invoice)

--- a/account_invoice_triple_discount/tests/test_invoice_triple_discount.py
+++ b/account_invoice_triple_discount/tests/test_invoice_triple_discount.py
@@ -43,7 +43,6 @@ class TestInvoiceTripleDiscount(SavepointCase):
         refund_form = Form(
             cls.env["account.move"].with_context(default_move_type="in_refund")
         )
-        # refund_form.partner_id = partner
         refund_form.name = "Test Refund for Triple Discount"
 
         with refund_form.invoice_line_ids.new() as refund_line:


### PR DESCRIPTION
We need this fix to avoid issues with `l10n_it_fatturapa_in` (https://github.com/OCA/l10n-italy/tree/14.0/l10n_it_fatturapa_in).
In this module there's a test that trying to import a refund with negative amounts and without this fix it fails cause tax sign it's not reversed unlike price unit.
So we analyzed how taxes are recomputed in 16.0 version of `account_invoice_triple_discount` and we found something different that adapted and applied to 14.0 version should no longer get issues with negative amounts.