### PR TITLE
[15.0][FIX] account_invoice_view_payment: Validate & View payments button

### DIFF
--- a/account_invoice_view_payment/models/account_payment.py
+++ b/account_invoice_view_payment/models/account_payment.py
@@ -20,28 +20,3 @@ class AccountPayment(models.Model):
             "type": "ir.actions.act_window",
         }
         return res
-
-
-class AccountPaymentRegister(models.TransientModel):
-    _inherit = "account.payment.register"
-
-    def create_payment_and_open(self):
-        account_move_model = self.env["account.move"]
-        payment_model = self.env["account.payment"]
-        payments = payment_model
-        for _payment_vals in account_move_model.search(
-            [("id", "in", self.env.context.get("active_ids", False))]
-        ):
-            vals = self._create_payment_vals_from_wizard()
-            payments += payment_model.create(vals)
-        payments.action_post()
-        res = {
-            "domain": [("id", "in", payments.ids), ("state", "=", "posted")],
-            "name": _("Payments"),
-            "view_mode": "tree,form",
-            "res_model": "account.payment",
-            "view_id": False,
-            "context": False,
-            "type": "ir.actions.act_window",
-        }
-        return res

--- a/account_invoice_view_payment/tests/test_account_invoice_view_payment.py
+++ b/account_invoice_view_payment/tests/test_account_invoice_view_payment.py
@@ -146,7 +146,7 @@ class TestAccountInvoiceViewPayment(TransactionCase):
             }
         )
 
-        res = wiz.create_payment_and_open()
+        res = wiz.action_create_payments()
 
         expect = {"type": "ir.actions.act_window", "res_model": "account.payment"}
         self.assertDictEqual(

--- a/account_invoice_view_payment/views/account_payment_view.xml
+++ b/account_invoice_view_payment/views/account_payment_view.xml
@@ -17,21 +17,4 @@
         </field>
     </record>
 
-    <record id="view_account_payment_form_multi" model="ir.ui.view">
-        <field name="name">account.payment.form.multi</field>
-        <field name="model">account.payment.register</field>
-        <field name="inherit_id" ref="account.view_account_payment_register_form" />
-        <field name="arch" type="xml">
-            <button name="action_create_payments" position="after">
-                <button
-                    name="create_payment_and_open"
-                    string="Validate &amp; View Payment"
-                    type="object"
-                    class="oe_highlight"
-                    groups="account.group_account_invoice"
-                />
-            </button>
-        </field>
-    </record>
-
 </odoo>


### PR DESCRIPTION
It is creating as many payments as invoices and it was not reconciling the invoices.

The solution is to remove the Validate & View Payments button because the standard button "Create Payments" already returns the action to see the payments involved. The button is not needed anymore!

![image](https://github.com/OCA/account-invoicing/assets/19620251/3329cef7-12e3-4ec9-a8a5-27199e1785b1)

cc @ForgeFlow
