### PR TITLE
[16.0][FIX] account_invoice_fiscal_position_update: fix fiscal positi…

### DIFF
--- a/account_invoice_fiscal_position_update/README.rst
+++ b/account_invoice_fiscal_position_update/README.rst
@@ -78,6 +78,8 @@ Contributors
 
     * Luis J. Salvatierra <luis.salvatierra@factorlibre.com>
 
+* Eduardo López (`Moduon <https://www.moduon.team/>`__)
+
 Maintainers
 ~~~~~~~~~~~
 

--- a/account_invoice_fiscal_position_update/models/account_move.py
+++ b/account_invoice_fiscal_position_update/models/account_move.py
@@ -40,5 +40,5 @@ class AccountMove(models.Model):
                     "to the new Fiscal Position because they don't have a "
                     "Product:\n - %s\nYou should update the Account and the "
                     "Taxes of these invoice lines manually."
-                ) % ("\n- ".join(lines_without_product.mapped("name")))
+                ) % ("\n- ".join(lines_without_product.mapped("display_name")))
         return res

--- a/account_invoice_fiscal_position_update/readme/CONTRIBUTORS.rst
+++ b/account_invoice_fiscal_position_update/readme/CONTRIBUTORS.rst
@@ -9,3 +9,5 @@
 * `Factor Libre <https://factorlibre.com>`_:
 
     * Luis J. Salvatierra <luis.salvatierra@factorlibre.com>
+
+* Eduardo López (`Moduon <https://www.moduon.team/>`__)

--- a/account_invoice_fiscal_position_update/static/description/index.html
+++ b/account_invoice_fiscal_position_update/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -433,6 +432,8 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Luis J. Salvatierra &lt;<a class="reference external" href="mailto:luis.salvatierra&#64;factorlibre.com">luis.salvatierra&#64;factorlibre.com</a>&gt;</li>
 </ul>
 </blockquote>
+</li>
+<li><p class="first">Eduardo López (<a class="reference external" href="https://www.moduon.team/">Moduon</a>)</p>
 </li>
 </ul>
 </div>

--- a/account_invoice_fiscal_position_update/tests/test_inv_fiscal_pos_update.py
+++ b/account_invoice_fiscal_position_update/tests/test_inv_fiscal_pos_update.py
@@ -127,10 +127,9 @@ class TestProductIdChange(AccountTestInvoicingCommon):
             fp_account.account_dest_id,
             "The account revenue of invoice line must be changed by fiscal position",
         )
-        # Test warning due to lines without product
+        # Test warning due to lines without product and description
         self.invoice_line_model.with_context(check_move_validity=False).create(
             {
-                "name": "Line without product",
                 "price_unit": 100,
                 "quantity": 1,
                 "move_id": out_invoice.id,
@@ -142,6 +141,12 @@ class TestProductIdChange(AccountTestInvoicingCommon):
         )._onchange_fiscal_position_id_account_invoice_fiscal_position_invoice()
         self.assertTrue(type(onchange_result) == dict)
         self.assertEqual(list(onchange_result.keys()), ["warning"])
+        lines_without_product = out_invoice.invoice_line_ids.filtered(
+            lambda l: not l.product_id.exists()
+        )
+        self.assertNotEqual(
+            len(lines_without_product), len(out_invoice.invoice_line_ids)
+        )
 
         # for all lines without product
         out_invoice_without_prd = self.invoice_model.create(


### PR DESCRIPTION
…on onchange

@moduon MT-1859

This PR solves [this issue](https://github.com/OCA/account-invoicing/issues/1677). 

## Module
account_invoice_fiscal_position_update

## Describe the bug
Server error on fiscal position change when the move line hasn't either product nor description.

## To Reproduce
**Affected versions**: 16.0 at least.


Steps to reproduce the behavior:
1. Create a new invoice.
2.  Add a line without product and description and another line with a product.
3. Go to "Other Info" page and select any fiscal position.

**Expected behavior**
The user should be prompt with a warning and those move lines shouldn't change the tax automatically.