### PR TITLE
[16.0][IMP] account_invoice_merge: Disable Merge Lines

### DIFF
--- a/account_invoice_merge/wizard/invoice_merge.py
+++ b/account_invoice_merge/wizard/invoice_merge.py
@@ -18,6 +18,7 @@ class InvoiceMerge(models.TransientModel):
     )
     date_invoice = fields.Date("Invoice Date")
     error_message = fields.Text()
+    disable_merge_lines = fields.Boolean()
 
     @api.model
     def default_get(self, default_fields):
@@ -68,7 +69,9 @@ class InvoiceMerge(models.TransientModel):
         ids = self.env.context.get("active_ids", [])
         invoices = self.env["account.move"].browse(ids)
         allinvoices = invoices.do_merge(
-            keep_references=self.keep_references, date_invoice=self.date_invoice
+            keep_references=self.keep_references,
+            date_invoice=self.date_invoice,
+            disable_merge_lines=self.disable_merge_lines,
         )
         xid = {
             "out_invoice": "action_move_out_invoice_type",

--- a/account_invoice_merge/wizard/invoice_merge_view.xml
+++ b/account_invoice_merge/wizard/invoice_merge_view.xml
@@ -19,13 +19,15 @@
                         * Invoices belong to the same partner.<br />
                         * Invoices have the same company, partner, address,
                         currency, journal, salesman, account and type.<br /><br />
-                        Lines will only be merged if:<br />
+                        If you don check "Disable Merge Lines", lines will only be merged if:<br
+                            />
                         * Invoice lines are exactly the same except for the
                         product, quantity and unit.<br />
                         </p>
                         <group name="options" colspan="4">
                             <field name="keep_references" />
                             <field name="date_invoice" />
+                            <field name="disable_merge_lines" />
                         </group>
                     </group>
                 </group>


### PR DESCRIPTION
Disable merge lines on invoice merge, for example when you wants to get original sections on invoices merged