### PR TITLE
[14.0][IMP] account_invoice_refund_link: Make more reliable the linking

### DIFF
--- a/account_invoice_refund_link/models/account_move.py
+++ b/account_invoice_refund_link/models/account_move.py
@@ -3,7 +3,7 @@
 # Copyright 2014-2022 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, fields, models
+from odoo import fields, models
 
 
 class AccountMove(models.Model):
@@ -12,22 +12,3 @@ class AccountMove(models.Model):
     refund_invoice_ids = fields.One2many(
         "account.move", "reversed_entry_id", string="Refund Invoices", readonly=True
     )
-
-    @api.model
-    def _reverse_move_vals(self, default_values, cancel=True):
-        move_vals = super()._reverse_move_vals(default_values, cancel)
-        if self.env.context.get("link_origin_line", False) and move_vals[
-            "move_type"
-        ] in (
-            "out_refund",
-            "in_refund",
-        ):
-            refund_lines_vals = [
-                x[2]
-                for x in move_vals.get("line_ids", [])
-                if not x[2].get("exclude_from_invoice_tab", True)
-            ]
-            for i, line in enumerate(self.invoice_line_ids):
-                if i < len(refund_lines_vals):
-                    refund_lines_vals[i]["origin_line_id"] = line.id
-        return move_vals

--- a/account_invoice_refund_link/models/account_move_line.py
+++ b/account_invoice_refund_link/models/account_move_line.py
@@ -1,6 +1,6 @@
 # Copyright 2004-2011 Pexego Sistemas Informáticos. (http://pexego.es)
-# Copyright 2016 Antonio Espinosa <antonio.espinosa@tecnativa.com>
-# Copyright 2014-2018 Pedro M. Baeza <pedro.baeza@tecnativa.com>
+# Copyright 2016 Tecnativa - Antonio Espinosa
+# Copyright 2014-2023 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import fields, models
@@ -24,3 +24,13 @@ class AccountInvoiceLine(models.Model):
         help="Refund invoice lines created from this invoice line",
         copy=False,
     )
+
+    def copy_data(self, default=None):
+        """Link refund lines with the original ones when copying move lines from the
+        `_reverse_move_vals` method.
+        """
+        res = super().copy_data(default=default)
+        if self.env.context.get("link_origin_line"):
+            for line, values in zip(self, res):
+                values["origin_line_id"] = line.id
+        return res


### PR DESCRIPTION
Forward-port of #1523 

Hooking on a high level method like `_reverse_move_vals` (although still being private), makes that other modules hooking into it may alter the number of returned lines (like for example, account_invoice_refund_line_selection).

We choose the low-level `copy_data` method that is used in such method for linking the refund lines with their origin ones, avoiding the problem.

@Tecnativa