### PR TITLE
[15.0][IMP] account_invoice_section_sale_order: Add config options to enable/disable ref and date in invoice section

### DIFF
--- a/account_invoice_section_sale_order/README.rst
+++ b/account_invoice_section_sale_order/README.rst
@@ -68,6 +68,9 @@ Contributors
   * Hiep Nguyen Hoang <hiepnh@trobz.com>
   * Jeroen Evens <jeroen.evens@dynapps.be>
 
+* `APSL-Nagarro <https://www.apsl.tech>`_:
+  * Patryk Pyczko <ppyczko@apsl.net>
+
 Other credits
 ~~~~~~~~~~~~~
 

--- a/account_invoice_section_sale_order/__manifest__.py
+++ b/account_invoice_section_sale_order/__manifest__.py
@@ -1,7 +1,7 @@
 # Copyright 2020 Camptocamp
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
-    "name": "Acccount Invoice Section Sale Order",
+    "name": "Account Invoice Section Sale Order",
     "version": "15.0.1.0.2",
     "summary": "For invoices targetting multiple sale order add"
     "sections with sale order name.",
@@ -10,4 +10,5 @@
     "license": "AGPL-3",
     "category": "Accounting & Finance",
     "depends": ["account", "sale"],
+    "data": ["views/res_config_settings.xml"],
 }

--- a/account_invoice_section_sale_order/i18n/ca.po
+++ b/account_invoice_section_sale_order/i18n/ca.po
@@ -18,43 +18,43 @@ msgstr ""
 #. module: account_invoice_section_sale_order
 #: model:ir.model,name:account_invoice_section_sale_order.model_res_config_settings
 msgid "Config Settings"
-msgstr ""
+msgstr "Ajustos de configuració"
 
 #. module: account_invoice_section_sale_order
 #: model:ir.model.fields,help:account_invoice_section_sale_order.field_res_config_settings__show_client_order_ref_in_invoice
 msgid ""
 "If enabled, the client's reference from the sale order will be included in "
 "the invoice section title."
-msgstr ""
+msgstr "Si està habilitat, la referència del client de la comanda de venda s'inclourà al títol de la secció de la factura."
 
 #. module: account_invoice_section_sale_order
 #: model:ir.model.fields,help:account_invoice_section_sale_order.field_res_config_settings__show_sale_order_date_in_invoice
 msgid ""
 "If enabled, the sale order date will be included in the invoice section "
 "title."
-msgstr ""
+msgstr "Si està habilitat, la data de la comanda de venda s'inclourà al títol de la secció de la factura."
 
 #. module: account_invoice_section_sale_order
 #: model:ir.model,name:account_invoice_section_sale_order.model_sale_order
 msgid "Sales Order"
-msgstr ""
+msgstr "Comanda de venda"
 
 #. module: account_invoice_section_sale_order
 #: model:ir.model.fields,field_description:account_invoice_section_sale_order.field_res_config_settings__show_client_order_ref_in_invoice
 msgid "Show Client Reference in Invoice Section"
-msgstr ""
+msgstr "Mostrar la referència del client a la secció de la factura"
 
 #. module: account_invoice_section_sale_order
 #: model:ir.model.fields,field_description:account_invoice_section_sale_order.field_res_config_settings__show_sale_order_date_in_invoice
 msgid "Show Sale Order Date in Invoice Section"
-msgstr ""
+msgstr "Mostrar la data de la comanda de venda a la secció de la factura"
 
 #. module: account_invoice_section_sale_order
 #: model_terms:ir.ui.view,arch_db:account_invoice_section_sale_order.res_config_settings_view_form
 msgid "Show the client reference in the invoice section name."
-msgstr ""
+msgstr "Mostrar la referència del client al nom de la secció de la factura."
 
 #. module: account_invoice_section_sale_order
 #: model_terms:ir.ui.view,arch_db:account_invoice_section_sale_order.res_config_settings_view_form
 msgid "Show the sale order date in the invoice section name."
-msgstr ""
+msgstr "Mostrar la data de la comanda de venda al nom de la secció de la factura."

