### PR TITLE
[15.0][IMP] Add option to split invoice lines by task

### DIFF
--- a/sale_timesheet_invoice_description/README.rst
+++ b/sale_timesheet_invoice_description/README.rst
@@ -38,8 +38,8 @@ Configuration
 To configure this module, you need to:
 
 #. Go to **Timesheets > Configuration > Settings** and select an option from
-   **Timesheet Invoice Description** and from **Spit Order lines by**
-   under **Billing** section.
+   **Timesheet Invoice Description**, **Spit Order lines by** and
+   **Timesheets for consecutive Invoices** under **Billing** section.
 
 Usage
 =====
@@ -61,6 +61,20 @@ To use this module, you need to:
    - For **Split Order lines by** select "Timesheet" if you want to create one
      invoice line for each Sale Order line's timesheet, or select "Task" if you
      want to create one invoice line for each Sale Order line's task.
+   - For **Timesheets for consecutive Invoices** select "Only uninvoiced" if
+     you want to ignore all already fully or partially invoiced timesheets when
+     creating consecutive invoices, or select "Uninvoiced and partially
+     invoiced" if you want to ignore only the already fully invoiced
+     timesheets.
+
+     - Caveat: Since a timesheet can be linked to only a single invoice line
+       (by its fields "Invoice Line"), the option "Uninvoiced and partially
+       invoiced" works for partially invoiced timesheets only on a second
+       invoice. The timesheet will then be linked to (only) its new invoice
+       line, and thus any further invoices are unable to determine the not yet
+       invoiced amount of that timesheet, because the link to the line on the
+       first invoice is no longer known.
+
    - Link the Sale Order with a project from **Project** field.
 #. Confirm Sale.
 #. Go to *Timesheets > Timesheets > My Timesheets*, create a record

--- a/sale_timesheet_invoice_description/README.rst
+++ b/sale_timesheet_invoice_description/README.rst
@@ -38,7 +38,8 @@ Configuration
 To configure this module, you need to:
 
 #. Go to **Timesheets > Configuration > Settings** and select an option from
-   **Timesheet Invoice Description** under **Billing** section.
+   **Timesheet Invoice Description** and from **Spit Order lines by**
+   under **Billing** section.
 
 Usage
 =====
@@ -54,17 +55,18 @@ To use this module, you need to:
    - **Unit of Measure** > 'Hours' (or any other time unit)
 #. Go to *Sales > Orders > Orders*, select a Sale Order or create a new one,
    add a product (service) under 'Order Lines' tab.
-#. Go to 'Other Info' tab (wihthin the same Sale Order) and:
+#. Go to 'Other Info' tab (within the same Sale Order) and:
 
    - Select an option from **Timesheet Invoice Description**.
