### PR TITLE
[15.0][Fix]sale_line_refund_to_invoice_qty Reinvoice credit note false not working anymore

### DIFF
--- a/sale_line_refund_to_invoice_qty/__manifest__.py
+++ b/sale_line_refund_to_invoice_qty/__manifest__.py
@@ -4,7 +4,7 @@
     "name": "Sale Line Refund To Invoice Qty",
     "summary": """Allow deciding whether refunded quantity should be considered
                 as quantity to reinvoice""",
-    "version": "15.0.1.0.1",
+    "version": "15.0.1.0.2",
     "category": "Sales",
     "website": "https://github.com/OCA/account-invoicing",
     "author": "ForgeFlow, Odoo Community Association (OCA)",

--- a/sale_line_refund_to_invoice_qty/models/account.py
+++ b/sale_line_refund_to_invoice_qty/models/account.py
@@ -12,9 +12,10 @@ class AccountMove(models.Model):
         move_vals = super(AccountMove, self)._reverse_move_vals(
             default_values, cancel=cancel
         )
-        if self.env.context.get("sale_qty_to_reinvoice", False):
+        if "sale_qty_to_reinvoice" in self.env.context:
+            is_sale_qty_to_reinvoice = self.env.context.get("sale_qty_to_reinvoice")
             for vals in move_vals["line_ids"]:
-                vals[2].update({"sale_qty_to_reinvoice": True})
+                vals[2].update({"sale_qty_to_reinvoice": is_sale_qty_to_reinvoice})
         return move_vals
 
 


### PR DESCRIPTION
- Fixed the issue "sale_qty_to_reinvoice" field was not updating for inverse invoices lines on add Credit Note.