### PR TITLE
[14.0][Fix] account_invoice_merge: merge invoice lines using 'name' 

### DIFF
--- a/account_invoice_merge/models/account_move.py
+++ b/account_invoice_merge/models/account_move.py
@@ -46,6 +46,7 @@ class AccountMove(models.Model):
             "account_id",
             "analytic_account_id",
             "product_uom_id",
+            "name",
         ]
         for field in ["sale_line_ids"]:
             if field in self.env["account.move.line"]._fields:


### PR DESCRIPTION
   Using label field in invoice line while merging invoices and hence it creates new
invoice line when same product have two different description in invoice line