### PR TITLE
[16.0][IMP] account_invoice_discount_display_amount: show discount a mount on invoice line

### DIFF
--- a/account_invoice_discount_display_amount/README.rst
+++ b/account_invoice_discount_display_amount/README.rst
@@ -32,6 +32,8 @@ This module allows to show the total discount amount
 applied to an invoice, both in the backend and the
 invoice PDF repot.
 
+Also it shows the discount amount in the invoice line.
+
 **Table of contents**
 
 .. contents::
@@ -52,6 +54,7 @@ To use this module, you need to:
 #. Apply a discount on an invoice line.
 #. The values 'Discount Total' and 'Total Without Discount'
    will be automatically updated.
+#. The discount amount will be displayed on each invoice line.
 
 Bug Tracker
 ===========
@@ -78,6 +81,8 @@ Contributors
 * Alexei Rivera <arivera@archeti.com>
 * [APSL-Nagarro](https://apsl.tech):
   * Santi Amorós <samoros@apsl.net>
+* Moduon <https://www.moduon.team/>
+  * Eduardo López
 
 Maintainers
 ~~~~~~~~~~~

--- a/account_invoice_discount_display_amount/readme/CONTRIBUTORS.rst
+++ b/account_invoice_discount_display_amount/readme/CONTRIBUTORS.rst
@@ -2,3 +2,5 @@
 * Alexei Rivera <arivera@archeti.com>
 * [APSL-Nagarro](https://apsl.tech):
   * Santi Amorós <samoros@apsl.net>
+* Moduon <https://www.moduon.team/>
+  * Eduardo López

--- a/account_invoice_discount_display_amount/readme/DESCRIPTION.rst
+++ b/account_invoice_discount_display_amount/readme/DESCRIPTION.rst
@@ -1,3 +1,5 @@
 This module allows to show the total discount amount
 applied to an invoice, both in the backend and the
 invoice PDF repot.
+
+Also it shows the discount amount in the invoice line.

--- a/account_invoice_discount_display_amount/readme/USAGE.rst
+++ b/account_invoice_discount_display_amount/readme/USAGE.rst
@@ -3,3 +3,4 @@ To use this module, you need to:
 #. Apply a discount on an invoice line.
 #. The values 'Discount Total' and 'Total Without Discount'
    will be automatically updated.
+#. The discount amount will be displayed on each invoice line.

--- a/account_invoice_discount_display_amount/static/description/index.html
+++ b/account_invoice_discount_display_amount/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -373,6 +372,7 @@ ul.auto-toc {
 <p>This module allows to show the total discount amount
 applied to an invoice, both in the backend and the
 invoice PDF repot.</p>
+<p>Also it shows the discount amount in the invoice line.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -401,6 +401,7 @@ invoice PDF repot.</p>
 <li>Apply a discount on an invoice line.</li>
 <li>The values ‘Discount Total’ and ‘Total Without Discount’
 will be automatically updated.</li>
+<li>The discount amount will be displayed on each invoice line.</li>
 </ol>
 </div>
 <div class="section" id="bug-tracker">
@@ -426,6 +427,8 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Alexei Rivera &lt;<a class="reference external" href="mailto:arivera&#64;archeti.com">arivera&#64;archeti.com</a>&gt;</li>
 <li>[APSL-Nagarro](<a class="reference external" href="https://apsl.tech">https://apsl.tech</a>):
 * Santi Amorós &lt;<a class="reference external" href="mailto:samoros&#64;apsl.net">samoros&#64;apsl.net</a>&gt;</li>
+<li>Moduon &lt;<a class="reference external" href="https://www.moduon.team/">https://www.moduon.team/</a>&gt;
+* Eduardo López</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/account_invoice_discount_display_amount/views/account_move_views.xml
+++ b/account_invoice_discount_display_amount/views/account_move_views.xml
@@ -16,7 +16,7 @@
                     expr="//field[@name='invoice_line_ids']/tree/field[@name='discount']"
                     position="after"
                 >
-                    <field name="discount_total" optional="hide" />
+                    <field name="discount_total" optional="show" />
                 </xpath>
             </data>
         </field>

--- a/account_invoice_discount_display_amount/views/account_move_views.xml
+++ b/account_invoice_discount_display_amount/views/account_move_views.xml
@@ -11,6 +11,13 @@
                     <field name="price_total_no_discount" />
                     <field name="discount_total" />
                 </xpath>
+
+                <xpath
+                    expr="//field[@name='invoice_line_ids']/tree/field[@name='discount']"
+                    position="after"
+                >
+                    <field name="discount_total" optional="hide" />
+                </xpath>
             </data>
         </field>
     </record>


### PR DESCRIPTION
Hello
this is the solution I mentioned here:
https://github.com/OCA/account-invoicing/issues/1785

This shows the discount amount in the invoice line.

@yajo @EmilioPascual @Shide @fcvalgar @rafaelbn review this PR when you can. Thank you.

@moduon MT-7125