### PR TITLE
[16.0][stock_picking_invoicing][FIX] stock_picking_invoicing:Stock Rule inv state - fwp 1782

### DIFF
--- a/stock_picking_invoicing/models/__init__.py
+++ b/stock_picking_invoicing/models/__init__.py
@@ -1,8 +1,6 @@
-# Copyright (C) 2019-Today: Odoo Community Association (OCA)
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-
 from . import stock_invoice_state_mixin
 from . import account_move
 from . import stock_move
 from . import stock_picking
 from . import stock_picking_type
+from . import stock_rule

--- a/stock_picking_invoicing/models/stock_rule.py
+++ b/stock_picking_invoicing/models/stock_rule.py
@@ -1,0 +1,14 @@
+# Copyright (C) 2024-Today - Akretion (<http://www.akretion.com>).
+# @author Magno Costa <magno.costa@akretion.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class StockRule(models.Model):
+    _inherit = "stock.rule"
+
+    def _get_custom_move_fields(self):
+        fields = super()._get_custom_move_fields()
+        fields += ["invoice_state"]
+        return fields


### PR DESCRIPTION
forward port of #1782 

(missing PRs  #1547 and #1548 don't need port as the conflicting demo product was changed already in v16)

cc @mbcosta @antoniospneto @renatonlima @marcelsavegnago @vanderleiromera

NOTE: CI is broken for unrelated reason, see https://github.com/OCA/account-invoicing/pull/1820