### PR TITLE
[14.0][FIX] account_invoice_merge: move call to _dirty_check to default_get

### DIFF
--- a/account_invoice_merge/tests/test_account_invoice_merge.py
+++ b/account_invoice_merge/tests/test_account_invoice_merge.py
@@ -98,7 +98,6 @@ class TestAccountInvoiceMerge(TransactionCase):
             active_ids=invoices.ids,
             active_model=invoices._name,
         ).create({})
-        wiz_id.fields_view_get()
         action = wiz_id.merge_invoices()
 
         self.assertEqual(
@@ -122,12 +121,11 @@ class TestAccountInvoiceMerge(TransactionCase):
 
     def test_account_invoice_merge_2(self):
         invoices = self.invoice1 | self.invoice3
-        wiz_id = self.wiz.with_context(
-            active_ids=invoices.ids,
-            active_model=invoices._name,
-        ).create({})
         with self.assertRaises(UserError):
-            wiz_id.fields_view_get()
+            self.wiz.with_context(
+                active_ids=invoices.ids,
+                active_model=invoices._name,
+            ).create({})
 
     def test_dirty_check(self):
         """Check"""
@@ -137,7 +135,7 @@ class TestAccountInvoiceMerge(TransactionCase):
         with self.assertRaises(UserError):
             wiz_id.with_context(
                 active_ids=self.invoice1.ids, active_model=self.invoice1._name
-            ).fields_view_get()
+            ).default_get([])
 
         # Check with two different invoice type
         # Create the invoice 4 with a different account
@@ -149,7 +147,7 @@ class TestAccountInvoiceMerge(TransactionCase):
             wiz_id.with_context(
                 active_ids=invoices.ids,
                 active_model=invoices._name,
-            ).fields_view_get()
+            ).default_get([])
 
         # Check with a canceled invoice
         # Create and cancel the invoice 5
@@ -161,7 +159,7 @@ class TestAccountInvoiceMerge(TransactionCase):
             wiz_id.with_context(
                 active_ids=invoices.ids,
                 active_model=invoices._name,
-            ).fields_view_get()
+            ).default_get([])
 
         # Check with an another company
         # Create the invoice 6 and change the company
@@ -174,7 +172,7 @@ class TestAccountInvoiceMerge(TransactionCase):
             wiz_id.with_context(
                 active_ids=invoices.ids,
                 active_model=invoices._name,
-            ).fields_view_get()
+            ).default_get([])
 
         # Check with two different partners
         invoices = self.invoice1 | self.invoice3
@@ -182,7 +180,7 @@ class TestAccountInvoiceMerge(TransactionCase):
             wiz_id.with_context(
                 active_ids=invoices.ids,
                 active_model=invoices._name,
-            ).fields_view_get()
+            ).default_get([])
 
     def test_account_invoice_merge_3(self):
 
@@ -207,5 +205,4 @@ class TestAccountInvoiceMerge(TransactionCase):
             active_ids=invoices.ids,
             active_model=invoices._name,
         ).create({})
-        wiz_id.fields_view_get()
         wiz_id.merge_invoices()

--- a/account_invoice_merge/wizard/invoice_merge.py
+++ b/account_invoice_merge/wizard/invoice_merge.py
@@ -20,6 +20,11 @@ class InvoiceMerge(models.TransientModel):
     date_invoice = fields.Date("Invoice Date")
 
     @api.model
+    def default_get(self, fields_list):
+        self._dirty_check()
+        return super().default_get(fields_list)
+
+    @api.model
     def _get_not_mergeable_invoices_message(self, invoices):
         """Overridable function to custom error message"""
         move_type_set = set(invoices.mapped("move_type"))
@@ -54,23 +59,6 @@ class InvoiceMerge(models.TransientModel):
                 all_msg += "\n".join([value for value in error_msg.values()])
                 raise UserError(all_msg)
         return {}
-
-    @api.model
-    def fields_view_get(
-        self, view_id=None, view_type="form", toolbar=False, submenu=False
-    ):
-        """Changes the view dynamically
-        @param self: The object pointer.
-        @param cr: A database cursor
-        @param uid: ID of the user currently logged in
-        @param context: A standard dictionary
-        @return: New arch of view.
-        """
-        res = super().fields_view_get(
-            view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=False
-        )
-        self._dirty_check()
-        return res
 
     def merge_invoices(self):
         """To merge similar type of account invoices.


### PR DESCRIPTION
we can't do this in fields_view_get, because this is called whenever you open a view that has the wizard action.

So if you have a button on an invoice form (active_model=='account.move', active_ids=[42]) returning an action to a list of invoices (where we have the wizard action defined), boom.

This should be cherry-picked to v15 too, but has already been corrected in [v16](https://github.com/OCA/account-invoicing/blob/16.0/account_invoice_merge/wizard/invoice_merge.py#L30)