### PR TITLE
[15.0][IMP] account_invoice_tax_required: Add customer information to error message for missing taxes in invoice lines

### DIFF
--- a/account_invoice_tax_required/i18n/account_invoice_tax_required.pot
+++ b/account_invoice_tax_required/i18n/account_invoice_tax_required.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-02-01 13:44+0000\n"
+"PO-Revision-Date: 2024-02-01 13:44+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,7 +18,15 @@ msgstr ""
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -28,4 +38,10 @@ msgstr ""
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
 msgid "No Taxes Defined!"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
 msgstr ""

--- a/account_invoice_tax_required/i18n/ar.po
+++ b/account_invoice_tax_required/i18n/ar.po
@@ -1,28 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-02-02 03:40+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: Arabic (https://www.transifex.com/oca/teams/23907/ar/)\n"
-"Language: ar\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 "
-"&& n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -36,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "فاتورة"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/bg.po
+++ b/account_invoice_tax_required/i18n/bg.po
@@ -1,27 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-02-02 03:40+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: Bulgarian (https://www.transifex.com/oca/teams/23907/bg/)\n"
-"Language: bg\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -35,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "Фактура"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/bs.po
+++ b/account_invoice_tax_required/i18n/bs.po
@@ -1,28 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-02-02 03:40+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: Bosnian (https://www.transifex.com/oca/teams/23907/bs/)\n"
-"Language: bs\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -36,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "Faktura"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/ca.po
+++ b/account_invoice_tax_required/i18n/ca.po
@@ -1,31 +1,35 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2022-08-09 10:06+0000\n"
-"Last-Translator: jabelchi <jabelchi@gmail.com>\n"
-"Language-Team: Catalan (https://www.transifex.com/oca/teams/23907/ca/)\n"
-"Language: ca\n"
+"POT-Creation-Date: 2024-02-01 08:35+0000\n"
+"PO-Revision-Date: 2024-02-01 08:35+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.3.2\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
 msgstr ""
-"La factura %(invoice)s té una línia amb el producte %(product)s que no té "
-"impostos"
+"La factura %(invoice)s per al client %(customer)s conté una línia amb el producte "
+"%(product)s sense impostos."
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
+msgstr "Factures amb Impostos Absents"
 
 #. module: account_invoice_tax_required
 #: model:ir.model,name:account_invoice_tax_required.model_account_move
@@ -38,13 +42,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr "No s'han definit impostos"
 
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-#~ msgid ""
-#~ "%s\n"
-#~ "%s"
-#~ msgstr ""
-#~ "%s\n"
-#~ "%s"
-
-#~ msgid "Invoice"
-#~ msgstr "Factura"
+msgid "Show invoices with lines without taxes"
+msgstr "Mostrar factures amb línies sense impostos"

--- a/account_invoice_tax_required/i18n/cs.po
+++ b/account_invoice_tax_required/i18n/cs.po
@@ -1,27 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-02-02 03:40+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: Czech (https://www.transifex.com/oca/teams/23907/cs/)\n"
-"Language: cs\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -35,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "Faktura"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/de.po
+++ b/account_invoice_tax_required/i18n/de.po
@@ -1,30 +1,35 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-10-11 11:41+0000\n"
-"Last-Translator: Rudolf Schnapka <rs@techno-flex.de>\n"
-"Language-Team: German (https://www.transifex.com/oca/teams/23907/de/)\n"
-"Language: de\n"
+"POT-Creation-Date: 2024-02-01 08:35+0000\n"
+"PO-Revision-Date: 2024-02-01 08:35+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 3.1.1\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
 msgstr ""
-"Rechnung %(invoice)s hat eine Position mit Produkt %(product)s ohne Steuer"
+"Rechnung %(invoice)s für Kunden %(customer)s enthält eine Zeile mit dem Produkt "
+"%(product)s ohne Steuern"
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
+msgstr "Rechnungen mit fehlenden Steuern"
 
 #. module: account_invoice_tax_required
 #: model:ir.model,name:account_invoice_tax_required.model_account_move
@@ -37,13 +42,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr "Keine Steuern festgelegt!"
 
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-#~ msgid ""
-#~ "%s\n"
-#~ "%s"
-#~ msgstr ""
-#~ "%s\n"
-#~ "%s"
-
-#~ msgid "Invoice"
-#~ msgstr "Rechnung"
+msgid "Show invoices with lines without taxes"
+msgstr "Rechnungen mit Positionen ohne Steuern anzeigen"

--- a/account_invoice_tax_required/i18n/el_GR.po
+++ b/account_invoice_tax_required/i18n/el_GR.po
@@ -1,28 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-02-02 03:40+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: Greek (Greece) (https://www.transifex.com/oca/teams/23907/"
-"el_GR/)\n"
-"Language: el_GR\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -36,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "Τιμολόγιο"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/en_GB.po
+++ b/account_invoice_tax_required/i18n/en_GB.po
@@ -1,28 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-02-02 03:40+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: English (United Kingdom) (https://www.transifex.com/oca/"
-"teams/23907/en_GB/)\n"
-"Language: en_GB\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -36,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "Invoice"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/es.po
+++ b/account_invoice_tax_required/i18n/es.po
@@ -1,58 +1,49 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2023-10-10 20:36+0000\n"
-"Last-Translator: Ivorra78 <informatica@totmaterial.es>\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
-"Language: es\n"
+"POT-Creation-Date: 2024-02-01 08:35+0000\n"
+"PO-Revision-Date: 2024-02-01 08:35+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.17\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
 msgstr ""
-"La factura %(invoice)s contiene una línea con el producto %(product)s que no "
-"tiene impuestos"
+"La factura %(invoice)s para el cliente %(customer)s contiene una línea con el producto "
+"%(product)s que no tiene impuestos"
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
+msgstr "Facturas sin impuestos"
 
 #. module: account_invoice_tax_required
 #: model:ir.model,name:account_invoice_tax_required.model_account_move
 msgid "Journal Entry"
-msgstr "Entrada Diaria"
+msgstr "Apunte contable"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
 msgid "No Taxes Defined!"
-msgstr "No hay impuestos definidos!"
+msgstr "¡No hay impuestos definidos!"
 
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-#~ msgid ""
-#~ "%(message)s\n"
-#~ "%(errors)s"
-#~ msgstr ""
-#~ "%(message)s\n"
-#~ "%(errors)s"
-
-#, python-format
-#~ msgid ""
-#~ "%s\n"
-#~ "%s"
-#~ msgstr ""
-#~ "%s\n"
-#~ "%s"
-
-#~ msgid "Invoice"
-#~ msgstr "Factura"
+msgid "Show invoices with lines without taxes"
+msgstr "Mostrar facturas con lineas sin impuestos"

--- a/account_invoice_tax_required/i18n/es_CR.po
+++ b/account_invoice_tax_required/i18n/es_CR.po
@@ -1,28 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-02-02 03:40+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: Spanish (Costa Rica) (https://www.transifex.com/oca/"
-"teams/23907/es_CR/)\n"
-"Language: es_CR\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -36,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "Factura"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/es_EC.po
+++ b/account_invoice_tax_required/i18n/es_EC.po
@@ -1,28 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-02-02 03:40+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: Spanish (Ecuador) (https://www.transifex.com/oca/teams/23907/"
-"es_EC/)\n"
-"Language: es_EC\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -36,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "Factura"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/es_ES.po
+++ b/account_invoice_tax_required/i18n/es_ES.po
@@ -1,28 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-02-02 03:40+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: Spanish (Spain) (https://www.transifex.com/oca/teams/23907/"
-"es_ES/)\n"
-"Language: es_ES\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -36,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "Factura"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/es_MX.po
+++ b/account_invoice_tax_required/i18n/es_MX.po
@@ -1,28 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-02-02 03:40+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: Spanish (Mexico) (https://www.transifex.com/oca/teams/23907/"
-"es_MX/)\n"
-"Language: es_MX\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -36,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "Factura"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/et.po
+++ b/account_invoice_tax_required/i18n/et.po
@@ -1,27 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-02-02 03:40+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: Estonian (https://www.transifex.com/oca/teams/23907/et/)\n"
-"Language: et\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -35,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "Arve"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/fi.po
+++ b/account_invoice_tax_required/i18n/fi.po
@@ -1,27 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-02-02 03:40+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: Finnish (https://www.transifex.com/oca/teams/23907/fi/)\n"
-"Language: fi\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -35,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "Lasku"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/fr.po
+++ b/account_invoice_tax_required/i18n/fr.po
@@ -1,29 +1,33 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
-# Quentin THEURET <odoo@kerpeo.com>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-03 01:13+0000\n"
-"PO-Revision-Date: 2018-02-03 01:13+0000\n"
-"Last-Translator: Quentin THEURET <odoo@kerpeo.com>, 2018\n"
-"Language-Team: French (https://www.transifex.com/oca/teams/23907/fr/)\n"
-"Language: fr\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
-msgstr "La facture %(invoice)s a un produit %(product)s sans taxe"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
+msgstr ""
 
 #. module: account_invoice_tax_required
 #: model:ir.model,name:account_invoice_tax_required.model_account_move
@@ -34,15 +38,10 @@ msgstr ""
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
 msgid "No Taxes Defined!"
-msgstr "Aucunes taxes définies"
+msgstr ""
 
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-#~ msgid ""
-#~ "%s\n"
-#~ "%s"
-#~ msgstr ""
-#~ "%s\n"
-#~ "%s"
-
-#~ msgid "Invoice"
-#~ msgstr "Facture"
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/fr_CA.po
+++ b/account_invoice_tax_required/i18n/fr_CA.po
@@ -1,28 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-02-02 03:40+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: French (Canada) (https://www.transifex.com/oca/teams/23907/"
-"fr_CA/)\n"
-"Language: fr_CA\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -36,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "Facture"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/fr_CH.po
+++ b/account_invoice_tax_required/i18n/fr_CH.po
@@ -1,28 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-02-02 03:40+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: French (Switzerland) (https://www.transifex.com/oca/"
-"teams/23907/fr_CH/)\n"
-"Language: fr_CH\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -36,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "Facture"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/gl.po
+++ b/account_invoice_tax_required/i18n/gl.po
@@ -1,27 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-02-02 03:40+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: Galician (https://www.transifex.com/oca/teams/23907/gl/)\n"
-"Language: gl\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -35,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "Factura"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/hr.po
+++ b/account_invoice_tax_required/i18n/hr.po
@@ -1,28 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-02-02 03:40+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: Croatian (https://www.transifex.com/oca/teams/23907/hr/)\n"
-"Language: hr\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -36,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "Račun"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/hr_HR.po
+++ b/account_invoice_tax_required/i18n/hr_HR.po
@@ -1,29 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-02-02 03:40+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: Croatian (Croatia) (https://www.transifex.com/oca/teams/23907/"
-"hr_HR/)\n"
-"Language: hr_HR\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -37,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "Račun"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/hu.po
+++ b/account_invoice_tax_required/i18n/hu.po
@@ -1,27 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-02-02 03:40+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: Hungarian (https://www.transifex.com/oca/teams/23907/hu/)\n"
-"Language: hu\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -35,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "Számla"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/id.po
+++ b/account_invoice_tax_required/i18n/id.po
@@ -1,27 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-02-02 03:40+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: Indonesian (https://www.transifex.com/oca/teams/23907/id/)\n"
-"Language: id\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=1; plural=0;\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -35,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "Faktur"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/it.po
+++ b/account_invoice_tax_required/i18n/it.po
@@ -1,27 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-02-02 03:40+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: Italian (https://www.transifex.com/oca/teams/23907/it/)\n"
-"Language: it\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -35,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "Fattura"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/ja.po
+++ b/account_invoice_tax_required/i18n/ja.po
@@ -1,27 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-02-02 03:40+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: Japanese (https://www.transifex.com/oca/teams/23907/ja/)\n"
-"Language: ja\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=1; plural=0;\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -35,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "請求書"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/lt.po
+++ b/account_invoice_tax_required/i18n/lt.po
@@ -1,28 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
 msgid ""
 msgstr ""
-"Project-Id-Version: account-financial-tools (8.0)\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-01 13:25+0000\n"
-"PO-Revision-Date: 2015-07-01 13:27+0000\n"
-"Last-Translator: <>\n"
-"Language-Team: Lithuanian (http://www.transifex.com/oca/OCA-account-"
-"financial-tools-8-0/language/lt/)\n"
-"Language: lt\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n"
-"%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -36,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "Sąskaita faktūra"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/mk.po
+++ b/account_invoice_tax_required/i18n/mk.po
@@ -1,27 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-02-02 03:40+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: Macedonian (https://www.transifex.com/oca/teams/23907/mk/)\n"
-"Language: mk\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=(n % 10 == 1 && n % 100 != 11) ? 0 : 1;\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -35,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "Фактура"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/mn.po
+++ b/account_invoice_tax_required/i18n/mn.po
@@ -1,27 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-02-02 03:40+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: Mongolian (https://www.transifex.com/oca/teams/23907/mn/)\n"
-"Language: mn\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -35,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "Нэхэмжлэл"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/nb.po
+++ b/account_invoice_tax_required/i18n/nb.po
@@ -1,28 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-02-02 03:40+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: Norwegian Bokmål (https://www.transifex.com/oca/teams/23907/"
-"nb/)\n"
-"Language: nb\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -36,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "Faktura"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/nb_NO.po
+++ b/account_invoice_tax_required/i18n/nb_NO.po
@@ -1,28 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-02-02 03:40+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: Norwegian Bokmål (Norway) (https://www.transifex.com/oca/"
-"teams/23907/nb_NO/)\n"
-"Language: nb_NO\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -36,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "Innmelding"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/nl.po
+++ b/account_invoice_tax_required/i18n/nl.po
@@ -1,27 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-02-02 03:40+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: Dutch (https://www.transifex.com/oca/teams/23907/nl/)\n"
-"Language: nl\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -35,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "Factuur"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/nl_BE.po
+++ b/account_invoice_tax_required/i18n/nl_BE.po
@@ -1,28 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-02-02 03:40+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: Dutch (Belgium) (https://www.transifex.com/oca/teams/23907/"
-"nl_BE/)\n"
-"Language: nl_BE\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -36,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "Factuur"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/nl_NL.po
+++ b/account_invoice_tax_required/i18n/nl_NL.po
@@ -1,28 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-02-02 03:40+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: Dutch (Netherlands) (https://www.transifex.com/oca/"
-"teams/23907/nl_NL/)\n"
-"Language: nl_NL\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -36,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "Factuur"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/pl.po
+++ b/account_invoice_tax_required/i18n/pl.po
@@ -1,29 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-02-02 03:40+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: Polish (https://www.transifex.com/oca/teams/23907/pl/)\n"
-"Language: pl\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n"
-"%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n"
-"%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -37,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "Faktura"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/pt.po
+++ b/account_invoice_tax_required/i18n/pt.po
@@ -1,27 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-02-02 03:40+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: Portuguese (https://www.transifex.com/oca/teams/23907/pt/)\n"
-"Language: pt\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -35,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "Fatura"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/pt_BR.po
+++ b/account_invoice_tax_required/i18n/pt_BR.po
@@ -1,30 +1,35 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2019-08-26 15:01+0000\n"
-"Last-Translator: Rodrigo Macedo <rmsolucoeseminformatic4@gmail.com>\n"
-"Language-Team: Portuguese (Brazil) (https://www.transifex.com/oca/"
-"teams/23907/pt_BR/)\n"
-"Language: pt_BR\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 3.8\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
-msgstr "A Fatura %(invoice)s com o produto %(product)s está sem impostos"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+"A fatura %(invoice)s para o cliente %(customer)s possui uma linha com o produto "
+"%(product)s sem impostos"
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
+msgstr "Faturas com Impostos Ausentes"
 
 #. module: account_invoice_tax_required
 #: model:ir.model,name:account_invoice_tax_required.model_account_move
@@ -37,13 +42,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr "Sem Impostos Definidos!"
 
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-#~ msgid ""
-#~ "%s\n"
-#~ "%s"
-#~ msgstr ""
-#~ "%s\n"
-#~ "%s"
-
-#~ msgid "Invoice"
-#~ msgstr "Fatura"
+msgid "Show invoices with lines without taxes"
+msgstr "Mostrar faturas com linhas sem impostos"

--- a/account_invoice_tax_required/i18n/pt_PT.po
+++ b/account_invoice_tax_required/i18n/pt_PT.po
@@ -1,28 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-02-02 03:40+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: Portuguese (Portugal) (https://www.transifex.com/oca/"
-"teams/23907/pt_PT/)\n"
-"Language: pt_PT\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -36,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "Fatura"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/ro.po
+++ b/account_invoice_tax_required/i18n/ro.po
@@ -1,28 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-02-02 03:40+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: Romanian (https://www.transifex.com/oca/teams/23907/ro/)\n"
-"Language: ro\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?"
-"2:1));\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -36,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "Factura"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/ru.po
+++ b/account_invoice_tax_required/i18n/ru.po
@@ -1,29 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-02-02 03:40+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: Russian (https://www.transifex.com/oca/teams/23907/ru/)\n"
-"Language: ru\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n"
-"%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -37,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "Счет"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/sk_SK.po
+++ b/account_invoice_tax_required/i18n/sk_SK.po
@@ -1,28 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-02-02 03:40+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: Slovak (Slovakia) (https://www.transifex.com/oca/teams/23907/"
-"sk_SK/)\n"
-"Language: sk_SK\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -36,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "Faktúra"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/sl.po
+++ b/account_invoice_tax_required/i18n/sl.po
@@ -1,30 +1,35 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-02-02 03:40+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: Slovenian (https://www.transifex.com/oca/teams/23907/sl/)\n"
-"Language: sl\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n"
-"%100==4 ? 2 : 3);\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
 msgstr ""
-"Račun %(invoice)s vsebuje postavko s proizvodom %(product)s brez davkov"
+"Račun %(invoice)s za stranko %(customer)s ima postavko s proizvodom "
+"%(product)s brez davkov"
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
+msgstr "Računi s pomanjkljivimi davki"
 
 #. module: account_invoice_tax_required
 #: model:ir.model,name:account_invoice_tax_required.model_account_move
@@ -37,5 +42,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr "Davki niso določeni!"
 
-#~ msgid "Invoice"
-#~ msgstr "Račun"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr "Prikaži račune s postavkami brez davkov"

--- a/account_invoice_tax_required/i18n/sv.po
+++ b/account_invoice_tax_required/i18n/sv.po
@@ -1,27 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-02-02 03:40+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: Swedish (https://www.transifex.com/oca/teams/23907/sv/)\n"
-"Language: sv\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -35,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "Faktura"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/th.po
+++ b/account_invoice_tax_required/i18n/th.po
@@ -1,27 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-02-02 03:40+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: Thai (https://www.transifex.com/oca/teams/23907/th/)\n"
-"Language: th\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=1; plural=0;\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -35,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "ใบแจ้งหนี้"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/tr.po
+++ b/account_invoice_tax_required/i18n/tr.po
@@ -1,27 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-02-02 03:40+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: Turkish (https://www.transifex.com/oca/teams/23907/tr/)\n"
-"Language: tr\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -35,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "Fatura"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/tr_TR.po
+++ b/account_invoice_tax_required/i18n/tr_TR.po
@@ -1,28 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-02-02 03:40+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: Turkish (Turkey) (https://www.transifex.com/oca/teams/23907/"
-"tr_TR/)\n"
-"Language: tr_TR\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=1; plural=0;\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -36,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "Fatura"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/zh_CN.po
+++ b/account_invoice_tax_required/i18n/zh_CN.po
@@ -1,28 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-02 03:40+0000\n"
-"PO-Revision-Date: 2018-02-02 03:40+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: Chinese (China) (https://www.transifex.com/oca/teams/23907/"
-"zh_CN/)\n"
-"Language: zh_CN\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=1; plural=0;\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -36,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "发票"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/i18n/zh_TW.po
+++ b/account_invoice_tax_required/i18n/zh_TW.po
@@ -1,27 +1,32 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * account_invoice_tax_required
+# 	* account_invoice_tax_required
 #
-# Translators:
 msgid ""
 msgstr ""
-"Project-Id-Version: account-financial-tools (8.0)\n"
+"Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-01 13:25+0000\n"
-"PO-Revision-Date: 2015-07-01 13:27+0000\n"
-"Last-Translator: <>\n"
-"Language-Team: Chinese (Taiwan) (http://www.transifex.com/oca/OCA-account-"
-"financial-tools-8-0/language/zh_TW/)\n"
-"Language: zh_TW\n"
+"POT-Creation-Date: 2024-02-01 13:45+0000\n"
+"PO-Revision-Date: 2024-02-01 13:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=1; plural=0;\n"
+"Plural-Forms: \n"
 
 #. module: account_invoice_tax_required
 #: code:addons/account_invoice_tax_required/models/account_move.py:0
 #, python-format
-msgid "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+msgid ""
+"Invoice %(invoice)s for customer %(customer)s has a line with product "
+"%(product)s with no taxes"
+msgstr ""
+
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Invoices with Missing Taxes"
 msgstr ""
 
 #. module: account_invoice_tax_required
@@ -35,5 +40,8 @@ msgstr ""
 msgid "No Taxes Defined!"
 msgstr ""
 
-#~ msgid "Invoice"
-#~ msgstr "發票"
+#. module: account_invoice_tax_required
+#: code:addons/account_invoice_tax_required/models/account_move.py:0
+#, python-format
+msgid "Show invoices with lines without taxes"
+msgstr ""

--- a/account_invoice_tax_required/models/account_move.py
+++ b/account_invoice_tax_required/models/account_move.py
@@ -5,7 +5,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import SUPERUSER_ID, _, models
-from odoo.exceptions import UserError
+from odoo.exceptions import RedirectWarning
 from odoo.tools import config
 
 
@@ -14,8 +14,10 @@ class AccountMove(models.Model):
 
     def _test_invoice_line_tax(self):
         errors = []
+        invoice_error_ids = []
         error_template = _(
-            "Invoice %(invoice)s has a line with product %(product)s with no taxes"
+            "Invoice %(invoice)s for customer %(customer)s "
+            "has a line with product %(product)s with no taxes"
         )
         for invoice_line in self.mapped("invoice_line_ids").filtered(
             lambda x: x.display_type is False
@@ -23,13 +25,41 @@ class AccountMove(models.Model):
             if not invoice_line.tax_ids:
                 error_string = error_template % {
                     "invoice": invoice_line.move_id.name,
+                    "customer": invoice_line.partner_id.name,
                     "product": invoice_line.name,
                 }
+                invoice_error_ids.append(invoice_line.move_id.id)
                 errors.append(error_string)
         if errors:
-            raise UserError(  # pylint: disable=C8107
-                "%(message)s\n%(errors)s"
-                % {"message": _("No Taxes Defined!"), "errors": "\n".join(errors)}
+            invoice_error_ids = list(set(invoice_error_ids))
+            action_error = {
+                "name": _("Invoices with Missing Taxes"),
+                "res_model": "account.move",
+                "type": "ir.actions.act_window",
+                "search_view_id": [
+                    self.env.ref("account.view_account_move_filter").id,
+                    "search",
+                ],
+            }
+            if len(invoice_error_ids) == 1:
+                action_error["view_mode"] = "form"
+                action_error["res_id"] = invoice_error_ids[0]
+                action_error["views"] = [
+                    [self.env.ref("account.view_move_form").id, "form"],
+                ]
+            else:
+                action_error["view_mode"] = "tree"
+                action_error["domain"] = [("id", "in", invoice_error_ids)]
+                action_error["views"] = [
+                    [self.env.ref("account.view_move_tree").id, "list"],
+                    [self.env.ref("account.view_move_form").id, "form"],
+                ]
+            error_msg = "%(message)s\n%(errors)s" % {
+                "message": _("No Taxes Defined!"),
+                "errors": "\n".join(errors),
+            }
+            raise RedirectWarning(
+                error_msg, action_error, _("Show invoices with lines without taxes")
             )
 
     def _post(self, soft=True):
@@ -50,7 +80,6 @@ class AccountMove(models.Model):
                 config["test_enable"],
             )
         )
-        for move in self:
-            if move.move_type != "entry" and (force_test or not skip_test):
-                move._test_invoice_line_tax()
+        if force_test or not skip_test:
+            self.filtered(lambda m: m.is_invoice())._test_invoice_line_tax()
         return super()._post(soft=soft)

--- a/account_invoice_tax_required/tests/test_account_move_tax_required.py
+++ b/account_invoice_tax_required/tests/test_account_move_tax_required.py
@@ -90,7 +90,7 @@ class TestAccountInvoiceTaxRequired(TestAccountReconciliationCommon):
 
     def test_exception(self):
         """Validate invoice without tax must raise exception"""
-        with self.assertRaises(exceptions.UserError):
+        with self.assertRaises(exceptions.RedirectWarning):
             self.invoice.with_context(test_tax_required=True).action_post()
 
     def test_mass_validation(self):
@@ -103,7 +103,7 @@ class TestAccountInvoiceTaxRequired(TestAccountReconciliationCommon):
             )
             .create({})
         )
-        with self.assertRaises(exceptions.UserError):
+        with self.assertRaises(exceptions.RedirectWarning):
             wizard.validate_move()
 
     def test_without_exception(self):


### PR DESCRIPTION
The customer is included in the error message of the line containing a product without tax and an action is added to go directly to the list of invoices containing those lines.

cc@Tecnativa TT47521

@carlosdauden @pedrobaeza  please review