### PR TITLE
[FIX] account_invoice_tax_note: Fix test

### DIFF
--- a/account_invoice_tax_note/tests/test_account_invoice.py
+++ b/account_invoice_tax_note/tests/test_account_invoice.py
@@ -49,7 +49,8 @@ class TestAccountInvoice(TransactionCase):
         self.product1.write({"taxes_id": [(6, False, self.tax1.ids)]})
         self.product2.write({"taxes_id": [(6, False, self.tax2.ids)]})
         account = self.env["account.account"].search(
-            [("account_type", "=", "income")], limit=1
+            [("account_type", "=", "income"), ("company_id", "=", self.env.company.id)],
+            limit=1,
         )
         account.write({"tax_ids": [(4, self.tax1.id, False), (4, self.tax2.id, False)]})
         journal = self.env["account.journal"].create(


### PR DESCRIPTION
For example, if we have install `l10n_es` the test raised an error of multicompany issues.

With this change, we avoid it.