### PR TITLE
[FIX] account_invoice_check_total: compatibility with hr_expense

### DIFF
--- a/account_invoice_check_total/models/account_move.py
+++ b/account_invoice_check_total/models/account_move.py
@@ -33,6 +33,8 @@ class AccountMove(models.Model):
             if (
                 self.env.user.has_group(GROUP_AICT)
                 and inv.move_type in ("in_invoice", "in_refund")
+                # hack for compatibility with hr_expense without depending on it
+                and not getattr(inv, "expense_sheet_id", None)
                 and float_compare(
                     inv.check_total,
                     inv.amount_total,


### PR DESCRIPTION
hr_expense creates moves of type in_invoice, but
of course does not set the check_total field.
So we skip the check if the move is linked to an
expense sheet. This is a hack but a dedicated glue module sounds overkill.