-   - Tick off **Split Order lines by timesheets**, if you want to create an
-     invoice line per each Sale Order timesheet's line.
+   - For **Split Order lines by** select "Timesheet" if you want to create one
+     invoice line for each Sale Order line's timesheet, or select "Task" if you
+     want to create one invoice line for each Sale Order line's task.
    - Link the Sale Order with a project from **Project** field.
 #. Confirm Sale.
 #. Go to *Timesheets > Timesheets > My Timesheets*, create a record
    (timesheet line) and select a task related to the Sale Order's project
    (and to your specific Sale Order's line). Remember to add the time spent.
-#. Go to the Sale Order and create its invoice (clic on 'Create Invoice').
+#. Go to the Sale Order and create its invoice (click on 'Create Invoice').
 
 Bug Tracker
 ===========
@@ -98,6 +100,10 @@ Contributors
 * `Akretion <https://www.akretion.com>`_:
 
   * Clément Mombereau <clement.mombereau@akretion.com.br>
+
+* `initOS <https://www.initos.com>`_:
+
+  * Andreas Zöllner <andreas.zoellner@initos.com>
 
 Maintainers
 ~~~~~~~~~~~

--- a/sale_timesheet_invoice_description/i18n/de.po
+++ b/sale_timesheet_invoice_description/i18n/de.po
@@ -9,16 +9,21 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-12-20 03:39+0000\n"
-"PO-Revision-Date: 2019-08-23 14:44+0000\n"
-"Last-Translator: Maria Sparenberg <maria.sparenberg@gmx.net>\n"
+"POT-Creation-Date: 2023-07-15 15:04+0000\n"
+"PO-Revision-Date: 2023-07-17 10:56+0200\n"
+"Last-Translator: Andreas Zöllner <andreas.zoellner@initos.com>\n"
 "Language-Team: German (https://www.transifex.com/oca/teams/23907/de/)\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 3.7.1\n"
+"X-Generator: Poedit 3.3.2\n"
+
+#. module: sale_timesheet_invoice_description
+#: model:ir.model,name:sale_timesheet_invoice_description.model_account_analytic_line
+msgid "Analytic Line"
+msgstr "Kostenstellen-Buchungen"
 
 #. module: sale_timesheet_invoice_description
 #: model:ir.model,name:sale_timesheet_invoice_description.model_res_config_settings
@@ -39,6 +44,16 @@ msgstr "Datum - Zeitaufwand - Beschreibung"
 
 #. module: sale_timesheet_invoice_description
 #: model_terms:ir.ui.view,arch_db:sale_timesheet_invoice_description.view_sales_config_inherit_timesheet_invoice_description
+msgid "Default for which timesheets to be invoiced on consecutive invoices"
+msgstr "Standard für welche Zeiterfassungen auf weiteren Rechnungen abgerechnet werden"
+
+#. module: sale_timesheet_invoice_description
+#: model_terms:ir.ui.view,arch_db:sale_timesheet_invoice_description.view_sales_config_inherit_timesheet_invoice_description
+msgid "Default splitting of order lines for invoice lines"
+msgstr "Standard-Splitten der Auftragspositionen für Rechnungszeilen"
+
+#. module: sale_timesheet_invoice_description
+#: model_terms:ir.ui.view,arch_db:sale_timesheet_invoice_description.view_sales_config_inherit_timesheet_invoice_description
 msgid "Default timesheet details on invoice lines"
 msgstr "Standard-Zeiterfassungsinfos bei Rechnungszeilen"
 
@@ -49,14 +64,44 @@ msgid "Description"
 msgstr "Beschreibung"
 
 #. module: sale_timesheet_invoice_description
+#: model:ir.model.fields,help:sale_timesheet_invoice_description.field_sale_order__timesheet_invoice_split
+msgid "How to split the order lines - by timesheet, by task, or not at all."
+msgstr "Wie die Auftragspositionen gesplittet werden - nach Zeiterfassung, nach Aufgabe oder gar nicht."
+
+#. module: sale_timesheet_invoice_description
+#: model:ir.model.fields,field_description:sale_timesheet_invoice_description.field_account_analytic_line__timesheet_invoice_line_id
+msgid "Invoice Line"
+msgstr "Rechnungszeile"
+
+#. module: sale_timesheet_invoice_description
+#: model:ir.model.fields,help:sale_timesheet_invoice_description.field_account_analytic_line__timesheet_invoice_line_id
+msgid "Invoice line created from the timesheet"
+msgstr "Rechnungszeile aus der Zeiterfassung"
+
+#. module: sale_timesheet_invoice_description
+#: model:ir.model,name:sale_timesheet_invoice_description.model_account_move
+msgid "Journal Entry"
+msgstr "Buchungssatz"
+
+#. module: sale_timesheet_invoice_description
+#: model:ir.model,name:sale_timesheet_invoice_description.model_account_move_line
+msgid "Journal Item"
+msgstr "Buchungszeile"
+
+#. module: sale_timesheet_invoice_description
 #: code:addons/sale_timesheet_invoice_description/models/sale.py:0
 #, python-format
 msgid "None"
 msgstr "Keine"
 
 #. module: sale_timesheet_invoice_description
+#: code:addons/sale_timesheet_invoice_description/models/sale.py:0
+#, python-format
+msgid "Only uninvoiced"
+msgstr "Nur nicht in Rechnung gestellte"
+
+#. module: sale_timesheet_invoice_description
 #: model:ir.model,name:sale_timesheet_invoice_description.model_sale_order
-#, fuzzy
 msgid "Sales Order"
 msgstr "Verkaufsauftrag"
 
@@ -66,16 +111,53 @@ msgid "Sales Order Line"
 msgstr "Auftragsposition"
 
 #. module: sale_timesheet_invoice_description
+#: model:ir.model.fields,field_description:sale_timesheet_invoice_description.field_account_move_line__timesheet_invoice_split model:ir.model.fields,field_description:sale_timesheet_invoice_description.field_res_config_settings__default_timesheet_invoice_split model:ir.model.fields,field_description:sale_timesheet_invoice_description.field_sale_order__timesheet_invoice_split
+msgid "Split Order lines by"
+msgstr "Gruppiere Auftragspositionen nach"
+
+#. module: sale_timesheet_invoice_description
+#: code:addons/sale_timesheet_invoice_description/models/sale.py:0
+#, python-format
+msgid "Task"
+msgstr "Aufgabe"
+
+#. module: sale_timesheet_invoice_description
 #: code:addons/sale_timesheet_invoice_description/models/sale.py:0
 #, python-format
 msgid "Time spent - Description"
 msgstr "Zeitaufwand - Beschreibung"
 
 #. module: sale_timesheet_invoice_description
-#: model:ir.model.fields,field_description:sale_timesheet_invoice_description.field_res_config_settings__default_timesheet_invoice_description
-#: model:ir.model.fields,field_description:sale_timesheet_invoice_description.field_sale_order__timesheet_invoice_description
+#: code:addons/sale_timesheet_invoice_description/models/sale.py:0
+#, python-format
+msgid "Timesheet"
+msgstr "Zeiterfassung"
+
+#. module: sale_timesheet_invoice_description
+#: model:ir.model.fields,field_description:sale_timesheet_invoice_description.field_account_move_line__timesheet_invoice_description model:ir.model.fields,field_description:sale_timesheet_invoice_description.field_res_config_settings__default_timesheet_invoice_description model:ir.model.fields,field_description:sale_timesheet_invoice_description.field_sale_order__timesheet_invoice_description
 msgid "Timesheet Invoice Description"
 msgstr "Beschreibung Zeitnachweisabrechnung"
+
+#. module: sale_timesheet_invoice_description
+#: model:ir.model.fields,field_description:sale_timesheet_invoice_description.field_account_move_line__timesheet_ids
+msgid "Timesheets"
+msgstr "Zeiterfassungen"
+
+#. module: sale_timesheet_invoice_description
+#: model:ir.model.fields,field_description:sale_timesheet_invoice_description.field_account_move_line__timesheet_invoice_consecutive model:ir.model.fields,field_description:sale_timesheet_invoice_description.field_res_config_settings__default_timesheet_invoice_consecutive model:ir.model.fields,field_description:sale_timesheet_invoice_description.field_sale_order__timesheet_invoice_consecutive
+msgid "Timesheets for consecutive Invoices"
+msgstr "Zeiterfassungen für weitere Rechnungen"
+
+#. module: sale_timesheet_invoice_description
+#: code:addons/sale_timesheet_invoice_description/models/sale.py:0
+#, python-format
+msgid "Uninvoiced and partially invoiced"
+msgstr "Nicht und teilweise in Rechnung gestellte"
+
+#. module: sale_timesheet_invoice_description
+#: model:ir.model.fields,help:sale_timesheet_invoice_description.field_sale_order__timesheet_invoice_consecutive
+msgid "Which timesheets are to be invoiced on consecutive invoices - only the yet completely uninvoiced (i.e., to ignore the already partially or fully invoiced), or also the already partially invoiced (i.e., to ignore only the already fully invoiced)."
+msgstr "Welche Zeiterfassungen auf weiteren Rechnungen abgerechnet werden - nur die noch nicht abgerechneten (d.h. alle teilweise oder vollständig abgerechneten werden ignoriert) oder auch die teilweise abgerechneten (d.h. nur die vollständig abgerechneten werden ignoriert)."
 
 #~ msgid "Quotation"
 #~ msgstr "Preisangebot"

--- a/sale_timesheet_invoice_description/i18n/sale_timesheet_invoice_description.pot
+++ b/sale_timesheet_invoice_description/i18n/sale_timesheet_invoice_description.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-07-15 15:04+0000\n"
+"PO-Revision-Date: 2023-07-15 15:04+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -33,6 +35,11 @@ msgstr ""
 #: code:addons/sale_timesheet_invoice_description/models/sale.py:0
 #, python-format
 msgid "Date - Time spent - Description"
+msgstr ""
+
+#. module: sale_timesheet_invoice_description
+#: model_terms:ir.ui.view,arch_db:sale_timesheet_invoice_description.view_sales_config_inherit_timesheet_invoice_description
+msgid "Default for which timesheets to be invoiced on consecutive invoices"
 msgstr ""
 
 #. module: sale_timesheet_invoice_description
@@ -83,6 +90,12 @@ msgid "None"
 msgstr ""
 
 #. module: sale_timesheet_invoice_description
+#: code:addons/sale_timesheet_invoice_description/models/sale.py:0
+#, python-format
+msgid "Only uninvoiced"
+msgstr ""
+
+#. module: sale_timesheet_invoice_description
 #: model:ir.model,name:sale_timesheet_invoice_description.model_sale_order
 msgid "Sales Order"
 msgstr ""
@@ -127,4 +140,26 @@ msgstr ""
 #. module: sale_timesheet_invoice_description
 #: model:ir.model.fields,field_description:sale_timesheet_invoice_description.field_account_move_line__timesheet_ids
 msgid "Timesheets"
+msgstr ""
+
+#. module: sale_timesheet_invoice_description
+#: model:ir.model.fields,field_description:sale_timesheet_invoice_description.field_account_move_line__timesheet_invoice_consecutive
+#: model:ir.model.fields,field_description:sale_timesheet_invoice_description.field_res_config_settings__default_timesheet_invoice_consecutive
+#: model:ir.model.fields,field_description:sale_timesheet_invoice_description.field_sale_order__timesheet_invoice_consecutive
+msgid "Timesheets for consecutive Invoices"
+msgstr ""
+
+#. module: sale_timesheet_invoice_description
+#: code:addons/sale_timesheet_invoice_description/models/sale.py:0
+#, python-format
+msgid "Uninvoiced and partially invoiced"
+msgstr ""
+
+#. module: sale_timesheet_invoice_description
+#: model:ir.model.fields,help:sale_timesheet_invoice_description.field_sale_order__timesheet_invoice_consecutive
+msgid ""
+"Which timesheets are to be invoiced on consecutive invoices - only the yet "
+"completely uninvoiced (i.e., to ignore the already partially or fully "
+"invoiced), or also the already partially invoiced (i.e., to ignore only the "
+"already fully invoiced)."
 msgstr ""

--- a/sale_timesheet_invoice_description/i18n/sale_timesheet_invoice_description.pot
+++ b/sale_timesheet_invoice_description/i18n/sale_timesheet_invoice_description.pot
@@ -37,6 +37,11 @@ msgstr ""
 
 #. module: sale_timesheet_invoice_description
 #: model_terms:ir.ui.view,arch_db:sale_timesheet_invoice_description.view_sales_config_inherit_timesheet_invoice_description
+msgid "Default splitting of order lines for invoice lines"
+msgstr ""
+
+#. module: sale_timesheet_invoice_description
+#: model_terms:ir.ui.view,arch_db:sale_timesheet_invoice_description.view_sales_config_inherit_timesheet_invoice_description
 msgid "Default timesheet details on invoice lines"
 msgstr ""
 
@@ -44,6 +49,11 @@ msgstr ""
 #: code:addons/sale_timesheet_invoice_description/models/sale.py:0
 #, python-format
 msgid "Description"
+msgstr ""
+
+#. module: sale_timesheet_invoice_description
+#: model:ir.model.fields,help:sale_timesheet_invoice_description.field_sale_order__timesheet_invoice_split
+msgid "How to split the order lines - by timesheet, by task, or not at all."
 msgstr ""
 
 #. module: sale_timesheet_invoice_description
@@ -84,14 +94,27 @@ msgstr ""
 
 #. module: sale_timesheet_invoice_description
 #: model:ir.model.fields,field_description:sale_timesheet_invoice_description.field_account_move_line__timesheet_invoice_split
+#: model:ir.model.fields,field_description:sale_timesheet_invoice_description.field_res_config_settings__default_timesheet_invoice_split
 #: model:ir.model.fields,field_description:sale_timesheet_invoice_description.field_sale_order__timesheet_invoice_split
-msgid "Split Order lines by timesheets"
+msgid "Split Order lines by"
+msgstr ""
+
+#. module: sale_timesheet_invoice_description
+#: code:addons/sale_timesheet_invoice_description/models/sale.py:0
+#, python-format
+msgid "Task"
 msgstr ""
 
 #. module: sale_timesheet_invoice_description
 #: code:addons/sale_timesheet_invoice_description/models/sale.py:0
 #, python-format
 msgid "Time spent - Description"
+msgstr ""
+
+#. module: sale_timesheet_invoice_description
+#: code:addons/sale_timesheet_invoice_description/models/sale.py:0
+#, python-format
+msgid "Timesheet"
 msgstr ""
 
 #. module: sale_timesheet_invoice_description

--- a/sale_timesheet_invoice_description/models/account_move.py
+++ b/sale_timesheet_invoice_description/models/account_move.py
@@ -1,5 +1,6 @@
 # Copyright 2020 Akretion - Clément Mombereau
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from collections import defaultdict
 
 from odoo import fields, models
 from odoo.osv import expression
@@ -18,13 +19,20 @@ class AccountMove(models.Model):
             lambda i: i.move_type == "out_invoice" and i.state == "draft"
         )
 
