### PR TITLE
[15.0][IMP] account_invoice_payment_term_date_due: fix conflict readonly view

### DIFF
--- a/account_invoice_payment_term_date_due/__manifest__.py
+++ b/account_invoice_payment_term_date_due/__manifest__.py
@@ -10,6 +10,9 @@
     "website": "https://github.com/OCA/account-invoicing",
     "license": "AGPL-3",
     "category": "Accounting",
-    "depends": ["account"],
+    "depends": [
+        "account",
+        "account_invoice_extract",
+    ],
     "data": ["views/account_move.xml"],
 }

--- a/account_invoice_payment_term_date_due/models/__init__.py
+++ b/account_invoice_payment_term_date_due/models/__init__.py
@@ -1,4 +1,4 @@
 # Copyright 2023 Pol Reig (pol.reig@qubiq.es)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from . import models
+from . import account_move

--- a/account_invoice_payment_term_date_due/models/account_move.py
+++ b/account_invoice_payment_term_date_due/models/account_move.py
@@ -1,0 +1,20 @@
+# Copyright 2023 Pol Reig (pol.reig@qubiq.es)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    extracting_ocr = fields.Boolean(default=False)
+
+    def _save_form(self, ocr_results, no_ref=False):
+        """
+        Boolean to make the `invoice_date_due` field not readonly
+        while executing the OCR function `_save_form`.
+        """
+        self.extracting_ocr = True
+        res = super()._save_form(ocr_results, no_ref)
+        self.extracting_ocr = False
+        return res

--- a/account_invoice_payment_term_date_due/views/account_move.xml
+++ b/account_invoice_payment_term_date_due/views/account_move.xml
@@ -15,11 +15,21 @@
                     attrs="{'invisible': ['|', ('invoice_payment_term_id', '=', False), ('invoice_date_due', '=', False)]}"
                     title="Arrow icon"
                 />
+                <field name="extracting_ocr" invisible="1" />
                 <field
                     class="text-muted"
                     name="invoice_date_due"
                     force_save="1"
-                    attrs="{'readonly': [('invoice_payment_term_id', '!=', False)], 'invisible': ['|', ('invoice_payment_term_id', '=', False), ('invoice_date_due', '=', False)]}"
+                    attrs="{
+                        'invisible': [
+                            '|',
+                            ('invoice_payment_term_id', '=', False),
+                            ('invoice_date_due', '=', False)
+                        ],
+                        'readonly': [
+                            ('extracting_ocr', '=', False)
+                        ]
+                    }"
                 />
             </xpath>
         </field>


### PR DESCRIPTION
In some invoices an error appeared in the OCR process, related to the readonly of the `invoice_date_due` field.