### PR TITLE
[14.0][FIX] stock_picking_invoicing: demo product compatible with MRP module

### DIFF
--- a/stock_picking_invoicing/demo/stock_picking_demo.xml
+++ b/stock_picking_invoicing/demo/stock_picking_demo.xml
@@ -21,7 +21,7 @@
         <field name="product_uom" ref="uom.product_uom_unit" />
     </record>
     <record id="stock_move_invoicing_1-2" model="stock.move">
-        <field name="product_id" ref="product.product_product_27" />
+        <field name="product_id" ref="product.product_product_25" />
         <field name="name">Test</field>
         <field name="picking_id" ref="stock_picking_invoicing_1" />
         <field name="invoice_state">2binvoiced</field>


### PR DESCRIPTION
If you try to install the `stock_picking_invoicing` module with the `MRP` module, the following error pops up when loading the demo data:

```
2023-09-07 14:30:35,162 290 INFO odoo odoo.modules.loading: loading stock_picking_invoicing/demo/stock_picking_demo.xml 
2023-09-07 14:30:35,482 290 WARNING odoo odoo.modules.loading: Module stock_picking_invoicing demo data failed to install, installed without demo data 
Traceback (most recent call last):
  File "/opt/odoo/odoo/tools/convert.py", line 677, in _tag_root
    f(rec)
  File "/opt/odoo/odoo/tools/convert.py", line 330, in _tag_function
    _eval_xml(self, rec, env)
  File "/opt/odoo/odoo/tools/convert.py", line 201, in _eval_xml
    return odoo.api.call_kw(model, method_name, args, kwargs)
  File "/opt/odoo/odoo/api.py", line 399, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/opt/odoo/odoo/api.py", line 386, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/opt/odoo/addons/stock/models/stock_picking.py", line 946, in button_validate
    raise UserError(_('You need to supply a Lot/Serial number for products %s.') % ', '.join(products_without_lots.mapped('display_name')))
odoo.exceptions.UserError: You need to supply a Lot/Serial number for products [FURN_8855] Drawer.
```

This happens because the MRP module changes the product `[FURN_8855] Drawer` so that it is tracked by **Lot/Serial** and this functionality is not handled in the `stock_picking_invoicing` module

To solve the problem, the product used in the demonstration was changed for one that does not have the tracking changed to **Lot/Serial** by the **MRP** module.