### PR TITLE
[16.0][IMP+FIX] account_invoice_tax_required: Don't bypass restriction on mass validation + better message

### DIFF
--- a/account_invoice_tax_required/i18n/account_invoice_tax_required.pot
+++ b/account_invoice_tax_required/i18n/account_invoice_tax_required.pot
@@ -26,7 +26,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/i18n/ar.po
+++ b/account_invoice_tax_required/i18n/ar.po
@@ -32,7 +32,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/i18n/bg.po
+++ b/account_invoice_tax_required/i18n/bg.po
@@ -31,7 +31,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/i18n/bs.po
+++ b/account_invoice_tax_required/i18n/bs.po
@@ -32,7 +32,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/i18n/ca.po
+++ b/account_invoice_tax_required/i18n/ca.po
@@ -32,8 +32,8 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
-msgstr "La factura té una línia amb el producte %s que no té impostos"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgstr "La factura %(invoice)s té una línia amb el producte %(product)s que no té impostos"
 
 #. module: account_invoice_tax_required
 #: model:ir.model,name:account_invoice_tax_required.model_account_move

--- a/account_invoice_tax_required/i18n/cs.po
+++ b/account_invoice_tax_required/i18n/cs.po
@@ -31,7 +31,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/i18n/de.po
+++ b/account_invoice_tax_required/i18n/de.po
@@ -34,8 +34,8 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
-msgstr "Die Rechnung hat eine Position mit Produkt %s ohne Steuer"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgstr "Die Rechnung %(invoice)s hat eine Position mit Produkt %(product)s ohne Steuer"
 
 #. module: account_invoice_tax_required
 #: model:ir.model,name:account_invoice_tax_required.model_account_move

--- a/account_invoice_tax_required/i18n/el_GR.po
+++ b/account_invoice_tax_required/i18n/el_GR.po
@@ -32,7 +32,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/i18n/en_GB.po
+++ b/account_invoice_tax_required/i18n/en_GB.po
@@ -32,7 +32,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/i18n/es.po
+++ b/account_invoice_tax_required/i18n/es.po
@@ -34,9 +34,9 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
-"La factura contiene una línea con el producto %s que no tiene impuestos"
+"La factura %(invoice)s contiene una línea con el producto %(product)s que no tiene impuestos"
 
 #. module: account_invoice_tax_required
 #: model:ir.model,name:account_invoice_tax_required.model_account_move

--- a/account_invoice_tax_required/i18n/es_CR.po
+++ b/account_invoice_tax_required/i18n/es_CR.po
@@ -32,7 +32,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/i18n/es_EC.po
+++ b/account_invoice_tax_required/i18n/es_EC.po
@@ -32,7 +32,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/i18n/es_ES.po
+++ b/account_invoice_tax_required/i18n/es_ES.po
@@ -32,7 +32,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/i18n/es_MX.po
+++ b/account_invoice_tax_required/i18n/es_MX.po
@@ -32,7 +32,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/i18n/et.po
+++ b/account_invoice_tax_required/i18n/et.po
@@ -31,7 +31,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/i18n/fi.po
+++ b/account_invoice_tax_required/i18n/fi.po
@@ -31,7 +31,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/i18n/fr.po
+++ b/account_invoice_tax_required/i18n/fr.po
@@ -32,8 +32,8 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
-msgstr "La facture a un produit %s sans taxe"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgstr "La facture %(invoice)s a un produit %(product)s sans taxe"
 
 #. module: account_invoice_tax_required
 #: model:ir.model,name:account_invoice_tax_required.model_account_move

--- a/account_invoice_tax_required/i18n/fr_CA.po
+++ b/account_invoice_tax_required/i18n/fr_CA.po
@@ -32,7 +32,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/i18n/fr_CH.po
+++ b/account_invoice_tax_required/i18n/fr_CH.po
@@ -32,7 +32,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/i18n/gl.po
+++ b/account_invoice_tax_required/i18n/gl.po
@@ -31,7 +31,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/i18n/hr.po
+++ b/account_invoice_tax_required/i18n/hr.po
@@ -35,8 +35,8 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
-msgstr "Račun sadrži stavku sa proizvodom %s bez poreza"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgstr "Račun %(invoice)s sadrži stavku sa proizvodom %(product)s bez poreza"
 
 #. module: account_invoice_tax_required
 #: model:ir.model,name:account_invoice_tax_required.model_account_move

