### PR TITLE
[FIX]partner_invoicing_mode: Invalid partner_invoice_id key to group sales. Fix #1747

### DIFF
--- a/partner_invoicing_mode/models/sale_order.py
+++ b/partner_invoicing_mode/models/sale_order.py
@@ -87,16 +87,11 @@ class SaleOrder(models.Model):
     def _get_invoice_grouping_keys(self) -> list:
         """
         We override the standard (in sale) grouping function in order to
-        add some missing keys. We remove also the partner_id key.
+        add some missing keys.
         """
         keys = super()._get_invoice_grouping_keys()
-        if "partner_invoice_id" not in keys:
-            keys.append("partner_invoice_id")
         if "payment_term_id" not in keys:
             keys.append("payment_term_id")
-        # Removing unwanted keys as we group on invoiced partner
-        if "partner_id" in keys:
-            keys.remove("partner_id")
         return keys
 
     def _get_generated_invoices(self, partition):


### PR DESCRIPTION
I'm not sure about this, but I already explained it in issue #1747.
 It seems there is new code added that wasn't in v15. In my opinion, it's a mistake to use the key partner_invoice_id for grouping. Odoo doesn't use it to compare against the sales order but against the values of the dictionary that will generate the invoice.

https://github.com/odoo/odoo/blob/56946ff1a99a1f02f2ec708161a754e22c25fe80/addons/sale/models/sale_order.py#L1155

 That is, it is always evaluated as None. In this dictionary, Odoo assigns the field partner_id the value of partner_invoice_id from the order:

https://github.com/odoo/odoo/blob/56946ff1a99a1f02f2ec708161a754e22c25fe80/addons/sale/models/sale_order.py#L1003

Therefore, if we want to group by invoice address, we should use the key partner_id, since this key is in the invoice value dictionary and already contains the value of the order's partner_invoice_id.