### PR TITLE
[14.0][REF] account_global_discount: line discount in invoice tab

### DIFF
--- a/account_global_discount/models/account_move.py
+++ b/account_global_discount/models/account_move.py
@@ -198,7 +198,6 @@ class AccountMove(models.Model):
                     - (disc_amount < 0.0 and -disc_amount or 0.0),
                     "account_id": discount.account_id.id,
                     "analytic_account_id": discount.account_analytic_id.id,
-                    "exclude_from_invoice_tab": True,
                     "tax_ids": [(4, x.id) for x in discount.tax_ids],
                     "partner_id": self.commercial_partner_id.id,
                 }


### PR DESCRIPTION
If change discount on invoice all compute is okay 
but I haven't line in invoice tab, it's only in move tab

--
I confirm that I have signed the CLA https:///odoo-community.org/page/cla and have read the guidelines on https://odoo-community.org/page/contributing