--- a/account_invoice_tax_required/i18n/hr_HR.po
+++ b/account_invoice_tax_required/i18n/hr_HR.po
@@ -33,7 +33,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/i18n/hu.po
+++ b/account_invoice_tax_required/i18n/hu.po
@@ -31,7 +31,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/i18n/id.po
+++ b/account_invoice_tax_required/i18n/id.po
@@ -31,7 +31,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/i18n/it.po
+++ b/account_invoice_tax_required/i18n/it.po
@@ -31,7 +31,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/i18n/ja.po
+++ b/account_invoice_tax_required/i18n/ja.po
@@ -31,7 +31,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/i18n/lt.po
+++ b/account_invoice_tax_required/i18n/lt.po
@@ -32,7 +32,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/i18n/mk.po
+++ b/account_invoice_tax_required/i18n/mk.po
@@ -31,7 +31,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/i18n/mn.po
+++ b/account_invoice_tax_required/i18n/mn.po
@@ -31,7 +31,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/i18n/nb.po
+++ b/account_invoice_tax_required/i18n/nb.po
@@ -32,7 +32,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/i18n/nb_NO.po
+++ b/account_invoice_tax_required/i18n/nb_NO.po
@@ -32,7 +32,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/i18n/nl.po
+++ b/account_invoice_tax_required/i18n/nl.po
@@ -31,7 +31,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/i18n/nl_BE.po
+++ b/account_invoice_tax_required/i18n/nl_BE.po
@@ -32,7 +32,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/i18n/nl_NL.po
+++ b/account_invoice_tax_required/i18n/nl_NL.po
@@ -32,7 +32,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/i18n/pl.po
+++ b/account_invoice_tax_required/i18n/pl.po
@@ -33,7 +33,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/i18n/pt.po
+++ b/account_invoice_tax_required/i18n/pt.po
@@ -31,7 +31,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/i18n/pt_BR.po
+++ b/account_invoice_tax_required/i18n/pt_BR.po
@@ -35,8 +35,8 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
-msgstr "A Fatura com o produto %s está sem impostos"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgstr "A Fatura %(invoice)s com o produto %(product)s está sem impostos"
 
 #. module: account_invoice_tax_required
 #: model:ir.model,name:account_invoice_tax_required.model_account_move

--- a/account_invoice_tax_required/i18n/pt_PT.po
+++ b/account_invoice_tax_required/i18n/pt_PT.po
@@ -32,7 +32,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/i18n/ro.po
+++ b/account_invoice_tax_required/i18n/ro.po
@@ -32,7 +32,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/i18n/ru.po
+++ b/account_invoice_tax_required/i18n/ru.po
@@ -33,7 +33,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/i18n/sk_SK.po
+++ b/account_invoice_tax_required/i18n/sk_SK.po
@@ -32,7 +32,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/i18n/sl.po
+++ b/account_invoice_tax_required/i18n/sl.po
@@ -32,8 +32,8 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
-msgstr "Račun vsebuje postavko s proizvodom %s brez davkov"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgstr "Račun %(invoice)s vsebuje postavko s proizvodom %(product)s brez davkov"
 
 #. module: account_invoice_tax_required
 #: model:ir.model,name:account_invoice_tax_required.model_account_move

--- a/account_invoice_tax_required/i18n/sv.po
+++ b/account_invoice_tax_required/i18n/sv.po
@@ -31,7 +31,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/i18n/th.po
+++ b/account_invoice_tax_required/i18n/th.po
@@ -31,7 +31,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/i18n/tr.po
+++ b/account_invoice_tax_required/i18n/tr.po
@@ -31,7 +31,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/i18n/tr_TR.po
+++ b/account_invoice_tax_required/i18n/tr_TR.po
@@ -32,7 +32,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/i18n/zh_CN.po
+++ b/account_invoice_tax_required/i18n/zh_CN.po
@@ -32,7 +32,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/i18n/zh_TW.po
+++ b/account_invoice_tax_required/i18n/zh_TW.po
@@ -31,7 +31,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice has a line with product %s with no taxes"
+msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required

