### PR TITLE
[16.0][IMP] account_invoice_show_currency_rate: prevent error when balance is zero

### DIFF
--- a/account_invoice_show_currency_rate/models/account_move.py
+++ b/account_invoice_show_currency_rate/models/account_move.py
@@ -71,7 +71,9 @@ class AccountMoveLine(models.Model):
         for line in self:
             if line.move_id.state != "posted" or not line.amount_currency:
                 continue
-            line.currency_rate = line.currency_id.round(
-                abs(line.amount_currency) / abs(line.balance)
+            line.currency_rate = (
+                line.currency_id.round(abs(line.amount_currency) / abs(line.balance))
+                if line.balance
+                else 0
             )
         return res


### PR DESCRIPTION
In Odoo this can happen for currency exchange entries where balance is 0 but currency amount > 0.