### PR TITLE
[FIX] account_invoicing: compute price recalcule

### DIFF
--- a/account_invoice_pricelist/models/account_move.py
+++ b/account_invoice_pricelist/models/account_move.py
@@ -61,12 +61,19 @@ class AccountMove(models.Model):
             lambda r: r.state == "draft"
         ).invoice_line_ids._compute_price_unit()
 
+    def action_switch_invoice_into_refund_credit_note(self):
+        return super(
+            AccountMove, self.with_context(avoid_price_unit_compute=True)
+        ).action_switch_invoice_into_refund_credit_note()
+
 
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
 
     @api.depends("quantity")
     def _compute_price_unit(self):
+        if self.env.context.get("avoid_price_unit_compute", False):
+            return True
         res = super()._compute_price_unit()
         for line in self:
             if not line.move_id.pricelist_id:


### PR DESCRIPTION
This change is to prevent the unit price from being recalculated since when making a refund invoice the price is recalculated and the price of the product is taken.