### PR TITLE
[13.0][FIX] account_invoice_show_currency_rate: use only debit from currency lines to get rate

### DIFF
--- a/account_invoice_show_currency_rate/models/account_move.py
+++ b/account_invoice_show_currency_rate/models/account_move.py
@@ -33,7 +33,7 @@ class AccountMove(models.Model):
             lines = item.line_ids.filtered(lambda x: x.amount_currency > 0)
             if item.state == "posted" and lines:
                 amount_currency_positive = sum(lines.mapped("amount_currency"))
-                total_debit = sum(item.line_ids.mapped("debit"))
+                total_debit = sum(lines.mapped("debit"))
                 item.currency_rate_amount = item.currency_id.round(
                     amount_currency_positive / total_debit
                 )


### PR DESCRIPTION
With anglo-saxon accounting, the booking of the COGS and stock interim account is done always in company currency. With the current logic, we are considering the extra debit of the COGS in the invoices which has no amount currency and the resulting rate is incorrect.