### PR TITLE
[15.0][FIX] account_invoice_pricelist: Make tests resilient

### DIFF
--- a/account_invoice_pricelist/tests/test_account_move_pricelist.py
+++ b/account_invoice_pricelist/tests/test_account_move_pricelist.py
@@ -28,12 +28,14 @@ class TestAccountMovePricelist(common.TransactionCase):
         cls.journal_sale = cls.env["account.journal"].create(
             {"name": "Test sale journal", "type": "sale", "code": "TEST_SJ"}
         )
+        cls.currency_usd = cls.env.ref("base.USD")
+        cls.currency_usd.active = True
         # Make sure the currency of the company is USD, as this not always happens
         # To be removed in V17: https://github.com/odoo/odoo/pull/107113
         cls.company = cls.env.company
         cls.env.cr.execute(
             "UPDATE res_company SET currency_id = %s WHERE id = %s",
-            (cls.env.ref("base.USD").id, cls.company.id),
+            (cls.currency_usd.id, cls.company.id),
         )
         cls.at_receivable = cls.env["account.account.type"].create(
             {


### PR DESCRIPTION
- Depending on the installed set of modules, the company currency may be USD or EUR. If the second case, these tests will fail, so we make sure that the company currency is USD for our tests, doing the change by SQL, as there's a Python constraint that prevents it.

Not needed in v17 due to: odoo/odoo#107113.

@Tecnativa