--- a/account_invoice_tax_required/models/account_move.py
+++ b/account_invoice_tax_required/models/account_move.py
@@ -1,7 +1,7 @@
 # Copyright 2015 - Camptocamp SA - Author Vincent Renaville
 # Copyright 2016 - Tecnativa - Angel Moya <odoo@tecnativa.com>
-# Copyright 2019 - Tecnativa - Pedro M. Baeza
 # Copyright 2019 - Punt Sistemes - Juan Vicente Pascual
+# Copyright 2019-2024 - Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import SUPERUSER_ID, _, models
@@ -30,7 +30,7 @@ class AccountMove(models.Model):
                 )
             )
 
-    def action_post(self):
+    def _post(self, soft=True):
         # Always test if it is required by context
         force_test = self.env.context.get("test_tax_required")
         skip_test = any(
@@ -51,4 +51,4 @@ class AccountMove(models.Model):
         for move in self:
             if move.move_type != "entry" and (force_test or not skip_test):
                 move._test_invoice_line_tax()
-        return super(AccountMove, self).action_post()
+        return super()._post(soft=soft)

--- a/account_invoice_tax_required/models/account_move.py
+++ b/account_invoice_tax_required/models/account_move.py
@@ -14,20 +14,22 @@ class AccountMove(models.Model):
 
     def _test_invoice_line_tax(self):
         errors = []
-        error_template = _("Invoice has a line with product %s with no taxes")
+        error_template = _(
+            "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+        )
         for invoice_line in self.mapped("invoice_line_ids").filtered(
             lambda x: x.display_type not in ("line_section", "line_note")
         ):
             if not invoice_line.tax_ids:
-                error_string = error_template % (invoice_line.name)
+                error_string = error_template % {
+                    "invoice": invoice_line.move_id.name,
+                    "product": invoice_line.name,
+                }
                 errors.append(error_string)
         if errors:
-            raise UserError(
-                _(
-                    "%(message)s\n%(errors)s",
-                    message="No Taxes Defined!",
-                    errors=("\n".join(x for x in errors)),
-                )
+            raise UserError(  # pylint: disable=C8107
+                "%(message)s\n%(errors)s"
+                % {"message": _("No Taxes Defined!"), "errors": "\n".join(errors)}
             )
 
     def _post(self, soft=True):

--- a/account_invoice_tax_required/tests/test_account_move_tax_required.py
+++ b/account_invoice_tax_required/tests/test_account_move_tax_required.py
@@ -1,4 +1,5 @@
 # Copyright 2016 - Tecnativa - Angel Moya <odoo@tecnativa.com>
+# Copyright 2024 - Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import exceptions
@@ -90,6 +91,19 @@ class TestAccountInvoiceTaxRequired(TestAccountReconciliationCommon):
         """Validate invoice without tax must raise exception"""
         with self.assertRaises(exceptions.UserError):
             self.invoice.with_context(test_tax_required=True).action_post()
+
+    def test_mass_validation(self):
+        wizard = (
+            self.env["validate.account.move"]
+            .with_context(
+                test_tax_required=True,
+                active_model="account.move",
+                active_ids=self.invoice.ids,
+            )
+            .create({})
+        )
+        with self.assertRaises(exceptions.UserError):
+            wizard.validate_move()
 
     def test_without_exception(self):
         """Validate invoice without tax must raise exception"""


### PR DESCRIPTION
Forward-port of #1642

If you use the action in the invoice list for doing mass validation, the restriction about taxes required is bypassed. That's because the mass validation wizard is not calling `action_post`, but directly `_post`. It includes a regression test.

A second commit improves the message, indicating the affected invoice.

@Tecnativa TT47059