### PR TITLE
[FIX] account_move_tier_validation: do not overwrite line values

### DIFF
--- a/account_move_tier_validation/models/account_move.py
+++ b/account_move_tier_validation/models/account_move.py
@@ -22,6 +22,14 @@ class AccountMove(models.Model):
     def _get_under_validation_exceptions(self):
         return super()._get_under_validation_exceptions() + ["needed_terms_dirty"]
 
+    def _get_validation_exceptions(self, extra_domain=None, add_base_exceptions=True):
+        res = super()._get_validation_exceptions(extra_domain, add_base_exceptions)
+        # we need to exclude amount_total,
+        # otherwise editing manually the values on lines dirties the field at onchange
+        # since it's not in readonly because readonly="not(review_ids)", it's then
+        # sent at save, and will override the values set by the user
+        return res + ["amount_total"]
+
     def _get_to_validate_message_name(self):
         name = super()._get_to_validate_message_name()
         if self.move_type == "in_invoice":


### PR DESCRIPTION
Edit a new journal entry with lines in currency X different from company currency Y. Say you have a line of value (amount_currency) N, which is converted to Y(N) (debit/credit). Then `amount_total` is also N. Because the `readonly="not(review_ids)"` was added, `amount_total` is dirty and sent at save. Therefore, Odoo uses it and sets the debit/credit values of the lines to N (instead of Y(N), the converted value). It's as if it's ignoring the currency conversion (note that the values are correct through onchange before the save).

To avoid this, exclude the field from being modified in `get_view`.