### PR TITLE
[15.0][FIX] account_invoice_pricelist: Adapted Tests for changes made in Sale module.

### DIFF
--- a/account_invoice_pricelist/tests/test_account_move_pricelist.py
+++ b/account_invoice_pricelist/tests/test_account_move_pricelist.py
@@ -6,16 +6,16 @@ import inspect
 from odoo.exceptions import UserError
 from odoo.tests import common
 
-from odoo.addons.sale.models.sale import SaleOrderLine as upstream
+from odoo.addons.sale.models.sale_order_line import SaleOrderLine as upstream
 
 # if this hash fails then the original function it was copied from
 # needs to be checked to see if there are any major changes that
 # need to be updated in this module's _get_real_price_currency
 
-VALID_HASHES = ["7c0bb27c20598327008f81aee58cdfb4"]
+VALID_HASHES = ["ae1579f90ae87798e0d86f6b7427d4aa"]
 
 
-class TestAccountMovePricelist(common.SavepointCase):
+class TestAccountMovePricelist(common.TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()


### PR DESCRIPTION
Adapted Tests for changes made in Sale module, this problem generate error in others PRs example https://github.com/OCA/account-invoicing/pull/1452 the LOG https://github.com/OCA/account-invoicing/actions/runs/4942212532/jobs/8835537437?pr=1452#step:8:137

2023-05-10 23:27:32,617 255 ERROR odoo odoo.tests.loader: Can not `import account_invoice_pricelist`. 
Traceback (most recent call last):
  File "/opt/odoo/odoo/tests/loader.py", line 33, in _get_tests_modules
    mod = importlib.import_module('.tests', modpath)
  File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 848, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/__w/account-invoicing/account-invoicing/account_invoice_pricelist/tests/__init__.py", line 3, in <module>
    from . import test_account_move_pricelist
  File "/__w/account-invoicing/account-invoicing/account_invoice_pricelist/tests/test_account_move_pricelist.py", line 9, in <module>
    from odoo.addons.sale.models.sale import SaleOrderLine as upstream

By solving this first problem another appear

ERROR odoo odoo.sql_db: bad query: INSERT INTO "product_template" ("id", "active", "categ_id", "
create_date", "create_uid", "detailed_type", "list_price", "name", "priority", "purchase_ok", "s
ale_delay", "sale_ok", "sequence", "tracking", "uom_id", "uom_po_id", "write_date", "write_uid")
 VALUES (nextval('product_template_id_seq'), true, 1, '2023-05-11 01:16:13.968840', 1, 'consu', 
'100.00', 'Product Test', '0', true, 0.0, true, 1, 'none', 1, 1, '2023-05-11 01:16:13.968840', 1
) RETURNING id
ERROR: null value in column "purchase_line_warn" of relation "product_template" violates not-nul
l constraint  

To solve I just get the Default Values of the object.

cc @rvalyi @renatonlima 