### PR TITLE
[16.0][FIX] account_invoice_triple_discount: Fix tax recompute on closed fiscal year

### DIFF
--- a/account_invoice_triple_discount/README.rst
+++ b/account_invoice_triple_discount/README.rst
@@ -84,6 +84,7 @@ Contributors
 * `Aion Tech <https://aiontech.company/>`_:
 
   * Simone Rubino <simone.rubino@aion-tech.it>
+* Laurent Mignon <laurent.mignon@acsone.eu>
 
 Maintainers
 ~~~~~~~~~~~

--- a/account_invoice_triple_discount/readme/CONTRIBUTORS.rst
+++ b/account_invoice_triple_discount/readme/CONTRIBUTORS.rst
@@ -4,3 +4,4 @@
 * `Aion Tech <https://aiontech.company/>`_:
 
   * Simone Rubino <simone.rubino@aion-tech.it>
+* Laurent Mignon <laurent.mignon@acsone.eu>

--- a/account_invoice_triple_discount/static/description/index.html
+++ b/account_invoice_triple_discount/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -434,6 +433,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Simone Rubino &lt;<a class="reference external" href="mailto:simone.rubino&#64;aion-tech.it">simone.rubino&#64;aion-tech.it</a>&gt;</li>
 </ul>
 </li>
+<li>Laurent Mignon &lt;<a class="reference external" href="mailto:laurent.mignon&#64;acsone.eu">laurent.mignon&#64;acsone.eu</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/account_invoice_triple_discount/tests/test_invoice_triple_discount.py
+++ b/account_invoice_triple_discount/tests/test_invoice_triple_discount.py
@@ -2,11 +2,12 @@
 # Copyright 2023 Simone Rubino - Aion Tech
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo.tests import TransactionCase
 from odoo.tests.common import Form
 
+from odoo.addons.base.tests.common import BaseCommon
 
-class TestInvoiceTripleDiscount(TransactionCase):
+
+class TestInvoiceTripleDiscount(BaseCommon):
     @classmethod
     def setUpClass(cls):
         super(TestInvoiceTripleDiscount, cls).setUpClass()
@@ -17,7 +18,6 @@ class TestInvoiceTripleDiscount(TransactionCase):
         cls.Partner = cls.env["res.partner"]
         cls.Journal = cls.env["account.journal"]
 
-        cls.partner = cls.Partner.create({"name": "test"})
         cls.tax = cls.AccountTax.create(
             {
                 "name": "TAX 15%",

--- a/account_invoice_triple_discount/tests/test_invoice_triple_discount.py
+++ b/account_invoice_triple_discount/tests/test_invoice_triple_discount.py
@@ -202,3 +202,19 @@ class TestInvoiceTripleDiscount(TransactionCase):
         invoice_line.discount = 100
         invoice_line.tax_ids = False
         self.assertEqual(invoice_line.discount, 100)
+
+    def test_tax_compute_with_lock_date(self):
+        # Check that the tax computation works even if the lock date is set
+        invoice = self.create_simple_invoice(0)
+        invoice_form = Form(invoice)
+        with invoice_form.invoice_line_ids.edit(0) as line_form:
+            line_form.name = "Line Decimals"
+            line_form.quantity = 9950
+            line_form.price_unit = 0.14
+            line_form.discount = 10
+            line_form.discount2 = 20
+        invoice_form.save()
+        invoice_line = invoice.invoice_line_ids[0]
+        invoice.action_post()
+        self.env.user.company_id.fiscalyear_lock_date = "2000-01-01"
+        invoice_line._compute_all_tax()


### PR DESCRIPTION
When computing the taxes and the totals on account.move.line it's required to prevent calls to the write method on account.move or triggering recompute of unexpected fields while we assign a temporary value to the discount field to use the aggregated one bedore calling the base implementation. Otherwise the update of the discount field will invalidate totals and ... on related accoun.move and trigger calls to the write method of account.move. Any call to the write method will trigger a set of check to see if the balance is still right or check if you try to write on a record prior to the fiscal year close date or .... At the end, every time you try to access to the taxes on the records, some errors could be unexpeced raised due to the trick a temporarily changing the discount value of the field while computing others fields.

In the future we should use dedicated fields for the 3 discount fields and make the native discount field a computed one with readonly=False. This approach would simplify a lot the code. See https://github.com/OCA/account-invoicing/pull/1638