### PR TITLE
[16.0][FIX] purchase_stock_picking_return_invoicing: Add digits="Product Unit of Measure" to qty_refunded + qty_returned fields

### DIFF
--- a/purchase_stock_picking_return_invoicing/models/purchase_order.py
+++ b/purchase_stock_picking_return_invoicing/models/purchase_order.py
@@ -193,10 +193,15 @@ class PurchaseOrder(models.Model):
 class PurchaseOrderLine(models.Model):
     _inherit = "purchase.order.line"
 
-    qty_refunded = fields.Float(compute="_compute_qty_refunded", string="Refunded Qty")
+    qty_refunded = fields.Float(
+        compute="_compute_qty_refunded",
+        string="Refunded Qty",
+        digits="Product Unit of Measure",
+    )
     qty_returned = fields.Float(
         compute="_compute_qty_returned",
         string="Returned* Qty",
+        digits="Product Unit of Measure",
         help="This is ONLY the returned quantity that is refundable.",
         store=True,
     )


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/account-invoicing/pull/1757

Add digits="Product Unit of Measure" to `qty_refunded` + `qty_returned` fields

Please @pedrobaeza can you review it?

@Tecnativa TT50034