### PR TITLE
[15.0][IMP] account_invoice_warn_message: added full invoice types support

### DIFF
--- a/account_invoice_warn_message/__manifest__.py
+++ b/account_invoice_warn_message/__manifest__.py
@@ -10,5 +10,5 @@
     "author": "ForgeFlow, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/account-invoicing",
     "depends": ["account"],
-    "data": ["views/account_move_views.xml"],
+    "data": ["views/account_move_views.xml", "views/res_config_settings_views.xml"],
 }

--- a/account_invoice_warn_message/models/__init__.py
+++ b/account_invoice_warn_message/models/__init__.py
@@ -1,1 +1,3 @@
+from . import res_company
+from . import res_config_settings
 from . import account_move

--- a/account_invoice_warn_message/models/account_move.py
+++ b/account_invoice_warn_message/models/account_move.py
@@ -3,6 +3,19 @@
 
 from odoo import api, fields, models
 
+from .res_company import INVOICE_WARN_MESSAGE_SELECTION
+
+INVOICE_WARN_MESSAGE_SEL_MAPPING = {
+    INVOICE_WARN_MESSAGE_SELECTION[0][0]: ["out_invoice", "out_refund"],
+    INVOICE_WARN_MESSAGE_SELECTION[1][0]: ["in_invoice", "in_refund"],
+    INVOICE_WARN_MESSAGE_SELECTION[2][0]: [
+        "out_invoice",
+        "out_refund",
+        "in_invoice",
+        "in_refund",
+    ],
+}
+
 
 class AccountMove(models.Model):
 
@@ -17,10 +30,13 @@ class AccountMove(models.Model):
         "partner_id.parent_id.invoice_warn",
     )
     def _compute_invoice_warn_msg(self):
+        move_types_warn = INVOICE_WARN_MESSAGE_SEL_MAPPING[
+            self.env.company.invoice_warn_message_type
+        ]
         for rec in self:
             if (
                 rec.partner_id
-                and rec.move_type in ("out_invoice", "out_refund")
+                and rec.move_type in move_types_warn
                 and rec.state == "draft"
             ):
                 if (

--- a/account_invoice_warn_message/models/res_company.py
+++ b/account_invoice_warn_message/models/res_company.py
@@ -1,0 +1,18 @@
+# Copyright 2024 Solvos Consultoría Informática
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+INVOICE_WARN_MESSAGE_SELECTION = [
+    ("customer", "Customers"),
+    ("vendor", "Vendors"),
+    ("both", "Both"),
+]
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    invoice_warn_message_type = fields.Selection(
+        INVOICE_WARN_MESSAGE_SELECTION, default=INVOICE_WARN_MESSAGE_SELECTION[0][0]
+    )

--- a/account_invoice_warn_message/models/res_config_settings.py
+++ b/account_invoice_warn_message/models/res_config_settings.py
@@ -1,0 +1,15 @@
+# Copyright 2024 Solvos Consultoría Informática
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    invoice_warn_message_type = fields.Selection(
+        related="company_id.invoice_warn_message_type",
+        string="Invoice warn message options",
+        readonly=False,
+        required=True,
+    )

--- a/account_invoice_warn_message/readme/CONTRIBUTORS.rst
+++ b/account_invoice_warn_message/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Héctor Villarreal <hector.villarreal@forgeflow.com>
 * Manuel Regidor <manuel.regidor@sygel.es>
+* David Alonso <david.alonso@solvos.es>

--- a/account_invoice_warn_message/readme/DESCRIPTION.rst
+++ b/account_invoice_warn_message/readme/DESCRIPTION.rst
@@ -1,2 +1,4 @@
 This module add a warning popup on invoice to ensure warning is populated
 no only when partner is changed.
+
+This popup could be configured for customer invoices, vendor ones, or both.

--- a/account_invoice_warn_message/views/res_config_settings_views.xml
+++ b/account_invoice_warn_message/views/res_config_settings_views.xml
@@ -1,0 +1,35 @@
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field
+            name="name"
+        >res.config.settings.view.form.inherit.account (in account_invoice_warn_message)</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="account.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//field[@name='module_account_reports']/../../../.."
+                position="after"
+            >
+                <t groups="account.group_warning_account">
+                    <h2>Warning messages</h2>
+                    <div class="row mt16 o_settings_container">
+                        <div class="col-12 col-lg-6 o_setting_box">
+                            <div class="o_setting_left_pane" />
+                            <div class="o_setting_right_pane">
+                                <label for="invoice_warn_message_type" />
+                                <div class="text-muted">
+                                For warning message for invoices configuration, please select invoice types involved:
+                            </div>
+                                <div class="content-group">
+                                    <div class="row mt16 ml4">
+                                        <field name="invoice_warn_message_type" />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </t>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
With this addition, warn messages are set only for customers by default, but can be set for vendors or both customers and vendors.

Port from v13 #1645