--- a/account_invoice_section_sale_order/i18n/es.po
+++ b/account_invoice_section_sale_order/i18n/es.po
@@ -18,43 +18,43 @@ msgstr ""
 #. module: account_invoice_section_sale_order
 #: model:ir.model,name:account_invoice_section_sale_order.model_res_config_settings
 msgid "Config Settings"
-msgstr ""
+msgstr "Opciones de configuración"
 
 #. module: account_invoice_section_sale_order
 #: model:ir.model.fields,help:account_invoice_section_sale_order.field_res_config_settings__show_client_order_ref_in_invoice
 msgid ""
 "If enabled, the client's reference from the sale order will be included in "
 "the invoice section title."
-msgstr ""
+msgstr "Si está habilitado, la referencia del cliente del pedido de venta se incluirá en el título de la sección de la factura."
 
 #. module: account_invoice_section_sale_order
 #: model:ir.model.fields,help:account_invoice_section_sale_order.field_res_config_settings__show_sale_order_date_in_invoice
 msgid ""
 "If enabled, the sale order date will be included in the invoice section "
 "title."
-msgstr ""
+msgstr "Si está habilitado, la fecha del pedido de venta se incluirá en el título de la sección de la factura."
 
 #. module: account_invoice_section_sale_order
 #: model:ir.model,name:account_invoice_section_sale_order.model_sale_order
 msgid "Sales Order"
-msgstr ""
+msgstr "Pedido de venta"
 
 #. module: account_invoice_section_sale_order
 #: model:ir.model.fields,field_description:account_invoice_section_sale_order.field_res_config_settings__show_client_order_ref_in_invoice
 msgid "Show Client Reference in Invoice Section"
-msgstr ""
+msgstr "Mostrar referencia del cliente en la sección de la factura"
 
 #. module: account_invoice_section_sale_order
 #: model:ir.model.fields,field_description:account_invoice_section_sale_order.field_res_config_settings__show_sale_order_date_in_invoice
 msgid "Show Sale Order Date in Invoice Section"
-msgstr ""
+msgstr "Mostrar fecha del pedido de venta en la sección de la factura"
 
 #. module: account_invoice_section_sale_order
 #: model_terms:ir.ui.view,arch_db:account_invoice_section_sale_order.res_config_settings_view_form
 msgid "Show the client reference in the invoice section name."
-msgstr ""
+msgstr "Mostrar la referencia del cliente en el nombre de la sección de la factura."
 
 #. module: account_invoice_section_sale_order
 #: model_terms:ir.ui.view,arch_db:account_invoice_section_sale_order.res_config_settings_view_form
 msgid "Show the sale order date in the invoice section name."
-msgstr ""
+msgstr "Mostrar la fecha del pedido de venta en el nombre de la sección de la factura."

--- a/account_invoice_section_sale_order/models/__init__.py
+++ b/account_invoice_section_sale_order/models/__init__.py
@@ -1,1 +1,2 @@
+from . import res_config_settings
 from . import sale_order

--- a/account_invoice_section_sale_order/models/res_config_settings.py
+++ b/account_invoice_section_sale_order/models/res_config_settings.py
@@ -1,0 +1,21 @@
+# Copyright 2025 Patryk Pyczko (APSL-Nagarro)<ppyczko@apsl.net>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class SaleConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    show_sale_order_date_in_invoice = fields.Boolean(
+        string="Show Sale Order Date in Invoice Section",
+        config_parameter="sale.show_sale_order_date_in_invoice",
+        help="If enabled, the sale order date will be included in the invoice section title.",
+    )
+
+    show_client_order_ref_in_invoice = fields.Boolean(
+        string="Show Client Reference in Invoice Section",
+        config_parameter="sale.show_client_order_ref_in_invoice",
+        help="If enabled, the client's reference from the sale order "
+        "will be included in the invoice section title.",
+    )

--- a/account_invoice_section_sale_order/models/sale_order.py
+++ b/account_invoice_section_sale_order/models/sale_order.py
@@ -54,7 +54,16 @@ class SaleOrder(models.Model):
     def _get_saleorder_section_name(self):
         """Returns the text for the section name."""
         self.ensure_one()
