### PR TITLE
[FIX] account_invoice_mass_sending: wrong channel name

### DIFF
--- a/account_invoice_mass_sending/data/queue_job.xml
+++ b/account_invoice_mass_sending/data/queue_job.xml
@@ -2,7 +2,7 @@
 <odoo>
         <!-- Queue Job Channel -->
         <record id="account_invoice_mass_sending_channel" model="queue.job.channel">
-            <field name="name">Invoice Mass Sending Job</field>
+            <field name="name">account_invoice_mass_sending_channel</field>
             <field name="parent_id" ref="queue_job.channel_root" />
         </record>
 


### PR DESCRIPTION
This is how it looks like without the fix:

![image](https://github.com/user-attachments/assets/5b8dc253-e485-4f37-a719-aafc99c27da2)


@moduon MT-8120