### PR TITLE
[14.0][FIX] account_invoice_triple_discount: recomputed taxes overwritten by old move line values

### DIFF
--- a/account_invoice_triple_discount/models/account_move.py
+++ b/account_invoice_triple_discount/models/account_move.py
@@ -16,9 +16,9 @@ class AccountMove(models.Model):
         restored after the original process is done
         """
         old_values_by_line_id = {}
-        digits = self.line_ids._fields["price_unit"]._digits
-        self.line_ids._fields["price_unit"]._digits = (16, 16)
-        for line in self.line_ids:
+        digits = self.invoice_line_ids._fields["price_unit"]._digits
+        self.invoice_line_ids._fields["price_unit"]._digits = (16, 16)
+        for line in self.invoice_line_ids:
             aggregated_discount = line._compute_aggregated_discount(line.discount)
             old_values_by_line_id[line.id] = {
                 "price_unit": line.price_unit,
@@ -26,9 +26,9 @@ class AccountMove(models.Model):
             }
             price_unit = line.price_unit * (1 - aggregated_discount / 100)
             line.update({"price_unit": price_unit, "discount": 0})
-        self.line_ids._fields["price_unit"]._digits = digits
+        self.invoice_line_ids._fields["price_unit"]._digits = digits
         res = super(AccountMove, self)._recompute_tax_lines(**kwargs)
-        for line in self.line_ids:
+        for line in self.invoice_line_ids:
             if line.id not in old_values_by_line_id:
                 continue
             line.update(old_values_by_line_id[line.id])

--- a/account_invoice_triple_discount/readme/CONTRIBUTORS.rst
+++ b/account_invoice_triple_discount/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * David Vidal <david.vidal@tecnativa.com>
 * Pedro M. Baeza <pedro.baeza@tecnativa.com>
 * Nikul Chaudhary <nikulchaudhary2112@gmail.com>
+* Eric Antones <eantones@nuobit.com>


### PR DESCRIPTION
We only need to save and restore the invoice lines, not all the move lines as is currently happening.

The restoration of the old lines is overwriting the changes made in the tax lines by the tax recomputation in line https://github.com/OCA/account-invoicing/blob/9b64ecc2b8e9b5146a12994b5c13f9a603b0db17/account_invoice_triple_discount/models/account_move.py#L30

This is a problem in a certain situations like in [repair_discount](https://github.com/OCA/manufacture/tree/14.0/repair_discount) module where the old values are kept due to this bug.
https://github.com/OCA/manufacture/blob/035a4de34a0de7e4f0db1a9c0ab3354acf235e99/repair_discount/models/mrp_repair.py#L115-L119