### PR TITLE
[16.0][FIX] account_invoice_fixed_discount: Monetary to Float

### DIFF
--- a/account_invoice_fixed_discount/models/account_move_line.py
+++ b/account_invoice_fixed_discount/models/account_move_line.py
@@ -8,10 +8,10 @@ from odoo.tools.float_utils import float_is_zero
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
 
-    discount_fixed = fields.Monetary(
+    discount_fixed = fields.Float(
         string="Discount (Fixed)",
         default=0.0,
-        currency_field="currency_id",
+        digits="Product Price",
         help=(
             "Apply a fixed amount discount to this line. The amount is multiplied by "
             "the quantity of the product."


### PR DESCRIPTION
This field was Float pre-16, it was changed to Monetary [there](https://github.com/OCA/account-invoicing/commit/3384403d138904130496cbbbdfd042dbe5061285) I assume as a natural part of the refactorization

https://github.com/OCA/sale-workflow/blob/627b3bee6fa0cb224c1e073df068019a90e96dce/sale_fixed_discount/models/sale_order_line.py#L12-L16
In `sale_fixed_discount` the field is `Float` and has configurable decimal precision through `Product Price`, but when creating an invoice from this sale it will get cut down to the Monetary precision causing inconsistencies.
Since this field goes hand in hand with `price_unit`, it makes more sense to keep it at the same precision as that field.

Sale:
![image](https://github.com/OCA/account-invoicing/assets/47854752/df817518-d1f3-4f3d-9faf-a92d1ca6bf73)

Invoice before changes:
![image](https://github.com/OCA/account-invoicing/assets/47854752/4aee44b2-130c-47cf-81f4-2341ef6fed5b)
