### PR TITLE
[15.0][IMP-FIX] account_invoice_transmit_method: Update domain of the second button "Send and print"

### DIFF
--- a/account_invoice_transmit_method/views/account_move.xml
+++ b/account_invoice_transmit_method/views/account_move.xml
@@ -35,7 +35,10 @@
             <field name="invoice_filter_type_domain" position="after">
                 <field name="transmit_method_code" invisible="1" />
             </field>
-            <button name="action_invoice_sent" position="attributes">
+            <xpath
+                expr="//button[@name='action_invoice_sent'][1]"
+                position="attributes"
+            >
                 <attribute name="attrs" operation="update">
                     {
                         'invisible': [
@@ -47,7 +50,23 @@
                         ],
                     }
                 </attribute>
-            </button>
+            </xpath>
+            <xpath
+                expr="//button[@name='action_invoice_sent'][2]"
+                position="attributes"
+            >
+                <attribute name="attrs" operation="update">
+                    {
+                        'invisible': [
+                            '|', '|', '|',
+                            ('state', '!=', 'posted'),
+                            ('is_move_sent', '=', False),
+                            ('move_type', 'not in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund')),
+                            ('transmit_method_code', 'not in', ('mail', False)),
+                        ],
+                    }
+                </attribute>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
The "Send and print" button should be displayed when the transmission method is defined as e-mail or False. In case an invoice modifies its transmit method to make a first sending and is changed again to another transmission method than fake or e-mail the second button will be visible. For this reason the attributes of the second button that is displayed when an invoice has already been sent must also be modified.

cc @Tecnativa TT48851

@pedrobaeza @carolinafernandez-tecnativa please review