### PR TITLE
[15.0][IMP] account_invoice_triple_discount: only manage lines with discount2 or discount3

### DIFF
--- a/account_invoice_triple_discount/readme/CONTRIBUTORS.rst
+++ b/account_invoice_triple_discount/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * David Vidal <david.vidal@tecnativa.com>
 * Pedro M. Baeza <pedro.baeza@tecnativa.com>
 * Nikul Chaudhary <nikulchaudhary2112@gmail.com>
+* Manuel Regidor <manuel.regidor@sygel.es>


### PR DESCRIPTION
Before this improvement, all the account.move.lines in an invoice were treated as if they had the second or third discount applied.

With this improvement, only lines affected by the second or third discount are managed in the inherited method _recompute_tax_lines, so the price_unit field is only written in those lines that need it.