### PR TITLE
[IMP] stock_picking_invoicing: set reversed_entry in return pick invoicing

### DIFF
--- a/stock_picking_invoicing/models/stock_picking.py
+++ b/stock_picking_invoicing/models/stock_picking.py
@@ -45,3 +45,11 @@ class StockPicking(models.Model):
         if any(m.invoice_state == "2binvoiced" for m in self.mapped("move_lines")):
             self.write({"invoice_state": "2binvoiced"})
         return super().action_assign()
+
+    def get_return_origin_invoice_ids(self):
+        """
+        Override this method if you need to set a specific invoice to return
+        :return: invoices
+        """
+        source_picking_id = self.mapped("move_lines.origin_returned_move_id.picking_id")
+        return source_picking_id.mapped("invoice_ids")

--- a/stock_picking_invoicing/wizards/stock_invoice_onshipping.py
+++ b/stock_picking_invoicing/wizards/stock_invoice_onshipping.py
@@ -528,12 +528,26 @@ class StockInvoiceOnshipping(models.TransientModel):
         invoices = self.env["account.move"].browse()
         for pickings in pick_list:
             moves = pickings.mapped("move_lines")
+            # Origin moves are set when invoicing a return picking
+            origin_moves = moves.mapped("origin_returned_move_id")
+            origin_account_move_id = False
+            if origin_moves:
+                # Core does not suport multi returns:
+                # pick first and set as invoice.reversed_entry_id
+                # TODO: check if this is approach changes in next versions
+                if pickings.get_return_origin_invoice_ids():
+                    origin_account_move_id = pickings.get_return_origin_invoice_ids()[
+                        0
+                    ].id
+
             grouped_moves_list = self._group_moves(moves)
             parts = self.ungroup_moves(grouped_moves_list)
             for moves_list in parts:
                 invoice, invoice_values = self._build_invoice_values_from_pickings(
                     pickings
                 )
+                if origin_account_move_id:
+                    invoice_values["reversed_entry_id"] = origin_account_move_id
                 lines = [(5, 0, {})]
                 line_values = False
                 for moves in moves_list:


### PR DESCRIPTION
This PR automatically references a picking's invoice in it's return invoice using the field `reversed_entry_id`


```
Stock Move  --->  Invoice 1
     |
     v
Return Stock Move  --->  Invoice 2 (references Invoice 1)


e.g. invoice_2.reversed_entry_id = invoice_1
```