+        invoiced = defaultdict(float)  # timesheet ID to already invoiced qty
+
         for aml in move_ids.invoice_line_ids:
             sale_line_delivery = aml._get_sale_line_delivery()
             if sale_line_delivery:
                 domain = [
                     ("so_line", "in", sale_line_delivery.ids),
                     ("project_id", "!=", False),
-                    ("timesheet_invoice_id", "=", aml.move_id.id),
+                    # Note: No longer consider only timesheets assigned to this
+                    # invoice, as that will miss the ones that are only
+                    # partially invoiced yet, e.g. through a manual change of
+                    # their invoice line's quantity. Instead, we will filter
+                    # out the fully invoiced timesheets below.
+                    # ("timesheet_invoice_id", "=", aml.move_id.id),
                 ]
                 if start_date:
                     domain = expression.AND([domain, [("date", ">=", start_date)]])
@@ -32,7 +40,43 @@ class AccountMove(models.Model):
                     domain = expression.AND([domain, [("date", "<=", end_date)]])
 
                 timesheets = self.env["account.analytic.line"].sudo().search(domain)
+
+                # determine already invoiced quantities per timesheet
+                # Caveats:
+                # * Works only if the timesheet is actually invoiced on just a
+                #   single invoice line (or none at all), since timesheets can
+                #   only be associated with a single invoice line through field
+                #   `timesheet_invoice_line_id`. There is no way to determine
+                #   all invoice lines a timesheet is invoiced on.
+                # * Works only if the association of an invoice line to the
+                #   timesheet has not been undone, e.g., by deleting an invoice
+                #   the timesheet had been invoiced on.
+                for ts in timesheets:
+                    inv_line = ts.timesheet_invoice_line_id
+                    if inv_line:
+                        # possibly multiple timesheets invoiced on same line
+                        sheets = inv_line.timesheet_ids
+                        qty_sum = sum(line.unit_amount for line in sheets)
+                        # convert invoice line quantity to timesheet UoM
+                        qty = inv_line.quantity
+                        uom = inv_line.product_uom_id
+                        qty = uom._compute_quantity(qty, ts.product_uom_id)
+                        # Since there is no other way to known what fraction of
+                        # this timesheet had been invoiced, do assume that the
+                        # invoiced quantity for this timesheet is proportional
+                        # to the total invoiced quantity of the line.
+                        # This is correct if the invoice line does invoice only
+                        # this single timesheet, but unclear if multiple.
+                        invoiced[ts.id] = ts.unit_amount * qty / qty_sum
+
+                # Filter out fully invoiced timesheets; take only the ones that
+                # are just partially invoiced or not yet invoiced at all.
+                timesheets = timesheets.filtered(
+                    lambda ts: invoiced[ts.id] < ts.unit_amount
+                )
                 timesheets.write({"timesheet_invoice_line_id": aml.id})
