### PR TITLE
[15.0][FIX+IMP] account_invoice_crm_tag: Proper line tag propagation + colors

### DIFF
--- a/account_invoice_crm_tag/README.rst
+++ b/account_invoice_crm_tag/README.rst
@@ -65,6 +65,7 @@ Contributors
 * `Tecnativa <https://www.tecnativa.com>`_:
 
   * Stefan Ungureanu
+  * Pedro M. Baeza
 
 Maintainers
 ~~~~~~~~~~~

--- a/account_invoice_crm_tag/models/sale_order.py
+++ b/account_invoice_crm_tag/models/sale_order.py
@@ -1,4 +1,5 @@
 # Copyright 2023 Tecnativa - Stefan Ungureanu
+# Copyright 2023 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import models
 
@@ -11,3 +12,15 @@ class SaleOrder(models.Model):
         if self.tag_ids:
             vals["crm_tag_ids"] = [(6, 0, self.tag_ids.ids)]
         return vals
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    def _prepare_invoice_line(self, **optional_values):
+        """Transfer CRM tags also to invoice lines, as although being a related stored,
+        it's not correctly saved due to the trick/duality of invoice_line_ids/line_ids.
+        """
+        res = super()._prepare_invoice_line(**optional_values)
+        res["crm_tag_ids"] = [(6, 0, self.order_id.tag_ids.ids)]
+        return res

--- a/account_invoice_crm_tag/readme/CONTRIBUTORS.rst
+++ b/account_invoice_crm_tag/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * `Tecnativa <https://www.tecnativa.com>`_:
 
   * Stefan Ungureanu
+  * Pedro M. Baeza

--- a/account_invoice_crm_tag/static/description/index.html
+++ b/account_invoice_crm_tag/static/description/index.html
@@ -413,6 +413,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <ul class="simple">
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
 <li>Stefan Ungureanu</li>
+<li>Pedro M. Baeza</li>
 </ul>
 </li>
 </ul>

--- a/account_invoice_crm_tag/views/account_invoice_views.xml
+++ b/account_invoice_crm_tag/views/account_invoice_views.xml
@@ -12,6 +12,7 @@
                     name="crm_tag_ids"
                     widget="many2many_tags"
                     attrs="{'invisible': [('move_type', 'not in', ['out_invoice','out_refund'])]}"
+                    options="{'color_field': 'color', 'no_create_edit': True}"
                 />
             </xpath>
         </field>


### PR DESCRIPTION
- Transfer properly CRM tags also to invoice lines, as although being a related stored, it's not correctly saved due to the trick/duality of invoice_line_ids/line_ids.
- Put color definition in many2many_tags widget.

@Tecnativa TT44457