### PR TITLE
[16.0][IMP] account_invoice_fixed_discount: Error on create expense

### DIFF
--- a/account_invoice_fixed_discount/tests/test_account_fixed_discount.py
+++ b/account_invoice_fixed_discount/tests/test_account_fixed_discount.py
@@ -137,3 +137,11 @@ class TestInvoiceFixedDiscount(TransactionCase):
         self.assertEqual(self.invoice.amount_total, 143)
         self.assertEqual(self.invoice.invoice_line_ids.price_unit, 200.00)
         self.assertEqual(self.invoice.invoice_line_ids.price_subtotal, 143)
+
+    def test_04_base_line_set_to_none(self):
+
+        self.vat._convert_to_tax_base_line_dict(
+            None,
+            price_unit=10,
+            currency=1,
+        )


### PR DESCRIPTION
When hr_expense is installed, base_line can be None:

https://github.com/odoo/odoo/blob/fa0a6b077b171473da950c969de9e25c3577058e/addons/hr_expense/models/hr_expense.py#L187

![image](https://github.com/OCA/account-invoicing/assets/1799080/5e1d85c2-2114-4778-af89-dcb6399f19a3)
