### PR TITLE
[14.0][FIX] stock_picking_invoicing: Invoice Type Map Dropshipping Case

### DIFF
--- a/stock_picking_invoicing/wizards/stock_invoice_onshipping.py
+++ b/stock_picking_invoicing/wizards/stock_invoice_onshipping.py
@@ -18,6 +18,7 @@ INVOICE_TYPE_MAP = {
     ("outgoing", "internal", "customer"): "out_invoice",
     ("incoming", "customer", "internal"): "out_refund",
     ("incoming", "supplier", "internal"): "in_invoice",
+    ("incoming", "supplier", "customer"): "in_invoice",
     ("outgoing", "internal", "supplier"): "in_refund",
     ("incoming", "transit", "internal"): "in_invoice",
     ("outgoing", "transit", "supplier"): "in_refund",


### PR DESCRIPTION
The Invoice Type Map was missing for Dropshipping case, should solve Issue https://github.com/OCA/account-invoicing/issues/1790 , the module don't has direct denpendecie of [stock_dropshipping module](https://github.com/OCA/OCB/tree/14.0/addons/stock_dropshipping) so I didn't find a way to include a test for this case.

cc @rvalyi @renatonlima @anpartner