### PR TITLE
[16.0][IMP] account_invoice_pricelist: Move discount to onchange

### DIFF
--- a/account_invoice_pricelist/models/account_move.py
+++ b/account_invoice_pricelist/models/account_move.py
@@ -58,9 +58,10 @@ class AccountMove(models.Model):
         return res
 
     def button_update_prices_from_pricelist(self):
-        self.filtered(
-            lambda r: r.state == "draft"
-        ).invoice_line_ids._compute_price_unit()
+        moves = self.filtered(lambda r: r.state == "draft")
+        moves.invoice_line_ids._compute_price_unit()
+        for line in moves.invoice_line_ids:
+            line._onchange_quantity()
 
 
 class AccountMoveLine(models.Model):
@@ -77,6 +78,21 @@ class AccountMoveLine(models.Model):
             ).price_unit = line._get_price_with_pricelist()
         return res
 
+    @api.onchange("quantity")
+    def _onchange_quantity(self):
+        if (
+            not self.move_id.pricelist_id
+            or not self.product_id
+            or not self.move_id.is_invoice()
+        ):
+            return
+        if self.move_id.pricelist_id.discount_policy == "with_discount":
+            self.with_context(check_move_validity=False).discount = 0.0
+        else:
+            final_price, rule_id = self._get_final_price_with_pricelist()
+            base_price = self._get_base_price_with_pricelist_without_discount(rule_id)
+            self._set_discount(self._calculate_discount(base_price, final_price))
+
     def _calculate_discount(self, base_price, final_price):
         if base_price == 0.0:
             return 0.0
@@ -85,44 +101,48 @@ class AccountMoveLine(models.Model):
             discount = 0.0
         return discount
 
+    def _get_final_price_with_pricelist(self):
+        self.ensure_one()
+        (final_price, rule_id,) = self.move_id.pricelist_id._get_product_price_rule(
+            self.product_id,
+            self.quantity or 1.0,
+            uom=self.product_uom_id,
+            date=self.move_id.invoice_date or fields.Date.today(),
+        )
+        return final_price, rule_id
+
+    def _get_base_price_with_pricelist_without_discount(self, rule_id):
+        self.ensure_one()
+        product = self.product_id
+        qty = self.quantity or 1.0
+        date = self.move_id.invoice_date or fields.Date.today()
+        uom = self.product_uom_id
+        rule = self.env["product.pricelist.item"].browse(rule_id)
+        while (
+            rule.base == "pricelist"
+            and rule.base_pricelist_id.discount_policy == "without_discount"
+        ):
+            new_rule_id = rule.base_pricelist_id._get_product_rule(
+                product, qty, uom=uom, date=date
+            )
+            rule = self.env["product.pricelist.item"].browse(new_rule_id)
+        return rule._compute_base_price(
+            product, qty, uom, date, target_currency=self.currency_id
+        )
+
     def _get_price_with_pricelist(self):
         price_unit = 0.0
         if self.move_id.pricelist_id and self.product_id and self.move_id.is_invoice():
-            product = self.product_id
-            qty = self.quantity or 1.0
-            date = self.move_id.invoice_date or fields.Date.today()
-            uom = self.product_uom_id
-            (final_price, rule_id,) = self.move_id.pricelist_id._get_product_price_rule(
-                product,
-                qty,
-                uom=uom,
-                date=date,
-            )
+            final_price, rule_id = self._get_final_price_with_pricelist()
             if self.move_id.pricelist_id.discount_policy == "with_discount":
                 price_unit = self.env["account.tax"]._fix_tax_included_price_company(
-                    final_price,
-                    product.taxes_id,
-                    self.tax_ids,
-                    self.company_id,
+                    final_price, self.product_id.taxes_id, self.tax_ids, self.company_id
                 )
                 self._set_discount(0.0)
                 return price_unit
             else:
-                rule_id = self.env["product.pricelist.item"].browse(rule_id)
-                while (
-                    rule_id.base == "pricelist"
-                    and rule_id.base_pricelist_id.discount_policy == "without_discount"
-                ):
-                    new_rule_id = rule_id.base_pricelist_id._get_product_rule(
-                        product, qty, uom=uom, date=date
-                    )
-                    rule_id = self.env["product.pricelist.item"].browse(new_rule_id)
-                base_price = rule_id._compute_base_price(
-                    product,
-                    qty,
-                    uom,
-                    date,
-                    target_currency=self.currency_id,
+                base_price = self._get_base_price_with_pricelist_without_discount(
+                    rule_id
                 )
                 price_unit = max(base_price, final_price)
                 self._set_discount(self._calculate_discount(base_price, final_price))


### PR DESCRIPTION
- Refactor some methods to reuse them elsewhere
- Move the `discount` calc to a dedicated `onchange` method (as discount doesn't have a `compute` here), as being in another fields compute isn't really correct

In the 16.0 migration the onchange methods were refactored to computes, but the editing of discount remained in the price_unit compute, which causes problems when editing the quantity and discount at once.

My case is that I have an invoice created from a sale order with 2 units at 200€ with a 50% discount (manually input, the pricelist calcs to 0%). A refund is created for this invoice that only wants to refund 1 of the 2 units. When creating the invoice everything is OK, but when editing the quantity to 1 the discount gets set to 0% due to the pricelist calc, this is fine but when you edit the discount back to 50% the subtotal compute ignores your 50% input and uses the 0% from the pricelist calc despite visually showing on the form 50% discount.



<details><summary>This occurs on runboat too</summary>
<p>

Invoice creation:
![image](https://github.com/OCA/account-invoicing/assets/47854752/0d7d6a10-83a5-4dd2-ade9-a36a74112c72)

Manually editing the lines:
![image](https://github.com/OCA/account-invoicing/assets/47854752/21e0e99e-d6cd-473d-9f7e-5a1dd0a8b8d1)

After saving:
![image](https://github.com/OCA/account-invoicing/assets/47854752/126a9518-5411-4d8c-a162-dd76a2158023)


With this PR the subtotal in the last screenshot becomes $100 like it should

</p>
</details> 

