### PR TITLE
[16.0][FIX] account_invoice_merge: this commit fixes the incorrect link bet…

### DIFF
--- a/account_invoice_merge/tests/test_account_invoice_merge.py
+++ b/account_invoice_merge/tests/test_account_invoice_merge.py
@@ -70,7 +70,6 @@ class TestAccountInvoiceMerge(AccountTestInvoicingCommon):
         return wiz
 
     def test_invoice_merge(self):
-
         self.assertEqual(len(self.invoice1.invoice_line_ids), 1)
         self.assertEqual(len(self.invoice2.invoice_line_ids), 1)
         invoice_len_args = [
@@ -134,7 +133,7 @@ class TestAccountInvoiceMerge(AccountTestInvoicingCommon):
             wiz.error_message, "All invoices must have the same: \n- Journal\n- Company"
         )
 
-    def test_callback(self):
+    def test_callback_different_sale_order_00(self):
         if "sale.order" not in self.env.registry:
             return True
         product_1, product_2 = self.env["product.product"].create(
@@ -223,3 +222,237 @@ class TestAccountInvoiceMerge(AccountTestInvoicingCommon):
         )
         invoices_2 = invoices_2.filtered(lambda i: i.state == "draft")
         self.assertEqual(sorted(invoices_2.ids), sorted(list(invoices_info.keys())))
