### PR TITLE
[14.0][FIX] account_invoice_section_sale_order check if line_ids exists

### DIFF
--- a/account_invoice_section_sale_order/models/sale_order.py
+++ b/account_invoice_section_sale_order/models/sale_order.py
@@ -18,7 +18,7 @@ class SaleOrder(models.Model):
         """
         invoices = super()._create_invoices(grouped=grouped, final=final, date=date)
         for invoice in invoices.sudo():
-            if (
+            if invoice.line_ids and (
                 len(invoice.line_ids.mapped(invoice.line_ids._get_section_grouping()))
                 == 1
             ):


### PR DESCRIPTION
Trying to create an invoice for a sale order which results in no invoices will raise an error.