### PR TITLE
[14.0][FIX] account_invoice_supplierinfo_update : update supplierinfo min_qty, based on new_min_quantity value on wizard line

### DIFF
--- a/account_invoice_supplierinfo_update/tests/test_account_invoice_supplierinfo_update.py
+++ b/account_invoice_supplierinfo_update/tests/test_account_invoice_supplierinfo_update.py
@@ -70,6 +70,10 @@ class Tests(TransactionCase):
         self.assertEqual(len(line_ids), 2)
         self.assertEqual(line_ids[0][2]["current_price"], False)
         self.assertEqual(line_ids[0][2]["new_price"], 400.0)
+        self.assertEqual(line_ids[0][2]["current_min_quantity"], 0.0)
+
+        # Change values
+        line_ids[0][2]["new_min_quantity"] = 6.0
 
         # Create and launch update process
         wizard = self.wizard_obj.create(
@@ -90,6 +94,7 @@ class Tests(TransactionCase):
         )
         self.assertEqual(len(supplierinfos1), 1)
         self.assertEqual(supplierinfos1.currency_id, self.currency)
+        self.assertEqual(supplierinfos1.min_qty, 6.0)
 
         self.assertEqual(supplierinfos1.price, 400.0)
 

--- a/account_invoice_supplierinfo_update/wizard/wizard_update_invoice_supplierinfo_line.py
+++ b/account_invoice_supplierinfo_update/wizard/wizard_update_invoice_supplierinfo_line.py
@@ -66,7 +66,7 @@ class WizardUpdateInvoiceSupplierinfoLine(models.TransientModel):
     def _prepare_supplierinfo_update(self):
         self.ensure_one()
         return {
-            "min_qty": 0.0,
+            "min_qty": self.new_min_quantity,
             "price": self.new_price,
             "currency_id": self.wizard_id.invoice_id.currency_id.id,
         }


### PR DESCRIPTION
Backport from #1436.

Internal task : https://gestion.coopiteasy.be/web#view_type=form&model=project.task&id=11195&active_id=11195&menu_id=