### PR TITLE
[14.0][IMP] manual invoicing mode

### DIFF
--- a/account_invoice_base_invoicing_mode/models/sale_order.py
+++ b/account_invoice_base_invoicing_mode/models/sale_order.py
@@ -62,3 +62,14 @@ class SaleOrder(models.Model):
             self.with_delay()._generate_invoices_by_partner(saleorder_ids)
         companies.write({last_execution_field_name: datetime.now()})
         return saleorder_groups
+
+    def _create_invoices(self, grouped=False, final=False, date=None):
+        moves = self.env["account.move"]
+        for partner_invoice in self.partner_invoice_id:
+            sales = self.filtered(lambda r: r.partner_invoice_id == partner_invoice)
+            moves += super(SaleOrder, sales)._create_invoices(
+                grouped=partner_invoice.one_invoice_per_order,
+                final=final,
+                date=date,
+            )
+        return moves


### PR DESCRIPTION
Actually, the invoicing mode only work with weekly, monthly automatic invoicing. But if you select manually some sale orders in a list,the action create invoice doesn't take into account the  "1 invoice by sale" parameter.
Add the invoicing mode when select the sale orders manually. 
