### PR TITLE
[16.0][FIX] account_invoice_pricelist: Avoid division by zero

### DIFF
--- a/account_invoice_pricelist/models/account_move.py
+++ b/account_invoice_pricelist/models/account_move.py
@@ -77,6 +77,8 @@ class AccountMoveLine(models.Model):
         return res
 
     def _calculate_discount(self, base_price, final_price):
+        if base_price == 0.0:
+            return 0.0
         discount = (base_price - final_price) / base_price * 100
         if (discount < 0 and base_price > 0) or (discount > 0 and base_price < 0):
             discount = 0.0


### PR DESCRIPTION
When calculating the discount, pricelists discount_policy not "with_discount", the percentage of the discount is calculated. If base_price is 0.0 we receive an error.

Cherry-pick from https://github.com/OCA/account-invoicing/pull/1076