### PR TITLE
 [16.0][FW] account_invoice_section_sale_order: multiple ports from 15.0

### DIFF
--- a/account_invoice_section_sale_order/__manifest__.py
+++ b/account_invoice_section_sale_order/__manifest__.py
@@ -10,4 +10,9 @@
     "license": "AGPL-3",
     "category": "Accounting & Finance",
     "depends": ["account", "sale"],
+    "data": [
+        "security/res_groups.xml",
+        "views/res_config_settings.xml",
+        "views/res_partner.xml",
+    ],
 }

--- a/account_invoice_section_sale_order/models/__init__.py
+++ b/account_invoice_section_sale_order/models/__init__.py
@@ -1,1 +1,5 @@
+from . import account_move
+from . import res_company
+from . import res_config_settings
+from . import res_partner
 from . import sale_order

--- a/account_invoice_section_sale_order/models/account_move.py
+++ b/account_invoice_section_sale_order/models/account_move.py
@@ -1,0 +1,40 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import _, api, models
+from odoo.exceptions import UserError
+
+
+class AccountMove(models.Model):
+
+    _inherit = "account.move"
+
+    def _get_ordered_invoice_lines(self):
+        """Sort invoice lines according to the section ordering"""
+        return self.invoice_line_ids.sorted(
+            key=self.env["account.move.line"]._get_section_ordering()
+        )
+
+
+class AccountMoveLine(models.Model):
+
+    _inherit = "account.move.line"
+
+    def _get_section_group(self):
+        """Return the section group to be used for a single invoice line"""
+        self.ensure_one()
+        return self.mapped(self._get_section_grouping())
+
+    def _get_section_grouping(self):
+        """Defines the grouping relation from the invoice lines to be used.
+
+        Meant to be overriden, in order to allow custom grouping.
+        """
+        invoice_section_grouping = self.company_id.invoice_section_grouping
+        if invoice_section_grouping == "sale_order":
+            return "sale_line_ids.order_id"
+        raise UserError(_("Unrecognized invoice_section_grouping"))
+
+    @api.model
+    def _get_section_ordering(self):
+        """Function to sort invoice lines before grouping"""
+        return lambda r: r.mapped(r._get_section_grouping())

--- a/account_invoice_section_sale_order/models/res_company.py
+++ b/account_invoice_section_sale_order/models/res_company.py
@@ -1,0 +1,23 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    invoice_section_name_scheme = fields.Char(
+        help="This is the name of the sections on invoices when generated from "
+        "sales orders. Keep empty to use default. You can use a python "
+        "expression with the 'object' (representing sale order) and 'time'"
+        " variables."
+    )
+
+    invoice_section_grouping = fields.Selection(
+        [
+            ("sale_order", "Group by sale Order"),
+        ],
+        help="Defines object used to group invoice lines",
+        default="sale_order",
+        required=True,
+    )

--- a/account_invoice_section_sale_order/models/res_config_settings.py
+++ b/account_invoice_section_sale_order/models/res_config_settings.py
@@ -1,0 +1,19 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+
+    _inherit = "res.config.settings"
+
+    invoice_section_name_scheme = fields.Char(
+        related="company_id.invoice_section_name_scheme",
+        readonly=False,
+    )
+
+    invoice_section_grouping = fields.Selection(
+        related="company_id.invoice_section_grouping",
+        readonly=False,
+        required=True,
+    )

--- a/account_invoice_section_sale_order/models/res_partner.py
+++ b/account_invoice_section_sale_order/models/res_partner.py
@@ -1,0 +1,14 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import fields, models
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    invoice_section_name_scheme = fields.Char(
+        help="This is the name of the sections on invoices when generated from "
+        "sales orders. Keep empty to use default. You can use a python "
+        "expression with the 'object' (representing sale order) and 'time'"
+        " variables."
+    )

--- a/account_invoice_section_sale_order/models/sale_order.py
+++ b/account_invoice_section_sale_order/models/sale_order.py
@@ -46,6 +46,11 @@ class SaleOrder(models.Model):
                                 # forcing the account_id is needed to avoid
                                 # incorrect default value
                                 "account_id": False,
+                                # see test: test_create_invoice_with_currency
+                                # if the currency is not set with the right value
+                                # the total amount will be wrong
+                                # because all line do not have the same currency
+                                "currency_id": invoice.currency_id.id,
                             },
                         )
                     )

