### PR TITLE
[14.0][FIX] account_invoice_base_invoicing_mode: Test partner_invoice_id instead of partner_id

### DIFF
--- a/account_invoice_base_invoicing_mode/models/sale_order.py
+++ b/account_invoice_base_invoicing_mode/models/sale_order.py
@@ -21,7 +21,7 @@ class SaleOrder(models.Model):
         )
         if not sales:
             return "No sale order found to invoice ?"
-        sales.partner_id.ensure_one()
+        sales.partner_invoice_id.ensure_one()
         invoices = sales._create_invoices(
             grouped=sales.partner_invoice_id.one_invoice_per_order,
             final=True,


### PR DESCRIPTION
I introduced a bug with the PR https://github.com/OCA/account-invoicing/pull/1598
We have to test the partner_invoice_id of the grouped sale.orders and not the partner_id. 