### PR TITLE
[16.0][IMP] sale_order_invoicing_grouping_criteria: use odoo's grouping functions

### DIFF
--- a/sale_order_invoicing_grouping_criteria/models/sale_order.py
+++ b/sale_order_invoicing_grouping_criteria/models/sale_order.py
@@ -14,38 +14,16 @@ class SaleOrder(models.Model):
         If not set, use the partner_id.
         :return: res.partner recordset
         """
-        self.ensure_one()
-        return self.partner_invoice_id or self.partner_id
+        res = self.env["res.partner"]
+        for sale in self:
+            res += sale.partner_invoice_id or sale.partner_id
+        return res
 
-    def _get_sale_invoicing_group_key(self):
-        """Prepare extended grouping criteria for sales orders."""
-        self.ensure_one()
-        group_key = [
-            self.company_id.id,
-            self.partner_invoice_id.id,
-            self.currency_id.id,
-        ]
-        partner = self._get_grouping_partner()
+    def _get_invoice_grouping_keys(self):
+        res = super()._get_invoice_grouping_keys()
+        partners = self._get_grouping_partner()
         criteria = (
-            partner.sale_invoicing_grouping_criteria_id
+            partners.mapped("sale_invoicing_grouping_criteria_id")
             or self.company_id.default_sale_invoicing_grouping_criteria_id
         )
-        for field in criteria.field_ids.sudo():
-            group_key.append(self[field.name])
-        return tuple(group_key)
-
-    def _create_invoices(self, grouped=False, final=False, date=None):
-        """Slice the batch according grouping criteria."""
-        order_groups = {}
-        for order in self:
-            group_key = order._get_sale_invoicing_group_key()
-            if group_key not in order_groups:
-                order_groups[group_key] = order
-            else:
-                order_groups[group_key] += order
-        moves = self.env["account.move"]
-        for group in order_groups.values():
-            moves += super(SaleOrder, group)._create_invoices(
-                grouped=grouped, final=final, date=date
-            )
-        return moves
+        return res + criteria.sudo().field_ids.mapped("name")


### PR DESCRIPTION
Odoo already has a grouping function that can be simply inherited to add more grouping criterias.

The function [is declared in the sale module](https://github.com/odoo/odoo/blob/e72ccc94375de18c99f7e86a9dafd830d6dde530/addons/sale/models/sale_order.py#L1413
), and its used [inside the _create_invoices function](https://github.com/odoo/odoo/blob/e72ccc94375de18c99f7e86a9dafd830d6dde530/addons/sale/models/sale_order.py#L1524
) to group the values of the new invoices.

The module sale_order_invoicing_grouping_criteria currently uses a new custom way to group invoices. 

Benefits of changing the grouping method:
- Reduce the amount of customization and code
- More compatibility with other odoo and oca modules

Cons of changing the grouping method: 
- Agrupation can only be done though fields present in the generated invoice. Fields only present in the sale, for example: sale id, can not be used in the agrupation (Thats why a test is commented, pending to solve) 

T-6942
