### PR TITLE
[16.0][FIX] account_invoice_pricelist: Make tests resilient

### DIFF
--- a/account_invoice_pricelist/tests/test_account_move_pricelist.py
+++ b/account_invoice_pricelist/tests/test_account_move_pricelist.py
@@ -1,23 +1,14 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo.exceptions import UserError
-from odoo.tests import common
+
+from odoo.addons.base.tests.common import BaseCommon
 
 
-class TestAccountMovePricelist(common.TransactionCase):
+class TestAccountMovePricelist(BaseCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.env = cls.env(
-            context=dict(
-                cls.env.context,
-                mail_create_nolog=True,
-                mail_create_nosubscribe=True,
-                mail_notrack=True,
-                no_reset_password=True,
-                tracking_disable=True,
-            )
-        )
         cls.AccountMove = cls.env["account.move"]
         cls.ProductPricelist = cls.env["product.pricelist"]
         cls.FiscalPosition = cls.env["account.fiscal.position"]
@@ -27,12 +18,14 @@ class TestAccountMovePricelist(common.TransactionCase):
         cls.journal_sale = cls.env["account.journal"].create(
             {"name": "Test sale journal", "type": "sale", "code": "TEST_SJ"}
         )
+        cls.currency_usd = cls.env.ref("base.USD")
+        cls.currency_usd.active = True
         # Make sure the currency of the company is USD, as this not always happens
         # To be removed in V17: https://github.com/odoo/odoo/pull/107113
         cls.company = cls.env.company
         cls.env.cr.execute(
             "UPDATE res_company SET currency_id = %s WHERE id = %s",
-            (cls.env.ref("base.USD").id, cls.company.id),
+            (cls.currency_usd.id, cls.company.id),
         )
         cls.a_receivable = cls.env["account.account"].create(
             {


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/account-invoicing/pull/1566

- Depending on the installed set of modules, the company currency may be USD or EUR. If the second case, these tests will fail, so we make sure that the company currency is USD for our tests, doing the change by SQL, as there's a Python constraint that prevents it.

Not needed in v17 due to: odoo/odoo#107113.

@Tecnativa