-        if self.client_order_ref:
-            return "{} - {}".format(self.name, self.client_order_ref or "")
-        else:
-            return self.name
+        config = self.env["ir.config_parameter"].sudo()
+        show_date = config.get_param("sale.show_sale_order_date_in_invoice", False)
+        show_client_ref = config.get_param(
+            "sale.show_client_order_ref_in_invoice", False
+        )
+
+        parts = [self.name]
+        if show_client_ref and self.client_order_ref:
+            parts.append(self.client_order_ref)
+        if show_date and self.date_order:
+            parts.append(self.date_order.date().strftime("%d/%m/%Y"))
+
+        return " - ".join(parts)

--- a/account_invoice_section_sale_order/readme/CONTRIBUTORS.rst
+++ b/account_invoice_section_sale_order/readme/CONTRIBUTORS.rst
@@ -3,3 +3,6 @@
   * Thierry Ducrest <thierry.ducrest@camptocamp.com>
   * Hiep Nguyen Hoang <hiepnh@trobz.com>
   * Jeroen Evens <jeroen.evens@dynapps.be>
+
+* `APSL-Nagarro <https://www.apsl.tech>`_:
+  * Patryk Pyczko <ppyczko@apsl.net>

--- a/account_invoice_section_sale_order/static/description/index.html
+++ b/account_invoice_section_sale_order/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -414,6 +414,8 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Jeroen Evens &lt;<a class="reference external" href="mailto:jeroen.evens&#64;dynapps.be">jeroen.evens&#64;dynapps.be</a>&gt;</li>
 </ul>
 </li>
+<li><a class="reference external" href="https://www.apsl.tech">APSL-Nagarro</a>:
+* Patryk Pyczko &lt;<a class="reference external" href="mailto:ppyczko&#64;apsl.net">ppyczko&#64;apsl.net</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="other-credits">
@@ -426,7 +428,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/account_invoice_section_sale_order/views/res_config_settings.xml
+++ b/account_invoice_section_sale_order/views/res_config_settings.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+  <!-- Copyright 2025 Patryk Pyczko (APSL-Nagarro)<ppyczko@apsl.net>
+       License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+
+  <record id="res_config_settings_view_form" model="ir.ui.view">
+    <field name="name">res.config.settings.view.form.inherit.account</field>
+    <field name="model">res.config.settings</field>
+    <field name="inherit_id" ref="account.res_config_settings_view_form" />
+    <field name="arch" type="xml">
+      <xpath expr="//div[@id='invoicing_settings']" position="inside">
+        <div class="col-12 col-lg-6 o_setting_box">
+          <div class="mt16">
+            <div class="o_setting_left_pane">
+              <field name="show_sale_order_date_in_invoice" />
+            </div>
+            <div class="o_setting_right_pane">
+              <label for="show_sale_order_date_in_invoice" />
+              <div class="text-muted">
+                Show the sale order date in the invoice section name.
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-12 col-lg-6 o_setting_box">
+          <div class="mt16">
+            <div class="o_setting_left_pane">
+              <field name="show_client_order_ref_in_invoice" />
+            </div>
+            <div class="o_setting_right_pane">
+              <label for="show_client_order_ref_in_invoice" />
+              <div class="text-muted">
+                Show the client reference in the invoice section name.
+              </div>
+            </div>
+          </div>
+        </div>
+      </xpath>
+    </field>
+  </record>
+
+</odoo>


### PR DESCRIPTION
This IMP improves customizability by introducing settings to toggle the display of the client reference and sale order date in invoice section names, giving users more control over their visibility.

**Example Outputs Based on Configurations**
![imagen](https://github.com/user-attachments/assets/3f7f6c11-f1e3-40cd-9f7c-22e6742cc9ea)




cc https://github.com/APSL 167051

@miquelalzanillas @lbarry-apsl @mpascuall @peluko00 @javierobcn @BernatObrador please review