### PR TITLE
[15.0][FIX] stock_picking_invoicing: Invoice Type Map Dropshipping Case, FWD 1823

### DIFF
--- a/stock_picking_invoicing/wizards/stock_invoice_onshipping.py
+++ b/stock_picking_invoicing/wizards/stock_invoice_onshipping.py
@@ -18,6 +18,7 @@ INVOICE_TYPE_MAP = {
     ("outgoing", "internal", "customer"): "out_invoice",
     ("incoming", "customer", "internal"): "out_refund",
     ("incoming", "supplier", "internal"): "in_invoice",
+    ("incoming", "supplier", "customer"): "in_invoice",
     ("outgoing", "internal", "supplier"): "in_refund",
     ("incoming", "transit", "internal"): "in_invoice",
     ("outgoing", "transit", "supplier"): "in_refund",


### PR DESCRIPTION
Foward Port https://github.com/OCA/account-invoicing/pull/1823

The Invoice Type Map was missing for Dropshipping case, should solve Issue https://github.com/OCA/account-invoicing/issues/1790 , the module don't has direct dependecie of [stock_dropshipping module](https://github.com/OCA/OCB/tree/15.0/addons/stock_dropshipping)

cc @rvalyi @renatonlima @anpartner