### PR TITLE
[17.0][FIX] account_invoice_section_sale_order: fix tax amount in test

### DIFF
--- a/account_invoice_section_sale_order/tests/test_invoice_group_by_sale_order.py
+++ b/account_invoice_section_sale_order/tests/test_invoice_group_by_sale_order.py
@@ -135,7 +135,7 @@ class TestInvoiceGroupBySaleOrder(TransactionCase):
         """Check invoice is generated with a correct total amount"""
         orders = self.order1_p1 | self.order2_p1
         invoices = orders._create_invoices()
-        self.assertEqual(invoices.amount_total, 80)
+        self.assertEqual(invoices.amount_untaxed, 80)
 
     def test_create_invoice_with_default_journal(self):
         """Using a specific journal for the invoice should not be broken"""


### PR DESCRIPTION
Taxes were added to demo products in https://github.com/odoo/odoo/commit/1443e5503c7396512a so the taxed amount is now 15% higher. The untaxed amount hasn't changed though.