### PR TITLE
[15.0][IMP]: account_invoice_section_sale_order add option to always create…

### DIFF
--- a/account_invoice_section_sale_order/__manifest__.py
+++ b/account_invoice_section_sale_order/__manifest__.py
@@ -10,4 +10,5 @@
     "license": "AGPL-3",
     "category": "Accounting & Finance",
     "depends": ["account", "sale"],
+    "data": ["views/res_config_settings.xml"],
 }

--- a/account_invoice_section_sale_order/models/__init__.py
+++ b/account_invoice_section_sale_order/models/__init__.py
@@ -1,1 +1,3 @@
 from . import sale_order
+from . import res_config_settings
+from . import res_company

--- a/account_invoice_section_sale_order/models/res_company.py
+++ b/account_invoice_section_sale_order/models/res_company.py
@@ -1,0 +1,13 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    always_create_invoice_section = fields.Boolean(
+        help="Defines when to create sections",
+        default=False,
+        string="Always create invoice section",
+    )

--- a/account_invoice_section_sale_order/models/res_config_settings.py
+++ b/account_invoice_section_sale_order/models/res_config_settings.py
@@ -1,0 +1,12 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    always_create_invoice_section = fields.Boolean(
+        related="company_id.always_create_invoice_section",
+        readonly=False,
+    )

--- a/account_invoice_section_sale_order/models/sale_order.py
+++ b/account_invoice_section_sale_order/models/sale_order.py
@@ -16,7 +16,10 @@ class SaleOrder(models.Model):
         """
         invoice_ids = super()._create_invoices(grouped=grouped, final=final)
         for invoice in invoice_ids:
-            if len(invoice.line_ids.mapped("sale_line_ids.order_id.id")) == 1:
+            if (
+                not invoice.company_id.always_create_invoice_section
+                and len(invoice.line_ids.mapped("sale_line_ids.order_id.id")) == 1
+            ):
                 continue
             so = None
             sequence = 10

--- a/account_invoice_section_sale_order/static/description/index.html
+++ b/account_invoice_section_sale_order/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -426,7 +426,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/account_invoice_section_sale_order/views/res_config_settings.xml
+++ b/account_invoice_section_sale_order/views/res_config_settings.xml
@@ -1,0 +1,25 @@
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.account</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="account.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[@id='invoicing_settings']" position="inside">
+                <div class="col-12 col-lg-6 o_setting_box">
+                        <div class="mt16">
+                                <div class="o_setting_left_pane">
+                                    <field name="always_create_invoice_section" />
+                                </div>
+                                <div class="o_setting_right_pane">
+                                    <label for="always_create_invoice_section" />
+                                    <div class="text-muted">
+                                        Always create a section even if an invoice is
+                                    created from a single sale order
+                                    </div>
+                                </div>
+                        </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Backport commit in [17.0](https://github.com/OCA/account-invoicing/pull/1887) allowing us to create section in invoice even if only one so is selected

![section](https://github.com/user-attachments/assets/2cd7bbb6-d8eb-4bca-a866-30bfc095ee10)
