### PR TITLE
[16.0][FIX] account_invoice_show_currency_rate: do not round currency rate

### DIFF
--- a/account_invoice_show_currency_rate/models/account_move.py
+++ b/account_invoice_show_currency_rate/models/account_move.py
@@ -39,7 +39,7 @@ class AccountMove(models.Model):
                     [abs(amc) for amc in lines.mapped("amount_currency")]
                 )
                 total_balance_positive = sum([abs(b) for b in lines.mapped("balance")])
-                item.currency_rate_amount = item.currency_id.round(
+                item.currency_rate_amount = (
                     amount_currency_positive / total_balance_positive
                 )
             else:
@@ -72,8 +72,6 @@ class AccountMoveLine(models.Model):
             if line.move_id.state != "posted" or not line.amount_currency:
                 continue
             line.currency_rate = (
-                line.currency_id.round(abs(line.amount_currency) / abs(line.balance))
-                if line.balance
-                else 0
+                abs(line.amount_currency) / abs(line.balance) if line.balance else 0
             )
         return res


### PR DESCRIPTION
Currency rates are not rounded in Odoo. Applying the rounding causes the currency rate of the line to be different when the move is posted.