### PR TITLE
[FIX] account_invoice_supplierinfo_update : make wizard working even if user is not member of the group 'uom.group_uom'.

### DIFF
--- a/account_invoice_supplierinfo_update/wizard/wizard_update_invoice_supplierinfo.xml
+++ b/account_invoice_supplierinfo_update/wizard/wizard_update_invoice_supplierinfo.xml
@@ -31,12 +31,14 @@
                             optional="show"
                         />
                         <field name="new_price" optional="show" />
+                        <field name="current_uom_id" invisible="1" />
                         <field
                             name="current_uom_id"
                             attrs="{'invisible': [('supplierinfo_id', '=', False)]}"
                             groups="uom.group_uom"
                             optional="show"
                         />
+                        <field name="new_uom_id" invisible="1" />
                         <field
                             name="new_uom_id"
                             groups="uom.group_uom"


### PR DESCRIPTION
Fixes : https://github.com/OCA/account-invoicing/pull/1444#issuecomment-1729733914

Ref : https://github.com/OCA/account-invoicing/pull/1444#issuecomment-1729859146

CC : @pedrobaeza, @carolinafernandez-tecnativa 