### PR TITLE
[16.0] account_invoice_supplierinfo_update: fix updating the right supplierinfo

### DIFF
--- a/account_invoice_supplierinfo_update/models/account_move_line.py
+++ b/account_invoice_supplierinfo_update/models/account_move_line.py
@@ -12,8 +12,9 @@ class AccountMoveLine(models.Model):
         """Given an invoice line, return the supplierinfo that matches
         with product and supplier, if exist"""
         self.ensure_one()
-        supplierinfos = self.product_id.seller_ids.filtered(
-            lambda seller: seller.partner_id == self.move_id.supplier_partner_id
+        supplierinfos = self.product_id._select_seller(
+            partner_id=self.move_id.supplier_partner_id,
+            quantity=self.quantity,
         )
         return supplierinfos and supplierinfos[0] or False
 

--- a/account_invoice_supplierinfo_update/views/account_invoice_view.xml
+++ b/account_invoice_supplierinfo_update/views/account_invoice_view.xml
@@ -4,7 +4,7 @@
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_move_form" />
         <field name="arch" type="xml">
-            <xpath expr="//button[@name='action_post']" position="after">
+            <xpath expr="//button[@name='button_draft']" position="after">
                 <button
                     name="check_supplierinfo"
                     string="Check Supplier Infos"


### PR DESCRIPTION
If you have variant of price per qty the module is not going to update the right supplierinfo

Reuse the native _sellect_seller to pick the right supplierinfo + add test

@legalsylvain 