### PR TITLE
[IMP][14.0] account_invoice_section_sale_order: Fix read/write access

### DIFF
--- a/account_invoice_section_sale_order/models/sale_order.py
+++ b/account_invoice_section_sale_order/models/sale_order.py
@@ -16,14 +16,16 @@ class SaleOrder(models.Model):
         the group name.
         Only do this for invoices targetting multiple groups
         """
-        invoice_ids = super()._create_invoices(grouped=grouped, final=final, date=date)
-        for invoice in invoice_ids:
+        invoices = super()._create_invoices(grouped=grouped, final=final, date=date)
+        for invoice in invoices.sudo():
             if (
                 len(invoice.line_ids.mapped(invoice.line_ids._get_section_grouping()))
                 == 1
             ):
                 continue
             sequence = 10
+            # Because invoices are already created, this would require
+            # an extra read access in order to read order fields.
             move_lines = invoice._get_ordered_invoice_lines()
             # Group move lines according to their sale order
             section_grouping_matrix = OrderedDict()
@@ -56,10 +58,14 @@ class SaleOrder(models.Model):
                     )
                     sequence += 10
                 for move_line in self.env["account.move.line"].browse(move_line_ids):
+                    # Because invoices are already created, this would require
+                    # an extra write access in order to read order fields.
                     move_line.sequence = sequence
                     sequence += 10
+            # Because invoices are already created, this would require
+            # an extra write access in order to read order fields.
             invoice.line_ids = section_lines
-        return invoice_ids
+        return invoices
 
     def _get_invoice_section_name(self):
         """Returns the text for the section name."""

--- a/account_invoice_section_sale_order/tests/common.py
+++ b/account_invoice_section_sale_order/tests/common.py
@@ -1,0 +1,84 @@
+from odoo.tests import tagged
+from odoo.tests.common import SavepointCase
+
+
+@tagged("-at_install", "post_install")
+class Common(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.setUpClassOrder()
+
+    @classmethod
+    def setUpClassOrder(cls):
+        cls.partner_1 = cls.env.ref("base.res_partner_1")
+        cls.product_1 = cls.env.ref("product.product_product_1")
+        cls.product_2 = cls.env.ref("product.product_product_2")
+        cls.product_1.invoice_policy = "order"
+        cls.product_2.invoice_policy = "order"
+        cls.order1_p1 = cls.env["sale.order"].create(
+            {
+                "partner_id": cls.partner_1.id,
+                "partner_shipping_id": cls.partner_1.id,
+                "partner_invoice_id": cls.partner_1.id,
+                "client_order_ref": "ref123",
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "order 1 line 1",
+                            "product_id": cls.product_1.id,
+                            "price_unit": 20,
+                            "product_uom_qty": 1,
+                            "product_uom": cls.product_1.uom_id.id,
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "order 1 line 2",
+                            "product_id": cls.product_2.id,
+                            "price_unit": 20,
+                            "product_uom_qty": 1,
+                            "product_uom": cls.product_1.uom_id.id,
+                        },
+                    ),
+                ],
+            }
+        )
+        cls.order1_p1.action_confirm()
+        cls.order2_p1 = cls.env["sale.order"].create(
+            {
+                "partner_id": cls.partner_1.id,
+                "partner_shipping_id": cls.partner_1.id,
+                "partner_invoice_id": cls.partner_1.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "order 2 line 1",
+                            "product_id": cls.product_1.id,
+                            "price_unit": 20,
+                            "product_uom_qty": 1,
+                            "product_uom": cls.product_1.uom_id.id,
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "order 2 line 2",
+                            "product_id": cls.product_2.id,
+                            "price_unit": 20,
+                            "product_uom_qty": 1,
+                            "product_uom": cls.product_1.uom_id.id,
+                        },
+                    ),
+                ],
+            }
+        )
+        cls.order2_p1.action_confirm()

--- a/account_invoice_section_sale_order/tests/test_access_rights.py
+++ b/account_invoice_section_sale_order/tests/test_access_rights.py
@@ -1,0 +1,60 @@
+# Copyright 2024 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo.tests import tagged
+
+from .common import Common
+
+
+@tagged("-at_install", "post_install")
+class TestAccessRights(Common):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.setUpClassUser()
+
+    @classmethod
+    def setUpClassUser(cls):
+        cls.create_only_group = cls.env["res.groups"].create(
+            {"name": "Create Only Group"}
+        )
+        cls.sale_manager_group = cls.env.ref("sales_team.group_sale_manager")
+        cls.env["ir.model.access"].create(
+            [
+                {
+                    "name": "invoice_create_only",
+                    "model_id": cls.env.ref("account.model_account_move").id,
+                    "group_id": cls.create_only_group.id,
+                    "perm_read": 0,
+                    "perm_write": 0,
+                    "perm_create": 1,
+                    "perm_unlink": 0,
+                },
+                {
+                    "name": "invoice_line_create_only",
+                    "model_id": cls.env.ref("account.model_account_move_line").id,
+                    "group_id": cls.create_only_group.id,
+                    "perm_read": 0,
+                    "perm_write": 0,
+                    "perm_create": 1,
+                    "perm_unlink": 0,
+                },
+            ]
+        )
+        cls.create_only_user = cls.env["res.users"].create(
+            {
+                "name": "Create Only User",
+                "login": "createonlyuser@example.com",
+                "groups_id": [
+                    (6, 0, (cls.create_only_group | cls.sale_manager_group).ids),
+                ],
+            }
+        )
+
+    def test_access_rights(self):
+        orders = self.order1_p1 + self.order2_p1
+        # We're testing that no exception is raised while creating invoices
+        # with a user having only create access on the invoices models
+        invoice_ids = orders.with_user(self.create_only_user)._create_invoices()
+        self.assertTrue(bool(invoice_ids))

--- a/account_invoice_section_sale_order/tests/test_invoice_group_by_sale_order.py
+++ b/account_invoice_section_sale_order/tests/test_invoice_group_by_sale_order.py
@@ -3,7 +3,8 @@
 import mock
 
 from odoo.exceptions import UserError
-from odoo.tests.common import SavepointCase
+
+from .common import Common
 
 SECTION_GROUPING_FUNCTION = "odoo.addons.account_invoice_section_sale_order.models.account_move.AccountMoveLine._get_section_grouping"  # noqa
 SECTION_NAME_FUNCTION = (
@@ -11,81 +12,7 @@ SECTION_NAME_FUNCTION = (
 )
 
 
-class TestInvoiceGroupBySaleOrder(SavepointCase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.partner_1 = cls.env.ref("base.res_partner_1")
-        cls.product_1 = cls.env.ref("product.product_product_1")
-        cls.product_2 = cls.env.ref("product.product_product_2")
-        cls.product_1.invoice_policy = "order"
-        cls.product_2.invoice_policy = "order"
-        cls.order1_p1 = cls.env["sale.order"].create(
-            {
-                "partner_id": cls.partner_1.id,
-                "partner_shipping_id": cls.partner_1.id,
-                "partner_invoice_id": cls.partner_1.id,
-                "client_order_ref": "ref123",
-                "order_line": [
-                    (
-                        0,
-                        0,
-                        {
-                            "name": "order 1 line 1",
-                            "product_id": cls.product_1.id,
-                            "price_unit": 20,
-                            "product_uom_qty": 1,
-                            "product_uom": cls.product_1.uom_id.id,
-                        },
-                    ),
-                    (
-                        0,
-                        0,
-                        {
-                            "name": "order 1 line 2",
-                            "product_id": cls.product_2.id,
-                            "price_unit": 20,
-                            "product_uom_qty": 1,
-                            "product_uom": cls.product_1.uom_id.id,
-                        },
-                    ),
-                ],
-            }
-        )
-        cls.order1_p1.action_confirm()
-        cls.order2_p1 = cls.env["sale.order"].create(
-            {
-                "partner_id": cls.partner_1.id,
-                "partner_shipping_id": cls.partner_1.id,
-                "partner_invoice_id": cls.partner_1.id,
-                "order_line": [
-                    (
-                        0,
-                        0,
-                        {
-                            "name": "order 2 line 1",
-                            "product_id": cls.product_1.id,
-                            "price_unit": 20,
-                            "product_uom_qty": 1,
-                            "product_uom": cls.product_1.uom_id.id,
-                        },
-                    ),
-                    (
-                        0,
-                        0,
-                        {
-                            "name": "order 2 line 2",
-                            "product_id": cls.product_2.id,
-                            "price_unit": 20,
-                            "product_uom_qty": 1,
-                            "product_uom": cls.product_1.uom_id.id,
-                        },
-                    ),
-                ],
-            }
-        )
-        cls.order2_p1.action_confirm()
-
+class TestInvoiceGroupBySaleOrder(Common):
     def test_create_invoice(self):
         """Check invoice is generated  with sale order sections."""
         result = {


### PR DESCRIPTION
The `sale.order._create_invoices()` method does not only requires `create` access to the `account.move` and `account.move.line` models.

Because we're actually sorting lines after the creating, it requires `read` access to sort, and `write` access to modify their sequence.

This is problematic when interracting with other modules like `invoice_mode_at_shipping` where stock users are the ones to create invoices.

This PR adds a few `sudo()` in the code, in order to avoid granting `read` and `write` access to users that shouldn't be allowed to read and write invoices.