--- a/account_invoice_section_sale_order/models/sale_order.py
+++ b/account_invoice_section_sale_order/models/sale_order.py
@@ -42,6 +42,10 @@ class SaleOrder(models.Model):
                                 "name": group._get_invoice_section_name(),
                                 "display_type": "line_section",
                                 "sequence": sequence,
+                                # see test: test_create_invoice_with_default_journal
+                                # forcing the account_id is needed to avoid
+                                # incorrect default value
+                                "account_id": False,
                             },
                         )
                     )

--- a/account_invoice_section_sale_order/models/sale_order.py
+++ b/account_invoice_section_sale_order/models/sale_order.py
@@ -1,49 +1,58 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+from collections import OrderedDict
 
 from odoo import models
+from odoo.tools.safe_eval import safe_eval, time
 
 
 class SaleOrder(models.Model):
     _inherit = "sale.order"
 
     def _create_invoices(self, grouped=False, final=False, date=None):
-        """Add sections by sale order in the invoice line.
+        """Add sections by groups in the invoice line.
 
-        Order the invoicing lines by sale order and add lines section with
-        the sale order name.
-        Only do this for invoices targetting multiple sale order
+        Order the invoicing lines by groups and add lines section with
+        the group name.
+        Only do this for invoices targetting multiple groups
         """
         invoice_ids = super()._create_invoices(grouped=grouped, final=final, date=date)
         for invoice in invoice_ids:
-            if len(invoice.line_ids.mapped("sale_line_ids.order_id.id")) == 1:
+            if (
+                len(invoice.line_ids.mapped(invoice.line_ids._get_section_grouping()))
+                == 1
+            ):
                 continue
-            so = None
             sequence = 10
+            move_lines = invoice._get_ordered_invoice_lines()
+            # Group move lines according to their sale order
+            section_grouping_matrix = OrderedDict()
+            for move_line in move_lines:
+                group = move_line._get_section_group()
+                section_grouping_matrix.setdefault(group, []).append(move_line.id)
+            # Prepare section lines for each group
             section_lines = []
-            lines = self._get_ordered_invoice_lines(invoice)
-            for line in lines:
-                if line.sale_line_ids.order_id and so != line.sale_line_ids.order_id:
-                    so = line.sale_line_ids.order_id
+            for group, move_line_ids in section_grouping_matrix.items():
+                if group:
                     section_lines.append(
                         (
                             0,
                             0,
                             {
-                                "name": so._get_saleorder_section_name(),
+                                "name": group._get_invoice_section_name(),
                                 "display_type": "line_section",
                                 "sequence": sequence,
                             },
                         )
                     )
                     sequence += 10
-                if line.display_type == "line_section":
-                    # add extra indent for existing SO Sections
-                    line.name = f"- {line.name}"
-                line.sequence = sequence
-                sequence += 10
+                for move_line in self.env["account.move.line"].browse(move_line_ids):
+                    if move_line.display_type == "line_section":
+                        # add extra indent for existing SO Sections
+                        move_line.name = f"- {move_line.name}"
+                    move_line.sequence = sequence
+                    sequence += 10
             invoice.line_ids = section_lines
-
         return invoice_ids
 
     def _get_ordered_invoice_lines(self, invoice):
@@ -51,10 +60,16 @@ class SaleOrder(models.Model):
             key=lambda r: r.sale_line_ids.order_id.id
         )
 
-    def _get_saleorder_section_name(self):
+    def _get_invoice_section_name(self):
         """Returns the text for the section name."""
         self.ensure_one()
-        if self.client_order_ref:
+        naming_scheme = (
+            self.partner_invoice_id.invoice_section_name_scheme
+            or self.company_id.invoice_section_name_scheme
+        )
+        if naming_scheme:
+            return safe_eval(naming_scheme, {"object": self, "time": time})
+        elif self.client_order_ref:
             return "{} - {}".format(self.name, self.client_order_ref or "")
         else:
             return self.name

--- a/account_invoice_section_sale_order/readme/CONFIGURATION.rst
+++ b/account_invoice_section_sale_order/readme/CONFIGURATION.rst
@@ -1,0 +1,9 @@
+To allow customization of the name of the section, user should be part of group
+`Allow customization of invoice section name from sale order`.
+
+A naming scheme can be defined per company on the configuration page in the
+`Customer Invoices` section, or per partner in the accounting page, using
+python expression.
+
+The object used for the grouping can be customized by installing extra module
+(e.g. `account_invoice_section_picking`).

--- a/account_invoice_section_sale_order/readme/CONTRIBUTORS.rst
+++ b/account_invoice_section_sale_order/readme/CONTRIBUTORS.rst
@@ -1,7 +1,9 @@
 * `Camptocamp <https://www.camptocamp.com>`_
 
   * Thierry Ducrest <thierry.ducrest@camptocamp.com>
+  * Akim Juillerat <akim.juillerat@camptocamp.com>
   * Hiep Nguyen Hoang <hiepnh@trobz.com>
+
 * `Dynapps <https://www.dynapps.eu>`_
 
   * Jeroen Evens

--- a/account_invoice_section_sale_order/readme/DESCRIPTION.rst
+++ b/account_invoice_section_sale_order/readme/DESCRIPTION.rst
@@ -4,4 +4,7 @@ to know which invoice line belongs to which sale order.
 
 This module helps by grouping invoicing lines into sections with the name of the
 targeted sale order.
+
+The name of the section can be customized by company and partner.
+
 This is only done when an invoice targets multiple sale order.

--- a/account_invoice_section_sale_order/security/res_groups.xml
+++ b/account_invoice_section_sale_order/security/res_groups.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="group_sale_order_invoice_section_name" model="res.groups">
+        <field
+            name="name"
+        >Allow customization of invoice section name from sale order</field>
+        <field name="category_id" ref="base.module_category_usability" />
+    </record>
+</odoo>

--- a/account_invoice_section_sale_order/tests/test_invoice_group_by_sale_order.py
+++ b/account_invoice_section_sale_order/tests/test_invoice_group_by_sale_order.py
@@ -1,7 +1,14 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+from unittest import mock
 
+from odoo.exceptions import UserError
 from odoo.tests.common import TransactionCase
+
+SECTION_GROUPING_FUNCTION = "odoo.addons.account_invoice_section_sale_order.models.account_move.AccountMoveLine._get_section_grouping"  # noqa
+SECTION_NAME_FUNCTION = (
+    "odoo.addons.base.models.res_users.Users._get_invoice_section_name"
+)
 
 
 class TestInvoiceGroupBySaleOrder(TransactionCase):
@@ -10,7 +17,9 @@ class TestInvoiceGroupBySaleOrder(TransactionCase):
         super().setUpClass()
         cls.partner_1 = cls.env.ref("base.res_partner_1")
         cls.product_1 = cls.env.ref("product.product_product_1")
+        cls.product_2 = cls.env.ref("product.product_product_2")
         cls.product_1.invoice_policy = "order"
+        cls.product_2.invoice_policy = "order"
         cls.order1_p1 = cls.env["sale.order"].create(
             {
                 "partner_id": cls.partner_1.id,
@@ -34,7 +43,7 @@ class TestInvoiceGroupBySaleOrder(TransactionCase):
                         0,
                         {
                             "name": "order 1 line 2",
-                            "product_id": cls.product_1.id,
+                            "product_id": cls.product_2.id,
                             "price_unit": 20,
                             "product_uom_qty": 1,
                             "product_uom": cls.product_1.uom_id.id,
@@ -82,7 +91,7 @@ class TestInvoiceGroupBySaleOrder(TransactionCase):
                         0,
                         {
                             "name": "order 2 line 2",
-                            "product_id": cls.product_1.id,
+                            "product_id": cls.product_2.id,
                             "price_unit": 20,
                             "product_uom_qty": 1,
                             "product_uom": cls.product_1.uom_id.id,
@@ -96,19 +105,23 @@ class TestInvoiceGroupBySaleOrder(TransactionCase):
     def test_create_invoice(self):
         """Check invoice is generated  with sale order sections."""
         result = {
-            0: "".join([self.order1_p1.name, " - ", self.order1_p1.client_order_ref]),
-            1: "order 1 line 1",
-            2: "order 1 line 2",
-            3: self.order2_p1.name,
-            4: "- order 2 section 1",
-            5: "order 2 line 1",
-            6: "- order 2 section 2",
-            7: "order 2 line 2",
+            10: (
+                "".join([self.order1_p1.name, " - ", self.order1_p1.client_order_ref]),
+                "line_section",
+            ),
+            20: ("order 1 line 1", "product"),
+            30: ("order 1 line 2", "product"),
+            40: (self.order2_p1.name, "line_section"),
+            50: ("- order 2 section 1", "line_section"),
+            60: ("order 2 line 1", "product"),
+            70: ("- order 2 section 2", "line_section"),
+            80: ("order 2 line 2", "product"),
         }
         invoice_ids = (self.order1_p1 + self.order2_p1)._create_invoices()
         lines = invoice_ids[0].invoice_line_ids.sorted("sequence")
-        for idx, line in enumerate(lines):
-            self.assertEqual(line.name, result[idx])
+        for line in lines:
+            self.assertEqual(line.name, result[line.sequence][0])
+            self.assertEqual(line.display_type, result[line.sequence][1])
 
     def test_create_invoice_no_section(self):
         """Check invoice for only one sale order
