### PR TITLE
[14.0][TMP] this is just a CI test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
                   grep "^[^#].*/" ${reqfile} || result=$?
                   if [ $result -eq 0 ] ; then
                       echo "Unreleased dependencies found in ${reqfile}."
-                      exit 1
+                      # exit 1
                   fi
               fi
           done


### PR DESCRIPTION
THIS IS JUST A TEST

I want to check if the CI really stopped passing on 14.0 (EDIT: it's also broken on 15.0 and 16.0!)
(and understand why the merge of #1782 failed)