### PR TITLE
[16.0][FIX] account_move_tier_validation: Pass context to allow confirming moves with tier validation

### DIFF
--- a/account_move_tier_validation/models/account_move.py
+++ b/account_move_tier_validation/models/account_move.py
@@ -33,3 +33,8 @@ class AccountMove(models.Model):
         elif self.move_type == "out_refund":
             name = _("Credit Note")
         return name
+
+    def action_post(self):
+        return super(
+            AccountMove, self.with_context(skip_validation_check=True)
+        ).action_post()

--- a/account_move_tier_validation/tests/test_tier_validation.py
+++ b/account_move_tier_validation/tests/test_tier_validation.py
@@ -1,6 +1,8 @@
 # Copyright 2018 ForgeFlow S.L.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
+from odoo import _, fields
+from odoo.exceptions import ValidationError
 from odoo.tests import common
 from odoo.tests.common import tagged
 
@@ -26,3 +28,56 @@ class TestAccountTierValidation(common.TransactionCase):
             ) as form:
                 form.save()
                 self.assertTrue(form.hide_post_button)
+
+    def test_03_move_post(self):
+        group_ids = [
+            self.env.ref("base.group_system").id,
+            self.env.ref("account.group_account_manager").id,
+        ]
+        self.test_user_1 = self.env["res.users"].create(
+            {
+                "name": "John",
+                "login": "test1",
+                "email": "john@test.com",
+                "groups_id": [(6, 0, group_ids)],
+            }
+        )
+        self.test_user_2 = self.env["res.users"].create(
+            {
+                "name": "Mike",
+                "login": "test2",
+                "email": "mike@test.com",
+                "groups_id": [(6, 0, group_ids)],
+            }
+        )
+        self.env["tier.definition"].create(
+            {
+                "model_id": self.env["ir.model"]
+                .search([("model", "=", "account.move")])
+                .id,
+                "definition_domain": "[('move_type', '=', 'out_invoice')]",
+                "reviewer_id": self.test_user_1.id,
+            }
+        )
+        partner = self.env["res.partner"].create({"name": "Test Partner"})
+        product = self.env["product.product"].create({"name": "Test product"})
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": partner.id,
+                "invoice_date_due": fields.Date.from_string("2024-01-01"),
+                "invoice_line_ids": [
+                    (0, 0, {"product_id": product.id, "quantity": 1, "price_unit": 30})
+                ],
+            }
+        )
+        invoice.with_user(self.test_user_2.id).request_validation()
+        invoice = invoice.with_user(self.test_user_1.id)
+        invoice.invalidate_model()
+        invoice.validate_tier()
+        with self.assertRaisesRegex(
+            ValidationError, _("You are not allowed to write those fields")
+        ):
+            invoice._post()
+        # Calls _post method by passing context skip_validation_check set to True
+        invoice.action_post()


### PR DESCRIPTION
Fixes https://github.com/OCA/account-invoicing/issues/1698