@@ -121,3 +134,56 @@ class TestInvoiceGroupBySaleOrder(TransactionCase):
             lambda r: r.display_type == "line_section"
         )
         self.assertEqual(len(line_sections), 0)
+
+    def test_unknown_invoice_section_grouping_value(self):
+        """Check an error is raised when invoice_section_grouping value is
+        unknown
+        """
+        mock_company_section_grouping = mock.patch.object(
+            type(self.env.company),
+            "invoice_section_grouping",
+            new_callable=mock.PropertyMock,
+        )
+        with mock_company_section_grouping as mocked_company_section_grouping:
+            mocked_company_section_grouping.return_value = "unknown"
+            with self.assertRaises(UserError):
+                (self.order1_p1 + self.order2_p1)._create_invoices()
+
+    def test_custom_grouping_by_sale_order_user(self):
+        """Check custom grouping by sale order user.
+
+        By mocking account.move.line_get_section_grouping and creating
+        res.users.get_invoice_section_name, this test ensures custom grouping
+        is possible by redefining these functions"""
+        demo_user = self.env.ref("base.user_demo")
+        admin_user = self.env.ref("base.partner_admin")
+        orders = self.order1_p1 + self.order2_p1
+        orders.write({"user_id": admin_user.id})
+        sale_order_3 = self.order1_p1.copy({"user_id": demo_user.id})
+        sale_order_3.order_line[0].name = "order 3 line 1"
+        sale_order_3.order_line[1].name = "order 3 line 2"
+        sale_order_3.action_confirm()
+
+        with mock.patch(
+            SECTION_GROUPING_FUNCTION
+        ) as mocked_get_section_grouping, mock.patch(
+            SECTION_NAME_FUNCTION, create=True
+        ) as mocked_get_invoice_section_name:
+            mocked_get_section_grouping.return_value = "sale_line_ids.order_id.user_id"
+            mocked_get_invoice_section_name.return_value = "Mocked value from ResUsers"
+            invoice = (orders + sale_order_3)._create_invoices()
+            result = {
+                10: ("Mocked value from ResUsers", "line_section"),
+                20: ("order 1 line 1", "product"),
+                30: ("order 1 line 2", "product"),
+                40: ("- order 2 section 1", "line_section"),
+                50: ("order 2 line 1", "product"),
+                60: ("- order 2 section 2", "line_section"),
+                70: ("order 2 line 2", "product"),
+                80: ("Mocked value from ResUsers", "line_section"),
+                90: ("order 3 line 1", "product"),
+                100: ("order 3 line 2", "product"),
+            }
+            for line in invoice.invoice_line_ids.sorted("sequence"):
+                self.assertEqual(line.name, result[line.sequence][0])
+                self.assertEqual(line.display_type, result[line.sequence][1])

