### PR TITLE
[14.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/account_mail_autosubscribe/__manifest__.py
+++ b/account_mail_autosubscribe/__manifest__.py
@@ -6,7 +6,7 @@
     "name": "Account Mail Autosubscribe",
     "summary": "Automatically subscribe partners to their company's invoices",
     "version": "14.0.1.0.0",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "maintainers": ["ivantodorovich"],
     "license": "AGPL-3",
     "category": "Accounting",


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 14.0.