### PR TITLE
[16.0][FIX] stock_picking_invoicing: Invoice Type Map Dropshipping Case, FWD 1823

### DIFF
--- a/stock_picking_invoicing/wizards/stock_invoice_onshipping.py
+++ b/stock_picking_invoicing/wizards/stock_invoice_onshipping.py
@@ -19,6 +19,7 @@ INVOICE_TYPE_MAP = {
     ("incoming", "customer", "internal"): "out_refund",
     ("incoming", "customer", "customer"): "out_refund",
     ("incoming", "supplier", "internal"): "in_invoice",
+    ("incoming", "supplier", "customer"): "in_invoice",
     ("outgoing", "internal", "supplier"): "in_refund",
     ("outgoing", "internal", "internal"): "in_refund",
     ("incoming", "transit", "internal"): "in_invoice",


### PR DESCRIPTION
Foward Port https://github.com/OCA/account-invoicing/pull/1823

The Invoice Type Map was missing for Dropshipping case, should solve Issue https://github.com/OCA/account-invoicing/issues/1790 , the module don't has direct dependecie of [stock_dropshipping module](https://github.com/OCA/OCB/tree/15.0/addons/stock_dropshipping)

cc @rvalyi @renatonlima @anpartner