### PR TITLE
[14.0][FIX] button validate payment visible in done state in account_invoice_view_payment

### DIFF
--- a/account_invoice_view_payment/views/account_payment_view.xml
+++ b/account_invoice_view_payment/views/account_payment_view.xml
@@ -12,6 +12,7 @@
                     type="object"
                     class="oe_highlight"
                     groups="account.group_account_invoice"
+                    attrs="{'invisible': [('state', '!=', 'draft')]}"
                 />
             </button>
         </field>


### PR DESCRIPTION
Button to validate payment is visible in the payment form even when this is done.
Trying to push it will raise an error of payment already validated.