+
+        return invoiced
 
     def _check_balanced(self):
         if self.env.context.get("split_aml_by_timesheets"):

--- a/sale_timesheet_invoice_description/models/account_move.py
+++ b/sale_timesheet_invoice_description/models/account_move.py
@@ -53,7 +53,15 @@ class AccountMoveLine(models.Model):
     )
 
     # Filled by sale order line's _prepare_invoice_line()
-    timesheet_invoice_description = fields.Char()
+    # Technical hint: We keep `Selection` fields as `Char`. This is
+    # intentionally done, in order to avoid code duplication (e.g., the need to
+    # specify their `selection` parameter). Note that they are not available to
+    # the Odoo users, but rather used just "internally" in the code. And there,
+    # on code as well as database level, the values of `Selection` and `Char`
+    # fields are just the same, namely strings. Hence, this works just fine.
+    timesheet_invoice_description = fields.Char(
+        readonly=True,
+    )
     timesheet_invoice_split = fields.Boolean("Split Order lines by timesheets")
 
     def _get_sale_line_delivery(self):

--- a/sale_timesheet_invoice_description/models/account_move.py
+++ b/sale_timesheet_invoice_description/models/account_move.py
@@ -62,7 +62,10 @@ class AccountMoveLine(models.Model):
     timesheet_invoice_description = fields.Char(
         readonly=True,
     )
-    timesheet_invoice_split = fields.Boolean("Split Order lines by timesheets")
+    timesheet_invoice_split = fields.Char(
+        string="Split Order lines by",
+        readonly=True,
+    )
 
     def _get_sale_line_delivery(self):
         return self.sale_line_ids.filtered(

--- a/sale_timesheet_invoice_description/models/res_config.py
+++ b/sale_timesheet_invoice_description/models/res_config.py
@@ -15,7 +15,18 @@ class ResConfigSettings(models.TransientModel):
         default=SaleOrder.timesheet_invoice_description.default,
         required=SaleOrder.timesheet_invoice_description.required,
     )
+    default_timesheet_invoice_split = fields.Selection(
+        selection="_get_timesheet_invoice_split",
+        string="Split Order lines by",
+        default_model="sale.order",
+        default=SaleOrder.timesheet_invoice_split.default,
+        required=SaleOrder.timesheet_invoice_split.required,
+    )
 
     @api.model
     def _get_timesheet_invoice_description(self):
         return self.env["sale.order"]._get_timesheet_invoice_description()
+
+    @api.model
+    def _get_timesheet_invoice_split(self):
+        return self.env["sale.order"]._get_timesheet_invoice_split()

--- a/sale_timesheet_invoice_description/models/res_config.py
+++ b/sale_timesheet_invoice_description/models/res_config.py
@@ -22,6 +22,13 @@ class ResConfigSettings(models.TransientModel):
         default=SaleOrder.timesheet_invoice_split.default,
         required=SaleOrder.timesheet_invoice_split.required,
     )
+    default_timesheet_invoice_consecutive = fields.Selection(
+        selection="_get_timesheet_invoice_consecutive",
+        string="Timesheets for consecutive Invoices",
+        default_model="sale.order",
+        default=SaleOrder.timesheet_invoice_consecutive.default,
+        required=SaleOrder.timesheet_invoice_consecutive.required,
+    )
 
     @api.model
     def _get_timesheet_invoice_description(self):
@@ -30,3 +37,7 @@ class ResConfigSettings(models.TransientModel):
     @api.model
     def _get_timesheet_invoice_split(self):
         return self.env["sale.order"]._get_timesheet_invoice_split()
