### PR TITLE
[16.0][FW][IMP] account_invoice_show_currency_rate: use absolute balance to get rate on credit amounts

### DIFF
--- a/account_invoice_show_currency_rate/tests/test_account_move.py
+++ b/account_invoice_show_currency_rate/tests/test_account_move.py
@@ -76,15 +76,19 @@ class TestAccountMove(common.TransactionCase):
         self.partner.property_product_pricelist = self.pricelist_currency
         invoice = self._create_invoice(self.currency)
         self.assertAlmostEqual(invoice.currency_rate_amount, 1.0, 2)
+        self.assertAlmostEqual(invoice.line_ids[0].currency_rate, 1.0, 2)
 
     def test_02_invoice_currency_extra(self):
         self.partner.property_product_pricelist = self.pricelist_currency_extra
         invoice = self._create_invoice(self.currency_extra)
         self.assertAlmostEqual(invoice.currency_rate_amount, 2.0, 2)
+        self.assertAlmostEqual(invoice.line_ids[0].currency_rate, 2.0, 2)
         rate_custom = self.currency_extra.rate_ids.filtered(
             lambda x: x.name == fields.Date.from_string("2000-01-01")
         )
         rate_custom.rate = 3.0
         self.assertAlmostEqual(invoice.currency_rate_amount, 2.0, 2)
+        self.assertAlmostEqual(invoice.line_ids[0].currency_rate, 2.0, 2)
         invoice.button_draft()
         self.assertAlmostEqual(invoice.currency_rate_amount, 3.0, 2)
+        self.assertAlmostEqual(invoice.line_ids[0].currency_rate, 3.0, 2)


### PR DESCRIPTION
FW of https://github.com/OCA/account-invoicing/pull/1838

- Odoo computes the currency rate on journal items (https://github.com/odoo/odoo/blob/e3d54695862f73d9be6c35121def57ed641a1a45/addons/account/models/account_move_line.py#L133). However, the computed rate is based on the rate configured in the system. It could be the case for manually created entries that the user has manually modified the amount in currency, so this module ensures that the computed rate is based on the actual currency amount applied.