### PR TITLE
[15.0][FIX] sale_timesheet_invoice_description: Fix tests according to qty_delivered compute change since

### DIFF
--- a/sale_timesheet_invoice_description/tests/test_sale_timesheet_description.py
+++ b/sale_timesheet_invoice_description/tests/test_sale_timesheet_description.py
@@ -181,13 +181,13 @@ class TestSaleTimesheetDescription(common.TransactionCase):
 
         # Add a new timesheets with the same date to the same invoiced sale.order.line
         self.timesheet.write({"name": "Description 1"})
-        self.timesheet2 = self.timesheet.copy().write(
+        self.timesheet2 = self.timesheet.copy(
             {
                 "name": "Description 2",
                 "date": datetime.strptime("2017-08-05", "%Y-%m-%d"),
             }
         )
-        self.timesheet3 = self.timesheet.copy().write(
+        self.timesheet3 = self.timesheet.copy(
             {
                 "name": "Description 3",
                 "date": datetime.strptime("2017-08-06", "%Y-%m-%d"),
@@ -199,6 +199,7 @@ class TestSaleTimesheetDescription(common.TransactionCase):
         )._create_invoices(start_date="2017-01-01", end_date="2018-01-01")
 
         self.assertEqual(len(invoice.invoice_line_ids), 4)
+        self.assertEqual(sum(self.sale_order.mapped("order_line.qty_delivered")), 3.93)
 
         # First line is a section with product's name
         aml_ids = invoice.invoice_line_ids.sorted(key=lambda aml: aml.sequence)
@@ -214,7 +215,7 @@ class TestSaleTimesheetDescription(common.TransactionCase):
 
         # Last aml quantity is calculated as the rest to equal the original aml quantity
         self.assertEqual(aml_ids[-1].name, "Description 3")
-        self.assertEqual(aml_ids[-1].quantity, 1.3)
+        self.assertEqual(aml_ids[-1].quantity, 1.29)
 
         # Invoice lines total must equal the expected order line's delivered and
         # invoiced quantities


### PR DESCRIPTION
Fix tests according to `qty_delivered` compute change since https://github.com/odoo/odoo/pull/115907/commits/12355a80042c70d4c4c23f6e22145358ccc747f8

Before, `qty_delivered` was calculated by summing up the analytical lines and converting with `uom_id`
Now, `qty_delivered` is computed by iterating each analytical lines and converting with `uom_id` each line.

This change of behavior, causes in some use cases that the rounding makes it differ by 0.01 (or more in some cases).

Please @pedrobaeza can you review it?

@Tecnativa