+
+    @api.model
+    def _get_timesheet_invoice_consecutive(self):
+        return self.env["sale.order"]._get_timesheet_invoice_consecutive()

--- a/sale_timesheet_invoice_description/models/res_config.py
+++ b/sale_timesheet_invoice_description/models/res_config.py
@@ -2,6 +2,8 @@
 
 from odoo import api, fields, models
 
+from .sale import SaleOrder
+
 
 class ResConfigSettings(models.TransientModel):
     _inherit = "res.config.settings"
@@ -10,6 +12,8 @@ class ResConfigSettings(models.TransientModel):
         selection="_get_timesheet_invoice_description",
         string="Timesheet Invoice Description",
         default_model="sale.order",
+        default=SaleOrder.timesheet_invoice_description.default,
+        required=SaleOrder.timesheet_invoice_description.required,
     )
 
     @api.model

--- a/sale_timesheet_invoice_description/models/sale.py
+++ b/sale_timesheet_invoice_description/models/sale.py
@@ -26,6 +26,8 @@ class SaleOrder(models.Model):
 
     def _get_timesheet_details(self, timesheet, desc_rule):
         details = []
+        if not desc_rule:
+            return details
         if desc_rule[0] == "1":
             details.append(fields.Date.to_string(timesheet.date))
         if desc_rule[1] == "1":

--- a/sale_timesheet_invoice_description/models/sale.py
+++ b/sale_timesheet_invoice_description/models/sale.py
@@ -237,7 +237,7 @@ class SaleOrder(models.Model):
                 if (
                     desc_dict
                     and desc_rule
-                    and desc_rule != "000"
+                    and (desc_rule != "000" or inv_split == "task")
                     and not is_third_party_test
                 ):
                     if inv_split:

--- a/sale_timesheet_invoice_description/models/sale.py
+++ b/sale_timesheet_invoice_description/models/sale.py
@@ -68,7 +68,12 @@ class SaleOrder(models.Model):
         # Override the original aml values with first timesheet
         init_ts_uom_id = ts_ids[0].product_uom_id
         init_ts_qty = ts_ids[0].unit_amount
-        init_qty = init_ts_uom_id._compute_quantity(init_ts_qty, aml_uom_id)
+        if ts_ids[-1] != ts_ids[0]:
+            # first one is not the last one, hence compute normally
+            init_qty = init_ts_uom_id._compute_quantity(init_ts_qty, aml_uom_id)
+        else:
+            # first one is the last one, hence assign the rest (see also below)
+            init_qty = aml_total - aml_sum  # note that here, aml_sum == 0
         aml_sum += init_qty
 
         aml.with_context(split_aml_by_timesheets=True).write(

--- a/sale_timesheet_invoice_description/models/sale.py
+++ b/sale_timesheet_invoice_description/models/sale.py
@@ -117,6 +117,17 @@ class SaleOrder(models.Model):
             "test_timesheet_description"
         )
 
+        # The wizard "sale.advance.payment.inv" method `create_invoices()` does
+        # provide the start and end date in the context rather than the kwargs.
+        # Note that they are read from there in the super method in module
+        # "sale_timesheet". Which is overwritten here without a super call.
+        # Also note that the unit tests do use the kwarg.
+        # Therefore, this method does accept the kwargs (for use with the unit
+        # tests), but falls back to the context in case values for the kwargs
+        # are not provided (as by the wizard).
+        start_date = start_date or self.env.context.get("timesheet_start_date")
+        end_date = end_date or self.env.context.get("timesheet_end_date")
+
         moves = super()._create_invoices(grouped=grouped, final=final)
         moves._link_timesheets_to_invoice_line(start_date=start_date, end_date=end_date)
 

--- a/sale_timesheet_invoice_description/models/sale.py
+++ b/sale_timesheet_invoice_description/models/sale.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import _, api, fields, models
-from odoo.tools import config
+from odoo.tools import config, format_date
 
 
 class SaleOrder(models.Model):
@@ -30,7 +30,9 @@ class SaleOrder(models.Model):
         if not desc_rule:
             return details
         if desc_rule[0] == "1":
-            details.append(fields.Date.to_string(timesheet.date))
+            lang = account_move_line.move_id.partner_id.lang
+            date = format_date(self.env, timesheet.date, lang_code=lang)
+            details.append(date)
         if desc_rule[1] == "1":
             details.append(
                 "{} {}".format(timesheet.unit_amount, timesheet.product_uom_id.name)

--- a/sale_timesheet_invoice_description/models/sale.py
+++ b/sale_timesheet_invoice_description/models/sale.py
@@ -52,7 +52,7 @@ class SaleOrder(models.Model):
         aml_total = aml.quantity
         aml_uom_id = aml.product_uom_id
         aml_sum = 0
-        ts_ids = ts_ids.sorted(lambda t: t.date)
+        ts_ids = ts_ids.sorted(lambda t: (t.date, t.task_id.id or 0))
 
         # Add a line section on top before the original aml
         self.env["account.move.line"].create(

--- a/sale_timesheet_invoice_description/models/sale.py
+++ b/sale_timesheet_invoice_description/models/sale.py
@@ -95,6 +95,8 @@ class SaleOrder(models.Model):
             }
         )
         aml_seq += 1
+        # note: updating invoice line on timesheet should not be necessary
+        ts_ids[0].write({"timesheet_invoice_line_id": aml.id})
 
         # Create one invoice line for each timesheet except the last one
         for ts_id in ts_ids[1:-1]:
@@ -112,6 +114,8 @@ class SaleOrder(models.Model):
             )
             aml_seq += 1
             aml_sum += qty
+            # update invoice line on timesheet
+            ts_id.write({"timesheet_invoice_line_id": new_aml.id})
 
         # Last new invoice line get the rest
         if ts_ids[-1] != ts_ids[0]:
@@ -126,6 +130,8 @@ class SaleOrder(models.Model):
                 }
             )
             aml_seq += 1
+            # update invoice line on timesheet
+            ts_ids[-1].write({"timesheet_invoice_line_id": last_aml.id})
 
         # Finally, recompute the (sub)total and taxes so that they all are
         # still correct.