--- a/account_invoice_section_sale_order/tests/test_invoice_group_by_sale_order.py
+++ b/account_invoice_section_sale_order/tests/test_invoice_group_by_sale_order.py
@@ -123,6 +123,13 @@ class TestInvoiceGroupBySaleOrder(TransactionCase):
             self.assertEqual(line.name, result[line.sequence][0])
             self.assertEqual(line.display_type, result[line.sequence][1])
 
+    def test_create_invoice_with_default_journal(self):
+        """Using a specific journal for the invoice should not be broken"""
+        journal = self.env["account.journal"].search([("type", "=", "sale")], limit=1)
+        (self.order1_p1 + self.order2_p1).with_context(
+            default_journal_id=journal.id
+        )._create_invoices()
+
     def test_create_invoice_no_section(self):
         """Check invoice for only one sale order
 

--- a/account_invoice_section_sale_order/tests/test_invoice_group_by_sale_order.py
+++ b/account_invoice_section_sale_order/tests/test_invoice_group_by_sale_order.py
@@ -120,6 +120,8 @@ class TestInvoiceGroupBySaleOrder(TransactionCase):
         invoice_ids = (self.order1_p1 + self.order2_p1)._create_invoices()
         lines = invoice_ids[0].invoice_line_ids.sorted("sequence")
         for line in lines:
+            if line.sequence not in result:
+                continue
             self.assertEqual(line.name, result[line.sequence][0])
             self.assertEqual(line.display_type, result[line.sequence][1])
 
@@ -203,5 +205,7 @@ class TestInvoiceGroupBySaleOrder(TransactionCase):
                 100: ("order 3 line 2", "product"),
             }
             for line in invoice.invoice_line_ids.sorted("sequence"):
+                if line.sequence not in result:
+                    continue
                 self.assertEqual(line.name, result[line.sequence][0])
                 self.assertEqual(line.display_type, result[line.sequence][1])

--- a/account_invoice_section_sale_order/tests/test_invoice_group_by_sale_order.py
+++ b/account_invoice_section_sale_order/tests/test_invoice_group_by_sale_order.py
@@ -123,6 +123,17 @@ class TestInvoiceGroupBySaleOrder(TransactionCase):
             self.assertEqual(line.name, result[line.sequence][0])
             self.assertEqual(line.display_type, result[line.sequence][1])
 
+    def test_create_invoice_with_currency(self):
+        """Check invoice is generated with a correct total amount"""
+        eur = self.env.ref("base.EUR")
+        pricelist = self.env["product.pricelist"].create(
+            {"name": "Europe pricelist", "currency_id": eur.id}
+        )
+        orders = self.order1_p1 | self.order2_p1
+        orders.write({"pricelist_id": pricelist.id})
+        invoices = orders._create_invoices()
+        self.assertEqual(invoices.amount_total, 80)
+
     def test_create_invoice_with_default_journal(self):
         """Using a specific journal for the invoice should not be broken"""
         journal = self.env["account.journal"].search([("type", "=", "sale")], limit=1)

--- a/account_invoice_section_sale_order/views/res_config_settings.xml
+++ b/account_invoice_section_sale_order/views/res_config_settings.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.account</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="account.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[@id='invoicing_settings']" position="inside">
+                <div
+                    class="col-12 col-lg-6 o_setting_box"
+                    id="invoice_section_sale_order"
+                    groups="account_invoice_section_sale_order.group_sale_order_invoice_section_name"
+                >
+                    <div class="o_setting_left_pane" />
+                    <div class="o_setting_right_pane">
+                        <span class="o_form_label">Section names</span>
+                        <div class="text-muted">
+                            Customize section names when invoicing from sale orders
+                        </div>
+                        <div class="row mt16">
+                            <label
+                                for="invoice_section_grouping"
+                                class="col-lg-4 o_light_label"
+                                string="Grouping object"
+                            />
+                            <field name="invoice_section_grouping" />
+                        </div>
+                        <div class="row">
+                            <label
+                                for="invoice_section_name_scheme"
+                                class="col-lg-4 o_light_label"
+                                string="Naming scheme"
+                            />
+                            <field name="invoice_section_name_scheme" />
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/account_invoice_section_sale_order/views/res_partner.xml
+++ b/account_invoice_section_sale_order/views/res_partner.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="view_partner_property_form" model="ir.ui.view">
+        <field name="name">res.partner.property.form.inherit</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="account.view_partner_property_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//page[@name='accounting']/group" position="inside">
+                <group
+                    name="invoice_section_sale_order"
+                    string="Custom section name on invoice"
+                    groups="account_invoice_section_sale_order.group_sale_order_invoice_section_name"
+                >
+                    <field name="invoice_section_name_scheme" />
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Same port than:
- https://github.com/OCA/account-invoicing/pull/1802

Port of the following PRs from 14.0 to 16.0:
- #1050
- #1117
- #1135
- #1384 (one commit updating `account_invoice_section_sale_order` regarding tests)