### PR TITLE
[16.0][FIX] account_tax_change: fix tax changes wizard

### DIFF
--- a/account_tax_change/wizards/account_move_apply_tax_change.py
+++ b/account_tax_change/wizards/account_move_apply_tax_change.py
@@ -97,8 +97,10 @@ class AccountMoveApplyTaxChange(models.TransientModel):
 
         Other modules could override this method.
         """
-        line.tax_ids -= self.tax_change_id.change_line_ids.tax_src_id
-        line.tax_ids |= self.tax_change_id.change_line_ids.tax_dest_id
+        for tax_change_line in self.tax_change_id.change_line_ids:
+            if tax_change_line.tax_src_id in line.tax_ids:
+                line.tax_ids -= tax_change_line.tax_src_id
+                line.tax_ids |= tax_change_line.tax_dest_id
         line.invalidate_recordset()
         line.modified(["tax_ids"])
         line.flush_recordset()


### PR DESCRIPTION
The result was wrong if multiple taxes were declared in the 'account.tax.change' mapping. Need to iterate on each tax change and check if it applies on the current invoice line.