--- a/sale_timesheet_invoice_description/models/sale.py
+++ b/sale_timesheet_invoice_description/models/sale.py
@@ -10,7 +10,9 @@ class SaleOrder(models.Model):
     _inherit = "sale.order"
 
     timesheet_invoice_description = fields.Selection(
-        "_get_timesheet_invoice_description", default="000"
+        "_get_timesheet_invoice_description",
+        default="000",
+        required=True,
     )
     timesheet_invoice_split = fields.Boolean("Split Order lines by timesheets")
 

--- a/sale_timesheet_invoice_description/models/sale.py
+++ b/sale_timesheet_invoice_description/models/sale.py
@@ -43,7 +43,7 @@ class SaleOrder(models.Model):
         desc_list = []
         for timesheet_id in timesheet_ids.sorted(lambda t: t.date):
             details = self._get_timesheet_details(timesheet_id, desc_rule)
-            desc_list.append(" - ".join(map(lambda x: str(x) or "", details)))
+            desc_list.append(" - ".join(details))
         return desc_list
 
     def _split_aml_by_timesheets(self, aml, ts_ids, desc_list, aml_seq):
@@ -185,9 +185,10 @@ class SaleOrder(models.Model):
                             aml, ts_ids, desc_list, aml_seq
                         )
                     else:
-                        desc = "\n".join(map(lambda x: str(x) or "", desc_list))
-                        new_name = aml.name + "\n" + desc
-                        aml.write({"name": new_name})
+                        desc = "\n".join(desc_list)
+                        if desc:
+                            new_name = aml.name + "\n" + desc
+                            aml.write({"name": new_name.strip()})
                         # keep sequence of invoice lines
                         aml.write({"sequence": aml_seq})
                         aml_seq += 1

--- a/sale_timesheet_invoice_description/models/sale.py
+++ b/sale_timesheet_invoice_description/models/sale.py
@@ -24,7 +24,8 @@ class SaleOrder(models.Model):
             ("011", _("Time spent - Description")),
         ]
 
-    def _get_timesheet_details(self, timesheet, desc_rule):
+    def _get_timesheet_details(self, account_move_line, timesheet):
+        desc_rule = account_move_line.timesheet_invoice_description
         details = []
         if not desc_rule:
             return details
@@ -38,11 +39,11 @@ class SaleOrder(models.Model):
             details.append(timesheet.name)
         return details
 
-    def _get_timesheet_descriptions(self, timesheet_ids, desc_rule):
-        """Returns a dict of timesheets' descriptions"""
+    def _get_timesheet_descriptions(self, account_move_line):
+        """Returns a dict of an invoice line's timesheets' descriptions"""
         desc_dict = {}
-        for timesheet_id in timesheet_ids:
-            details = self._get_timesheet_details(timesheet_id, desc_rule)
+        for timesheet_id in account_move_line.timesheet_ids:
+            details = self._get_timesheet_details(account_move_line, timesheet_id)
             desc_dict[timesheet_id] = " - ".join(details)
         return desc_dict
 
@@ -173,7 +174,7 @@ class SaleOrder(models.Model):
                 ts_ids = aml.timesheet_ids
                 desc_rule = aml.timesheet_invoice_description
                 inv_split = aml.timesheet_invoice_split
