### PR TITLE
[IMP][16.0] Add hooks to account_invoice_pricelist 

### DIFF
--- a/account_invoice_pricelist/__init__.py
+++ b/account_invoice_pricelist/__init__.py
@@ -1,1 +1,3 @@
 from . import models
+from .hooks import pre_init_hook
+from .hooks import post_init_hook

--- a/account_invoice_pricelist/__manifest__.py
+++ b/account_invoice_pricelist/__manifest__.py
@@ -11,4 +11,6 @@
     "depends": ["account"],
     "data": ["views/account_invoice_view.xml"],
     "installable": True,
+    "pre_init_hook": "pre_init_hook",
+    "post_init_hook": "post_init_hook",
 }

--- a/account_invoice_pricelist/hooks.py
+++ b/account_invoice_pricelist/hooks.py
@@ -1,0 +1,19 @@
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+
+def pre_init_hook(cr):
+    """Precreate pricelist_id column to prevent tracked computation."""
+    logger = logging.getLogger(__name__)
+    logger.info("Add account_move.financial_type column if it does not yet exist")
+    cr.execute("ALTER TABLE account_move ADD COLUMN IF NOT EXISTS pricelist_id int4")
+
+
+def post_init_hook(cr, registry):
+    """Fill pricelist_id without tracking."""
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    moves = env["account.move"].search(
+        [("move_type", "in", ("out_invoice", "out_refund"))]
+    )
+    moves.with_context(tracking_disable=True)._compute_pricelist_id()

--- a/account_invoice_pricelist/hooks.py
+++ b/account_invoice_pricelist/hooks.py
@@ -1,8 +1,8 @@
 import logging
 
-from odoo import SUPERUSER_ID, api
 from psycopg2.extras import execute_values
 
+from odoo import SUPERUSER_ID, api
 
 def pre_init_hook(cr):
     """Precreate pricelist_id column to prevent tracked computation."""
@@ -19,15 +19,15 @@ def post_init_hook(cr, registry):
     )
     vals = []
     for invoice in moves:
-        if (
-            invoice.partner_id
-            and invoice.partner_id.property_product_pricelist
-        ):
-            vals.append((invoice.id,invoice.partner_id.property_product_pricelist.id))
+        if invoice.partner_id and invoice.partner_id.property_product_pricelist:
+            vals.append((invoice.id, invoice.partner_id.property_product_pricelist.id))
     if vals:
-        execute_values(cr, """
+        execute_values(
+            cr,
+            """
             UPDATE account_move SET pricelist_id = vals.p
             FROM (VALUES %s) AS vals (id, p)
             WHERE account_move.id = vals.id
-            """, vals
+            """,
+            vals,
         )

--- a/account_invoice_pricelist/hooks.py
+++ b/account_invoice_pricelist/hooks.py
@@ -4,6 +4,7 @@ from psycopg2.extras import execute_values
 
 from odoo import SUPERUSER_ID, api
 
+
 def pre_init_hook(cr):
     """Precreate pricelist_id column to prevent tracked computation."""
     logger = logging.getLogger(__name__)


### PR DESCRIPTION
Before this change installing this module on a database with only a few million account_moves would take upwards of an hour. The vast majority of the installation time was taken by the newly enabled tracking on the pricelist_id field.

After this change we precreate the pricelist_id column and then post installation update only those moves required with tracking disabled.