### PR TITLE
[14.0][FIX] stock_picking_invoicing: Inform field invoice_state in Stock Rule

### DIFF
--- a/stock_picking_invoicing/models/__init__.py
+++ b/stock_picking_invoicing/models/__init__.py
@@ -1,8 +1,6 @@
-# Copyright (C) 2019-Today: Odoo Community Association (OCA)
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-
 from . import stock_invoice_state_mixin
 from . import account_move
 from . import stock_move
 from . import stock_picking
 from . import stock_picking_type
+from . import stock_rule

--- a/stock_picking_invoicing/models/stock_rule.py
+++ b/stock_picking_invoicing/models/stock_rule.py
@@ -1,0 +1,14 @@
+# Copyright (C) 2024-Today - Akretion (<http://www.akretion.com>).
+# @author Magno Costa <magno.costa@akretion.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class StockRule(models.Model):
+    _inherit = "stock.rule"
+
+    def _get_custom_move_fields(self):
+        fields = super()._get_custom_move_fields()
+        fields += ["invoice_state"]
+        return fields


### PR DESCRIPTION
Inform field invoice_state in Stock Rule

https://github.com/OCA/OCB/blob/14.0/addons/stock/models/stock_rule.py#L259

```bash
    def _get_custom_move_fields(self):
        """ The purpose of this method is to be override in order to easily add
        fields from procurement 'values' argument to move data.
        """
        return []
```

Review of https://github.com/OCA/account-invoicing/pull/1025 

Also remove License Header in init file with only imports

cc @rvalyi @renatonlima @kevinkhao