### PR TITLE
[16.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/account_mail_autosubscribe/README.rst
+++ b/account_mail_autosubscribe/README.rst
@@ -57,7 +57,7 @@ Credits
 Authors
 ~~~~~~~
 
-* Camptocamp SA
+* Camptocamp
 
 Contributors
 ~~~~~~~~~~~~

--- a/account_mail_autosubscribe/__manifest__.py
+++ b/account_mail_autosubscribe/__manifest__.py
@@ -5,8 +5,8 @@
 {
     "name": "Account Mail Autosubscribe",
     "summary": "Automatically subscribe partners to their company's invoices",
-    "version": "16.0.1.0.0",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "version": "16.0.1.0.1",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "maintainers": ["ivantodorovich"],
     "license": "AGPL-3",
     "category": "Accounting",

--- a/account_mail_autosubscribe/static/description/index.html
+++ b/account_mail_autosubscribe/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -401,7 +402,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="authors">
 <h2><a class="toc-backref" href="#toc-entry-4">Authors</a></h2>
 <ul class="simple">
-<li>Camptocamp SA</li>
+<li>Camptocamp</li>
 </ul>
 </div>
 <div class="section" id="contributors">
@@ -419,7 +420,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 16.0.