### PR TITLE
[FIX] account_invoice_fixed_discount: Check base_line type

### DIFF
--- a/account_invoice_fixed_discount/models/account_tax.py
+++ b/account_invoice_fixed_discount/models/account_tax.py
@@ -44,6 +44,10 @@ class AccountTax(models.Model):
             handle_price_include=handle_price_include,
             extra_context=extra_context,
         )
-        if base_line._name == "account.move.line" and base_line.discount_fixed:
+        if (
+            base_line
+            and base_line._name == "account.move.line"
+            and base_line.discount_fixed
+        ):
             res["discount"] = base_line._get_discount_from_fixed_discount()
         return res


### PR DESCRIPTION
hr_expense calls _convert_to_tax_base_line_dict with base_line set to None. Comparison of base_line._name in account_invoice_fixed_discount causes an attribute error.

Add extra check to ensure there is an account.move.line to check against in base_line.