### PR TITLE
[16.0][IMP] account_invoice_fixed_discount: avoid replace in xml

### DIFF
--- a/account_invoice_fixed_discount/reports/report_account_invoice.xml
+++ b/account_invoice_fixed_discount/reports/report_account_invoice.xml
@@ -1,35 +1,32 @@
 <!-- Copyright 2017 ForgeFlow S.L.
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
-    <template
-        id="report_invoice_document"
-        inherit_id="account.report_invoice_document"
-        priority="101"
-    >
+    <template id="report_invoice_document" inherit_id="account.report_invoice_document">
         <xpath expr="//t[@t-set='display_discount']" position="after">
             <t
                 t-set="display_discount_fixed"
                 t-value="any([l.discount_fixed for l in o.invoice_line_ids])"
             />
         </xpath>
-        <xpath expr="//th[@t-if='display_discount']/span" position="replace">
+        <xpath expr="//th[@t-if='display_discount']/span" position="attributes">
+            <attribute name="t-if">not display_discount_fixed</attribute>
+        </xpath>
+
+        <xpath expr="//th[@t-if='display_discount']/span" position="before">
             <t t-if="display_discount_fixed">
                 <span>Discount Amount (%)</span>
             </t>
-            <t t-else="">
-                <span>Disc. %</span>
-            </t>
         </xpath>
-        <span t-field="line.discount" position="replace">
+
+        <span t-field="line.discount" position="before">
             <t t-if="display_discount_fixed">
-                <span class="text-nowrap" t-field="line.discount_fixed" /> (or <span
+                <span class="text-nowrap" t-field="line.discount_fixed" /><span
                     class="text-nowrap"
-                    t-field="line.discount"
-                /> %)
+                > (or</span>
             </t>
-            <t t-else="">
-                <span class="text-nowrap" t-field="line.discount" />
-            </t>
+        </span>
+        <span t-field="line.discount" position="after">
+            <t t-if="display_discount_fixed"><span class="text-nowrap"> %)</span></t>
         </span>
     </template>
 </odoo>


### PR DESCRIPTION
I am currently facing a problem with to many decimal numbers in a standard Odoo installation on the invoice PDF. 
![image](https://github.com/OCA/account-invoicing/assets/1799080/2e7ba7b3-68b6-4efc-9cbc-0b91b7f8cd5f)

I assume this causes by this code section: 
![image](https://github.com/OCA/account-invoicing/assets/1799080/d0aa0ec6-e02f-49c5-bfb7-db3296c9aaa8)


I also evaluated that adding this options will solve the issue in standard Odoo:
t-options='{"widget": "float", "decimal_precision": "Discount"}'

https://github.com/odoo/odoo/blob/5911f056f9ed45a82a694782f82aa3170d0b74ac/addons/account/views/report_invoice.xml#L126C49-L126C100

But this module is using replace, which would bring back the problem. Therefore I would like to change the xml not using "replace".