+
+    def _add_qty_delivered_and_create_invoice(self, sale_order):
+        for line in sale_order.order_line:
+            if line.qty_delivered < line.product_uom_qty:
+                line.qty_delivered += 1
+        sale_order._create_invoices(final=True)
+
+    def _add_qty_received_and_create_invoice(self, purchase_order):
+        for line in purchase_order.order_line:
+            if line.qty_received < line.product_qty:
+                line.qty_received += 1
+        purchase_order.action_create_invoice()
+
+    def test_callback_different_sale_order_01(self):
+        if "sale.order" not in self.env.registry:
+            return True
+        product_1, product_2 = self.env["product.product"].create(
+            [
+                {"name": "product 1", "list_price": 5.0, "invoice_policy": "delivery"},
+                {"name": "product 2", "list_price": 10.0, "invoice_policy": "delivery"},
+            ]
+        )
+        # Test pre-computes of lines with order
+        sale_order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner_a.id,
+                "order_line": [
+                    Command.create({"product_id": product_1.id, "product_uom_qty": 5}),
+                    Command.create({"product_id": product_2.id, "product_uom_qty": 5}),
+                ],
+            }
+        )
+        sale_order_2 = sale_order.copy()
+
+        sale_order.action_confirm()
+        sale_order_2.action_confirm()
+
+        self._add_qty_delivered_and_create_invoice(sale_order)
+        self._add_qty_delivered_and_create_invoice(sale_order)
+        self._add_qty_delivered_and_create_invoice(sale_order)
+        self._add_qty_delivered_and_create_invoice(sale_order_2)
+        self._add_qty_delivered_and_create_invoice(sale_order_2)
+        self._add_qty_delivered_and_create_invoice(sale_order_2)
+
+        inv_sale_order = sale_order.mapped("order_line.invoice_lines.move_id")
+        inv_sale_order_2 = sale_order_2.mapped("order_line.invoice_lines.move_id")
+        total_inv_sale_order = inv_sale_order | inv_sale_order_2
+
+        self.assertEqual(len(inv_sale_order), 3)
+        self.assertEqual(len(inv_sale_order_2), 3)
+        self.assertEqual(len(total_inv_sale_order), 6)
+        for line in sale_order.order_line:
+            self.assertEqual(line.qty_delivered, 3)
+            self.assertEqual(line.qty_invoiced, 3)
+        for line in sale_order_2.order_line:
+            self.assertEqual(line.qty_delivered, 3)
+            self.assertEqual(line.qty_invoiced, 3)
+
+        invoices = (
+            sale_order.mapped("order_line.invoice_lines.move_id")[:1]
+            | sale_order_2.mapped("order_line.invoice_lines.move_id")[:1]
+        )
+        invoices.do_merge(keep_references=False, date_invoice=fields.Date.today())
+
+        inv_sale_order = sale_order.mapped("order_line.invoice_lines.move_id")
+        inv_sale_order_2 = sale_order_2.mapped("order_line.invoice_lines.move_id")
+        total_inv_sale_order = inv_sale_order | inv_sale_order_2
+
+        self.assertEqual(len(inv_sale_order), 3)
+        self.assertEqual(len(inv_sale_order_2), 3)
+        self.assertEqual(len(total_inv_sale_order), 5)
+        for line in sale_order.order_line:
+            self.assertEqual(line.qty_delivered, 3)
+            self.assertEqual(line.qty_invoiced, 3)
+        for line in sale_order_2.order_line:
+            self.assertEqual(line.qty_delivered, 3)
+            self.assertEqual(line.qty_invoiced, 3)
+
+    def test_callback_same_sale_order(self):
+        if "sale.order" not in self.env.registry:
+            return True
+        product_1, product_2 = self.env["product.product"].create(
+            [
+                {"name": "product 1", "list_price": 5.0, "invoice_policy": "delivery"},
+                {"name": "product 2", "list_price": 10.0, "invoice_policy": "delivery"},
+            ]
+        )
+        # Test pre-computes of lines with order
+        sale_order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner_a.id,
+                "order_line": [
+                    Command.create({"product_id": product_1.id, "product_uom_qty": 5}),
+                    Command.create({"product_id": product_2.id, "product_uom_qty": 5}),
+                ],
+            }
+        )
+
+        sale_order.action_confirm()
+        self._add_qty_delivered_and_create_invoice(sale_order)
+        self._add_qty_delivered_and_create_invoice(sale_order)
+        self._add_qty_delivered_and_create_invoice(sale_order)
+        self._add_qty_delivered_and_create_invoice(sale_order)
+        self._add_qty_delivered_and_create_invoice(sale_order)
+
+        invoices = sale_order.mapped("order_line.invoice_lines.move_id")
+        invoices[-1].button_cancel()
+        invoices[-2].action_post()
+
+        self.assertEqual(len(invoices), 5)
+        for line in sale_order.order_line:
+            self.assertEqual(line.qty_delivered, 5)
+            self.assertEqual(line.qty_invoiced, 4)
+
+        invoices[:2].do_merge(keep_references=False)
+
+        invoices = sale_order.mapped("order_line.invoice_lines.move_id")
+
+        self.assertEqual(len(invoices), 4)
+        for line in sale_order.order_line:
+            self.assertEqual(line.qty_delivered, 5)
+            self.assertEqual(line.qty_invoiced, 4)
+
+    def test_callback_different_purchase_order(self):
+        if "purchase.order" not in self.env.registry:
+            return True
+        product_1, product_2 = self.env["product.product"].create(
+            [
+                {"name": "product 1", "list_price": 5.0, "invoice_policy": "delivery"},
+                {"name": "product 2", "list_price": 10.0, "invoice_policy": "delivery"},
+            ]
+        )
+        # Test pre-computes of lines with order
+        purchase_order = self.env["purchase.order"].create(
+            {
+                "partner_id": self.partner_a.id,
+                "order_line": [
+                    Command.create({"product_id": product_1.id, "product_qty": 5}),
+                    Command.create({"product_id": product_2.id, "product_qty": 5}),
+                ],
+            }
+        )
+        purchase_order_2 = purchase_order.copy()
+
+        purchase_order.button_confirm()
+        purchase_order_2.button_confirm()
+
+        self._add_qty_received_and_create_invoice(purchase_order)
+        self._add_qty_received_and_create_invoice(purchase_order)
+        self._add_qty_received_and_create_invoice(purchase_order)
+        self._add_qty_received_and_create_invoice(purchase_order_2)
+        self._add_qty_received_and_create_invoice(purchase_order_2)
+        self._add_qty_received_and_create_invoice(purchase_order_2)
+
+        inv_purchase_order = purchase_order.mapped("order_line.invoice_lines.move_id")
+        inv_purchase_order_2 = purchase_order_2.mapped(
+            "order_line.invoice_lines.move_id"
+        )
+        total_inv_purchase_order = inv_purchase_order | inv_purchase_order_2
+
+        self.assertEqual(len(inv_purchase_order), 3)
+        self.assertEqual(len(inv_purchase_order_2), 3)
+        self.assertEqual(len(total_inv_purchase_order), 6)
+        for line in purchase_order.order_line:
+            self.assertEqual(line.qty_received, 3)
+            self.assertEqual(line.qty_invoiced, 3)
+        for line in purchase_order_2.order_line:
+            self.assertEqual(line.qty_received, 3)
+            self.assertEqual(line.qty_invoiced, 3)
+
+        invoices = inv_purchase_order[:1] | inv_purchase_order_2[:1]
+        invoices[:2].do_merge(keep_references=False)
+
+        inv_purchase_order = purchase_order.mapped("order_line.invoice_lines.move_id")
+        inv_purchase_order_2 = purchase_order_2.mapped(
+            "order_line.invoice_lines.move_id"
+        )
+        total_inv_purchase_order = inv_purchase_order | inv_purchase_order_2
+
+        self.assertEqual(len(inv_purchase_order), 3)
+        self.assertEqual(len(inv_purchase_order_2), 3)
+        self.assertEqual(len(total_inv_purchase_order), 5)
+        for line in purchase_order.order_line:
+            self.assertEqual(line.qty_received, 3)
+            self.assertEqual(line.qty_invoiced, 3)
+        for line in purchase_order_2.order_line:
+            self.assertEqual(line.qty_received, 3)
+            self.assertEqual(line.qty_invoiced, 3)
+
+    def test_callback_same_purchase_order(self):
+        if "purchase.order" not in self.env.registry:
+            return True
+        product_1, product_2 = self.env["product.product"].create(
+            [
+                {"name": "product 1", "list_price": 5.0, "invoice_policy": "delivery"},
+                {"name": "product 2", "list_price": 10.0, "invoice_policy": "delivery"},
+            ]
+        )
+        # Test pre-computes of lines with order
+        purchase_order = self.env["purchase.order"].create(
+            {
+                "partner_id": self.partner_a.id,
+                "order_line": [
+                    Command.create({"product_id": product_1.id, "product_qty": 5}),
+                    Command.create({"product_id": product_2.id, "product_qty": 5}),
+                ],
+            }
+        )
+
+        purchase_order.button_confirm()
+        self._add_qty_received_and_create_invoice(purchase_order)
+        self._add_qty_received_and_create_invoice(purchase_order)
+        self._add_qty_received_and_create_invoice(purchase_order)
+        self._add_qty_received_and_create_invoice(purchase_order)
+        self._add_qty_received_and_create_invoice(purchase_order)
+
+        invoices = purchase_order.mapped("order_line.invoice_lines.move_id")
+        invoices[-1].button_cancel()
+        invoices[-2].write({"invoice_date": fields.Date.today()})
+        invoices[-2].action_post()
+
+        self.assertEqual(len(invoices), 5)
+        for line in purchase_order.order_line:
+            self.assertEqual(line.qty_received, 5)
+            self.assertEqual(line.qty_invoiced, 4)
+
+        invoices[:2].do_merge(keep_references=False)
+
+        invoices = purchase_order.mapped("order_line.invoice_lines.move_id")
+
+        self.assertEqual(len(invoices), 4)
+        for line in purchase_order.order_line:
+            self.assertEqual(line.qty_received, 5)
+            self.assertEqual(line.qty_invoiced, 4)


### PR DESCRIPTION
This commit fixes the following cases.

1. A sales or purchase order with more than two invoices and we merge two of these. Without the change, the other invoice reference was lost.
2. X sales or purchase order with more than two invoices and we merge two of these. Without the change, the other invoice reference was lost.
3. Merge logic for purchase order invoices not implemented.


