### PR TITLE
[15.0][14.0][FIX] fix tax compute on create invoice from sale order with fixed discount

### DIFF
--- a/account_invoice_fixed_discount/models/account_move.py
+++ b/account_invoice_fixed_discount/models/account_move.py
@@ -12,7 +12,10 @@ class AccountMove(models.Model):
         self, recompute_tax_base_amount=False, tax_rep_lines_to_recompute=None
     ):
         vals = {}
-        for line in self.invoice_line_ids.filtered("discount_fixed"):
+        # use line_ids because invoice_line_ids may be empty during creation
+        for line in self.line_ids.filtered(
+            lambda l: not l.exclude_from_invoice_tab and l.discount_fixed
+        ):
             vals[line] = {"price_unit": line.price_unit}
             price_unit = line.price_unit - line.discount_fixed
             line.update({"price_unit": price_unit})


### PR DESCRIPTION
Step to reproduce :
- Install account_invoice_fixed_discount and sale_fixed_discount, and active discount in config
- Create a sale order and add a product with unit price 100$, fixed discount 50$ and tax 15%.  The total untaxed is 50$ and the tax 7.5$.
- Confirm this sale order and create the invoice : the tax is now 15$ instead of 7.5$  (tax computation ignore the discount)