### PR TITLE
[FIX] account_invoice_discount_display_amount: hide discount amount on invoice line

### DIFF
--- a/account_invoice_discount_display_amount/README.rst
+++ b/account_invoice_discount_display_amount/README.rst
@@ -32,8 +32,6 @@ This module allows to show the total discount amount
 applied to an invoice, both in the backend and the
 invoice PDF repot.
 
-Also it shows the discount amount in the invoice line.
-
 **Table of contents**
 
 .. contents::
@@ -54,7 +52,6 @@ To use this module, you need to:
 #. Apply a discount on an invoice line.
 #. The values 'Discount Total' and 'Total Without Discount'
    will be automatically updated.
-#. The discount amount will be displayed on each invoice line.
 
 Bug Tracker
 ===========
@@ -81,8 +78,6 @@ Contributors
 * Alexei Rivera <arivera@archeti.com>
 * [APSL-Nagarro](https://apsl.tech):
   * Santi Amorós <samoros@apsl.net>
-* Moduon <https://www.moduon.team/>
-  * Eduardo López
 
 Maintainers
 ~~~~~~~~~~~

--- a/account_invoice_discount_display_amount/readme/CONTRIBUTORS.rst
+++ b/account_invoice_discount_display_amount/readme/CONTRIBUTORS.rst
@@ -2,5 +2,3 @@
 * Alexei Rivera <arivera@archeti.com>
 * [APSL-Nagarro](https://apsl.tech):
   * Santi Amorós <samoros@apsl.net>
-* Moduon <https://www.moduon.team/>
-  * Eduardo López

--- a/account_invoice_discount_display_amount/readme/DESCRIPTION.rst
+++ b/account_invoice_discount_display_amount/readme/DESCRIPTION.rst
@@ -1,5 +1,3 @@
 This module allows to show the total discount amount
 applied to an invoice, both in the backend and the
 invoice PDF repot.
-
-Also it shows the discount amount in the invoice line.

--- a/account_invoice_discount_display_amount/readme/USAGE.rst
+++ b/account_invoice_discount_display_amount/readme/USAGE.rst
@@ -3,4 +3,3 @@ To use this module, you need to:
 #. Apply a discount on an invoice line.
 #. The values 'Discount Total' and 'Total Without Discount'
    will be automatically updated.
-#. The discount amount will be displayed on each invoice line.

--- a/account_invoice_discount_display_amount/static/description/index.html
+++ b/account_invoice_discount_display_amount/static/description/index.html
@@ -373,7 +373,6 @@ ul.auto-toc {
 <p>This module allows to show the total discount amount
 applied to an invoice, both in the backend and the
 invoice PDF repot.</p>
-<p>Also it shows the discount amount in the invoice line.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -402,7 +401,6 @@ invoice PDF repot.</p>
 <li>Apply a discount on an invoice line.</li>
 <li>The values ‘Discount Total’ and ‘Total Without Discount’
 will be automatically updated.</li>
-<li>The discount amount will be displayed on each invoice line.</li>
 </ol>
 </div>
 <div class="section" id="bug-tracker">
@@ -428,8 +426,6 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Alexei Rivera &lt;<a class="reference external" href="mailto:arivera&#64;archeti.com">arivera&#64;archeti.com</a>&gt;</li>
 <li>[APSL-Nagarro](<a class="reference external" href="https://apsl.tech">https://apsl.tech</a>):
 * Santi Amorós &lt;<a class="reference external" href="mailto:samoros&#64;apsl.net">samoros&#64;apsl.net</a>&gt;</li>
-<li>Moduon &lt;<a class="reference external" href="https://www.moduon.team/">https://www.moduon.team/</a>&gt;
-* Eduardo López</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/account_invoice_discount_display_amount/views/account_move_views.xml
+++ b/account_invoice_discount_display_amount/views/account_move_views.xml
@@ -11,13 +11,6 @@
                     <field name="price_total_no_discount" />
                     <field name="discount_total" />
                 </xpath>
-
-                <xpath
-                    expr="//field[@name='invoice_line_ids']/tree/field[@name='discount']"
-                    position="after"
-                >
-                    <field name="discount_total" optional="show" />
-                </xpath>
             </data>
         </field>
     </record>


### PR DESCRIPTION

This reverts commits 1a299b0f0cf6824e721fb57f324985fbfbb2088f and 8415add2089aa68c43903968eb6fbb3ee11e429a.

@moduon MT-7125