### PR TITLE
[IMP] don't check totals on inter company created invoice

### DIFF
--- a/account_invoice_check_total/models/account_move.py
+++ b/account_invoice_check_total/models/account_move.py
@@ -34,6 +34,8 @@ class AccountMove(models.Model):
             if (
                 self.env.user.has_group(GROUP_AICT)
                 and inv.move_type in ("in_invoice", "in_refund")
+                # compatibility with account_invoice_inter_company
+                and not getattr(inv, "auto_generated", False)
                 and float_compare(
                     inv.check_total,
                     inv.amount_total,


### PR DESCRIPTION
To properly unit-test this would require a glue module implementation, but this is simpler.

[auto_generated](https://github.com/OCA/multi-company/blob/f124464740a3a52b3c2fcc9909d389ade31ff0c9/account_invoice_inter_company/models/account_move.py#L16) boolean is used by `account_invoice_inter_company`.