### PR TITLE
[FIX] account_invoice_fixed_discount: Fixed devision by zero error to…

### DIFF
--- a/account_invoice_fixed_discount/models/account_move_line.py
+++ b/account_invoice_fixed_discount/models/account_move_line.py
@@ -82,4 +82,8 @@ class AccountMoveLine(models.Model):
         currency = self.currency_id or self.company_id.currency_id
         if float_is_zero(self.discount_fixed, precision_rounding=currency.rounding):
             return 0.0
-        return (self.discount_fixed / self.price_unit) * 100
+        return (
+            (self.price_unit != 0)
+            and ((self.discount_fixed) / self.price_unit) * 100
+            or 0.00
+        )

--- a/account_invoice_fixed_discount/tests/test_account_fixed_discount.py
+++ b/account_invoice_fixed_discount/tests/test_account_fixed_discount.py
@@ -144,3 +144,14 @@ class TestInvoiceFixedDiscount(TransactionCase):
             price_unit=10,
             currency=1,
         )
+
+    def test_05_fixed_discount_without_price(self):
+        """Tests fixed discount with 0 unit price."""
+        with Form(self.invoice) as invoice_form:
+            with invoice_form.invoice_line_ids.edit(0) as line:
+                line.quantity = 1.0
+                line.price_unit = 0.0
+                line.discount_fixed = 50.0
+        self.assertEqual(self.invoice.invoice_line_ids.discount, 0.0)
+        self.assertEqual(self.invoice.invoice_line_ids.price_subtotal, 0.0)
+        self.assertEqual(self.invoice.amount_total, 0.0)


### PR DESCRIPTION
… v17.0

Case: When an invoice line includes a product with a unit price of 0 and a fixed discount is applied (even by mistake), it results in a traceback error.

Sometimes users may not be aware of the proper configurations for applying discounts. If this occurs, the system prevents further entry and shows a traceback.

This scenario has already been addressed in sale_fixed_discount previously.