### PR TITLE
[16.0][IMP] account_invoice_refund_link: Make more reliable the linking

### DIFF
--- a/account_invoice_refund_link/__manifest__.py
+++ b/account_invoice_refund_link/__manifest__.py
@@ -1,7 +1,7 @@
 # Copyright 2004-2011 Pexego Sistemas Informáticos. (http://pexego.es)
 # Copyright 2016 Antonio Espinosa <antonio.espinosa@tecnativa.com>
-# Copyright 2014-2017 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # Copyright 2021 Tecnativa - João Marques
+# Copyright 2014-2023 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {

--- a/account_invoice_refund_link/models/account_move.py
+++ b/account_invoice_refund_link/models/account_move.py
@@ -12,22 +12,3 @@ class AccountMove(models.Model):
     refund_invoice_ids = fields.One2many(
         "account.move", "reversed_entry_id", string="Refund Invoices", readonly=True
     )
-
-    def _reverse_moves(self, default_values_list=None, cancel=False):
-        reverse_moves = super()._reverse_moves(
-            default_values_list=default_values_list, cancel=cancel
-        )
-        if self.env.context.get("link_origin_line", False):
-            for move in reverse_moves:
-                if move.move_type in ("out_refund", "in_refund"):
-                    refund_lines = move.line_ids.filtered(
-                        lambda x: x.display_type == "product"
-                    )
-                    for i, line in enumerate(
-                        self.invoice_line_ids.filtered(
-                            lambda x: x.display_type == "product"
-                        )
-                    ):
-                        if i < len(refund_lines):
-                            refund_lines[i].origin_line_id = line.id
-        return reverse_moves

--- a/account_invoice_refund_link/models/account_move_line.py
+++ b/account_invoice_refund_link/models/account_move_line.py
@@ -1,6 +1,6 @@
 # Copyright 2004-2011 Pexego Sistemas Informáticos. (http://pexego.es)
-# Copyright 2016 Antonio Espinosa <antonio.espinosa@tecnativa.com>
-# Copyright 2014-2018 Pedro M. Baeza <pedro.baeza@tecnativa.com>
+# Copyright 2016 Tecnativa - Antonio Espinosa
+# Copyright 2014-2023 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import fields, models
@@ -23,3 +23,13 @@ class AccountInvoiceLine(models.Model):
         help="Refund invoice lines created from this invoice line",
         copy=False,
     )
+
+    def copy_data(self, default=None):
+        """Link refund lines with the original ones when copying move lines from the
+        `_reverse_move_vals` method.
+        """
+        res = super().copy_data(default=default)
+        if self.env.context.get("link_origin_line"):
+            for line, values in zip(self, res):
+                values["origin_line_id"] = line.id
+        return res

--- a/account_invoice_refund_link/tests/test_invoice_refund_link.py
+++ b/account_invoice_refund_link/tests/test_invoice_refund_link.py
@@ -1,5 +1,5 @@
-# Copyright 2016 Antonio Espinosa <antonio.espinosa@tecnativa.com>
-# Copyright 2014-2017 Pedro M. Baeza <pedro.baeza@tecnativa.com>
+# Copyright 2016 Tecnativa - Antonio Espinosa
+# Copyright 2014-2023 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo.tests.common import TransactionCase
@@ -119,20 +119,14 @@ class TestInvoiceRefundLink(TestInvoiceRefundLinkBase):
         refund = self.invoice.refund_invoice_ids[0]
         self.invoice.copy()
         self.assertEqual(
-            refund.invoice_line_ids.mapped("origin_line_id"),
-            self.invoice.invoice_line_ids.filtered(
-                lambda x: x.display_type == "product"
-            ),
+            refund.invoice_line_ids.origin_line_id, self.invoice.invoice_line_ids
         )
 
     def test_refund_copy(self):
         refund = self.invoice.refund_invoice_ids[0]
         refund.copy()
         self.assertEqual(
-            self.invoice.invoice_line_ids.filtered(
-                lambda x: x.display_type == "product"
-            ),
-            refund.invoice_line_ids.mapped("origin_line_id"),
+            self.invoice.invoice_line_ids, refund.invoice_line_ids.origin_line_id
         )
 
 


### PR DESCRIPTION
Forward-port of #1523

Hooking on a high level method like `_reverse_moves` (although still being private), makes that other modules hooking into it may alter the number of returned lines (like for example, account_invoice_refund_line_selection).

We choose the low-level `copy_data` method that is used in such method for linking the refund lines with their origin ones, avoiding the problem.

@Tecnativa 