-                desc_dict = self._get_timesheet_descriptions(ts_ids, desc_rule)
+                desc_dict = self._get_timesheet_descriptions(aml)
                 if (
                     desc_dict
                     and desc_rule

--- a/sale_timesheet_invoice_description/readme/CONFIGURE.rst
+++ b/sale_timesheet_invoice_description/readme/CONFIGURE.rst
@@ -1,4 +1,5 @@
 To configure this module, you need to:
 
 #. Go to **Timesheets > Configuration > Settings** and select an option from
-   **Timesheet Invoice Description** under **Billing** section.
+   **Timesheet Invoice Description** and from **Split Order lines by**
+   under **Billing** section.

--- a/sale_timesheet_invoice_description/readme/CONFIGURE.rst
+++ b/sale_timesheet_invoice_description/readme/CONFIGURE.rst
@@ -1,5 +1,5 @@
 To configure this module, you need to:
 
 #. Go to **Timesheets > Configuration > Settings** and select an option from
-   **Timesheet Invoice Description** and from **Split Order lines by**
-   under **Billing** section.
+   **Timesheet Invoice Description**, **Spit Order lines by** and
+   **Timesheets for consecutive Invoices** under **Billing** section.

--- a/sale_timesheet_invoice_description/readme/CONTRIBUTORS.rst
+++ b/sale_timesheet_invoice_description/readme/CONTRIBUTORS.rst
@@ -9,3 +9,7 @@
 * `Akretion <https://www.akretion.com>`_:
 
   * Clément Mombereau <clement.mombereau@akretion.com.br>
+
+* `initOS <https://www.initos.com>`_:
+
+  * Andreas Zöllner <andreas.zoellner@initos.com>

--- a/sale_timesheet_invoice_description/readme/USAGE.rst
+++ b/sale_timesheet_invoice_description/readme/USAGE.rst
@@ -15,6 +15,20 @@ To use this module, you need to:
    - For **Split Order lines by** select "Timesheet" if you want to create one
      invoice line for each Sale Order line's timesheet, or select "Task" if you
      want to create one invoice line for each Sale Order line's task.
+   - For **Timesheets for consecutive Invoices** select "Only uninvoiced" if
+     you want to ignore all already fully or partially invoiced timesheets when
+     creating consecutive invoices, or select "Uninvoiced and partially
+     invoiced" if you want to ignore only the already fully invoiced
+     timesheets.
+
+     - Caveat: Since a timesheet can be linked to only a single invoice line
+       (by its fields "Invoice Line"), the option "Uninvoiced and partially
+       invoiced" works for partially invoiced timesheets only on a second
+       invoice. The timesheet will then be linked to (only) its new invoice
+       line, and thus any further invoices are unable to determine the not yet
+       invoiced amount of that timesheet, because the link to the line on the
+       first invoice is no longer known.
+
    - Link the Sale Order with a project from **Project** field.
 #. Confirm Sale.
 #. Go to *Timesheets > Timesheets > My Timesheets*, create a record

--- a/sale_timesheet_invoice_description/readme/USAGE.rst
+++ b/sale_timesheet_invoice_description/readme/USAGE.rst
@@ -9,14 +9,15 @@ To use this module, you need to:
    - **Unit of Measure** > 'Hours' (or any other time unit)
 #. Go to *Sales > Orders > Orders*, select a Sale Order or create a new one,
    add a product (service) under 'Order Lines' tab.
-#. Go to 'Other Info' tab (wihthin the same Sale Order) and:
+#. Go to 'Other Info' tab (within the same Sale Order) and:
 
    - Select an option from **Timesheet Invoice Description**.
-   - Tick off **Split Order lines by timesheets**, if you want to create an
-     invoice line per each Sale Order timesheet's line.
+   - For **Split Order lines by** select "Timesheet" if you want to create one
+     invoice line for each Sale Order line's timesheet, or select "Task" if you
+     want to create one invoice line for each Sale Order line's task.
    - Link the Sale Order with a project from **Project** field.
 #. Confirm Sale.
 #. Go to *Timesheets > Timesheets > My Timesheets*, create a record
    (timesheet line) and select a task related to the Sale Order's project
    (and to your specific Sale Order's line). Remember to add the time spent.
-#. Go to the Sale Order and create its invoice (clic on 'Create Invoice').
+#. Go to the Sale Order and create its invoice (click on 'Create Invoice').

--- a/sale_timesheet_invoice_description/static/description/index.html
+++ b/sale_timesheet_invoice_description/static/description/index.html
@@ -407,8 +407,8 @@ ul.auto-toc {
 add a product (service) under ‘Order Lines’ tab.</li>
 <li>Go to ‘Other Info’ tab (wihthin the same Sale Order) and:<ul>
 <li>Select an option from <strong>Timesheet Invoice Description</strong>.</li>
-<li>Tick off <strong>Split Order lines by timesheets</strong>, if you want to create an
-invoice line per each Sale Order timesheet’s line.</li>
+<li>For <strong>Split Order lines by</strong> select "Timesheet" if you want to create one invoice line for each Sale Order line's timesheet,
+or select "Task" if you want to create one invoice line for each Sale Order line's task.</li>
 <li>Link the Sale Order with a project from <strong>Project</strong> field.</li>
 </ul>
 </li>

--- a/sale_timesheet_invoice_description/tests/test_sale_timesheet_description.py
+++ b/sale_timesheet_invoice_description/tests/test_sale_timesheet_description.py
@@ -28,6 +28,25 @@ class TestSaleTimesheetDescription(common.TransactionCase):
         )
         cls.product_uom_hour = cls.env.ref("uom.product_uom_hour")
         cls.product_uom_day = cls.env.ref("uom.product_uom_day")
+
+        # Make sure the UoM's have the necessary properties for the rounding
+        # effects on the quantities in the unit tests do work as expected.
+        # Note: Need to write the (new) reference UoM first.
+        cls.product_uom_day.write(
+            {
+                "uom_type": "reference",
+                "factor": 1.0,
+                "rounding": 0.01,
+            }
+        )
+        cls.product_uom_hour.write(
+            {
+                "uom_type": "smaller",
+                "factor": 8.0,
+                "rounding": 0.01,
+            }
+        )
+
         cls.product = cls.env["product.product"].create(
             {
                 "name": "Test product",

--- a/sale_timesheet_invoice_description/tests/test_sale_timesheet_description.py
+++ b/sale_timesheet_invoice_description/tests/test_sale_timesheet_description.py
@@ -182,6 +182,16 @@ class TestSaleTimesheetDescription(common.TransactionCase):
         )._create_invoices()
         self.assertEqual(invoice2.line_ids[0].name, expected)
 
+    def _change_uom_on_line(self, so_line):
+        """Set a different UoM on SO line/Invoice line from Timesheets UoM"""
+        new_uom = self.product_uom_day
+        new_qty = so_line.product_uom._compute_quantity(
+            so_line.product_uom_qty, new_uom
+        )
+        so_line.product_uom = new_uom.id
+        so_line.product_uom_qty = new_qty
+        so_line.product_uom_change()  # to adjust the unit price
+
     def test_sale_timesheet_description_000(self):
         self._test_sale_time_description("000", "Test product")
 
@@ -262,13 +272,7 @@ class TestSaleTimesheetDescription(common.TransactionCase):
         self.sale_order.timesheet_invoice_split = True
         self.sale_order.timesheet_invoice_description = "001"
         # Set a different UoM on SO line/Invoice line from Timesheets UoM
-        new_uom = self.product_uom_day
-        new_qty = self.so_line.product_uom._compute_quantity(
-            self.so_line.product_uom_qty, new_uom
-        )
-        self.so_line.product_uom = new_uom.id
-        self.so_line.product_uom_qty = new_qty
-        self.so_line.product_uom_change()  # to adjust the unit price
+        self._change_uom_on_line(self.so_line)
 
         # Add a new timesheets with the same date to the same invoiced sale.order.line
         self.timesheet.write({"name": "Description 1"})
@@ -334,13 +338,7 @@ class TestSaleTimesheetDescription(common.TransactionCase):
         self.sale_order_2.timesheet_invoice_description = "001"
         # Set a different UoM on sale order line / invoice line from
         # timesheet's UoM, but only for the first line = first product / task.
-        new_uom = self.product_uom_day
-        new_qty = self.so_2_line_1.product_uom._compute_quantity(
-            self.so_2_line_1.product_uom_qty, new_uom
-        )
-        self.so_2_line_1.product_uom = new_uom.id
-        self.so_2_line_1.product_uom_qty = new_qty
-        self.so_2_line_1.product_uom_change()  # to adjust the unit price
+        self._change_uom_on_line(self.so_2_line_1)
 
         # Add two new timesheets to the first invoiced sale order line
         self.timesheet_2_1.write({"name": "Description 1"})

--- a/sale_timesheet_invoice_description/tests/test_sale_timesheet_description.py
+++ b/sale_timesheet_invoice_description/tests/test_sale_timesheet_description.py
@@ -196,7 +196,13 @@ class TestSaleTimesheetDescription(common.TransactionCase):
         self.sale_order.timesheet_invoice_split = True
         self.sale_order.timesheet_invoice_description = "001"
         # Set a different UoM on SO line/Invoice line from Timesheets UoM
-        self.so_line.write({"product_uom": self.product_uom_day.id})
+        new_uom = self.product_uom_day
+        new_qty = self.so_line.product_uom._compute_quantity(
+            self.so_line.product_uom_qty, new_uom
+        )
+        self.so_line.product_uom = new_uom.id
+        self.so_line.product_uom_qty = new_qty
+        self.so_line.product_uom_change()  # to adjust the unit price
 
         # Add a new timesheets with the same date to the same invoiced sale.order.line
         self.timesheet.write({"name": "Description 1"})

--- a/sale_timesheet_invoice_description/tests/test_sale_timesheet_description.py
+++ b/sale_timesheet_invoice_description/tests/test_sale_timesheet_description.py
@@ -280,7 +280,7 @@ class TestSaleTimesheetDescription(common.TransactionCase):
         self.assertEqual(invoice.invoice_line_ids[0].name, expected)
 
     def test_three_timesheets_same_date_split(self):
-        self.sale_order.timesheet_invoice_split = True
+        self.sale_order.timesheet_invoice_split = "timesheet"
         self.sale_order.timesheet_invoice_description = "001"
         # Set a different UoM on SO line/Invoice line from Timesheets UoM
         self._change_uom_on_line(self.so_line)
@@ -345,7 +345,7 @@ class TestSaleTimesheetDescription(common.TransactionCase):
         )
 
     def test_three_plus_two_timesheets_split(self):
-        self.sale_order_2.timesheet_invoice_split = True
+        self.sale_order_2.timesheet_invoice_split = "timesheet"
         self.sale_order_2.timesheet_invoice_description = "001"
         # Set a different UoM on sale order line / invoice line from
         # timesheet's UoM, but only for the first line = first product / task.

--- a/sale_timesheet_invoice_description/tests/test_sale_timesheet_description.py
+++ b/sale_timesheet_invoice_description/tests/test_sale_timesheet_description.py
@@ -5,6 +5,7 @@
 from datetime import datetime
 
 from odoo.tests import common
+from odoo.tools import DEFAULT_SERVER_DATE_FORMAT
 from odoo.tools.float_utils import float_compare
 
 
@@ -15,7 +16,17 @@ class TestSaleTimesheetDescription(common.TransactionCase):
 
         # Make sure user is in English
         cls.env.user.lang = "en_US"
-        cls.partner = cls.env["res.partner"].create({"name": "Test partner"})
+        cls.partner = cls.env["res.partner"].create(
+            {
+                "name": "Test partner",
+                "lang": "en_US",
+            }
+        )
+        # make sure to use the default date format, such as used in the tests
+        # below in the verbatim description strings
+        lang = cls.env["res.lang"].search([("code", "=", "en_US")], limit=1)
+        lang.date_format = DEFAULT_SERVER_DATE_FORMAT
+
         cls.analytic_account = cls.env["account.analytic.account"].create(
             {"name": "Test analytic account"}
         )

--- a/sale_timesheet_invoice_description/tests/test_sale_timesheet_description.py
+++ b/sale_timesheet_invoice_description/tests/test_sale_timesheet_description.py
@@ -473,7 +473,9 @@ class TestSaleTimesheetDescription(common.TransactionCase):
         self.assertEqual(aml_ids[0].display_type, "line_section")
         self.assertEqual(aml_ids[0].name, "Test product")
         # Next line refers to first task
+        task_name = "%s: Test product" % (self.sale_order_2.name,)
         descs = [
+            task_name,
             "Description 1",
             "Description 2",
             "Description 3",
@@ -498,7 +500,9 @@ class TestSaleTimesheetDescription(common.TransactionCase):
         self.assertEqual(aml_ids[2].display_type, "line_section")
         self.assertEqual(aml_ids[2].name, "Test product 2")
         # Next line refer to second timesheet
+        task_name = "%s: Test product 2" % (self.sale_order_2.name,)
         descs = [
+            task_name,
             "Description 11",
             "Description 12",
         ]

--- a/sale_timesheet_invoice_description/views/res_config_view.xml
+++ b/sale_timesheet_invoice_description/views/res_config_view.xml
@@ -21,6 +21,17 @@
                         </div>
                     </div>
                 </div>
+                <div class="content-group" name="sale_timesheet_invoice_split">
+                    <div class="mt16">
+                        <label for="default_timesheet_invoice_split" />
+                        <div class="text-muted">
+                            Default splitting of order lines for invoice lines
+                        </div>
+                        <div class="text-muted">
+                            <field name="default_timesheet_invoice_split" />
+                        </div>
+                    </div>
+                </div>
             </xpath>
         </field>
     </record>

--- a/sale_timesheet_invoice_description/views/res_config_view.xml
+++ b/sale_timesheet_invoice_description/views/res_config_view.xml
@@ -32,6 +32,17 @@
                         </div>
                     </div>
                 </div>
+                <div class="content-group" name="sale_timesheet_invoice_consecutive">
+                    <div class="mt16">
+                        <label for="default_timesheet_invoice_consecutive" />
+                        <div class="text-muted">
+                            Default for which timesheets to be invoiced on consecutive invoices
+                        </div>
+                        <div class="text-muted">
+                            <field name="default_timesheet_invoice_consecutive" />
+                        </div>
+                    </div>
+                </div>
             </xpath>
         </field>
     </record>

--- a/sale_timesheet_invoice_description/views/sale_view.xml
+++ b/sale_timesheet_invoice_description/views/sale_view.xml
@@ -10,6 +10,7 @@
             <field name="fiscal_position_id" position="after">
                 <field name="timesheet_invoice_description" />
                 <field name="timesheet_invoice_split" />
+                <field name="timesheet_invoice_consecutive" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
This extends sale_timesheet_invoice_description by the option to split invoice lines by task.

One can now choose to split either by timesheet or by task.