### PR TITLE
[16.0][REF] sale_stock_picking_invoicing: Allow other modules inform Fields that should not be used from Sale 'prepare' methods, FWD 1906

### DIFF
--- a/sale_stock_picking_invoicing/wizards/stock_invoice_onshipping.py
+++ b/sale_stock_picking_invoicing/wizards/stock_invoice_onshipping.py
@@ -29,6 +29,39 @@ class StockInvoiceOnshipping(models.TransientModel):
         "Has down payments", default=_default_has_down_payment, readonly=True
     )
 
+    def _get_fields_not_used_from_sale(self):
+        """Fields not used from Sale 'prepare' method"""
+        # For reference, fields get from 'prepare' method
+        #   "ref": self.client_order_ref or ''
+        #   "narration": self.note,
+        #   "campaign_id": self.campaign_id.id,
+        #   "medium_id": self.medium_id.id,
+        #   "source_id": self.source_id.id,
+        #   "team_id": self.team_id.id,
+        #   "partner_shipping_id": self.partner_shipping_id.id,
+        #   "partner_bank_id": self.company_id.partner_id.bank_ids.
+        #      filtered(lambda bank: bank.company_id.id in
+        #      (self.company_id.id, False))[:1].id,
+        #   "invoice_payment_term_id": self.payment_term_id.id,
+        #   "payment_reference": self.reference,
+        #   "transaction_ids": [(6, 0, self.transaction_ids.ids)],
+
+        return {
+            "move_type",
+            "currency_id",
+            "user_id",
+            "invoice_user_id",
+            "partner_id",
+            "fiscal_position_id",
+            "journal_id",  # company comes from the journal
+            "invoice_origin",
+            "invoice_line_ids",
+            "company_id",
+            # Another fields
+            "__last_update",
+            "display_name",
+        }
+
     def _build_invoice_values_from_pickings(self, pickings):
         invoice, values = super()._build_invoice_values_from_pickings(pickings)
 
@@ -65,40 +98,9 @@ class StockInvoiceOnshipping(models.TransientModel):
                 refs.add(sale_values["ref"])
                 narration.add(sale_values["narration"])
 
-                # Original dict from sale module, for reference:
-                # Fields to get:
-                #  "ref": self.client_order_ref or ''
-                #  "narration": self.note,
-                #  "campaign_id": self.campaign_id.id,
-                #  "medium_id": self.medium_id.id,
-                #  "source_id": self.source_id.id,
-                #  "team_id": self.team_id.id,
-                #  "partner_shipping_id": self.partner_shipping_id.id,
-                #  "partner_bank_id": self.company_id.partner_id.bank_ids.
-                #      filtered(lambda bank: bank.company_id.id in
-                #      (self.company_id.id, False))[:1].id,
-                #  "invoice_payment_term_id": self.payment_term_id.id,
-                #  "payment_reference": self.reference,
-                #  "transaction_ids": [(6, 0, self.transaction_ids.ids)],
-
-                # Fields to remove
-                vals_to_remove = {
-                    "move_type",
-                    "currency_id",
-                    "user_id",
-                    "invoice_user_id",
-                    "partner_id",
-                    "fiscal_position_id",
-                    "journal_id",  # company comes from the journal
-                    "invoice_origin",
-                    "invoice_line_ids",
-                    "company_id",
-                    # Another fields
-                    "__last_update",
-                    "display_name",
-                }
                 sale_values_rm = {
-                    k: sale_values[k] for k in set(sale_values) - vals_to_remove
+                    k: sale_values[k]
+                    for k in set(sale_values) - self._get_fields_not_used_from_sale()
                 }
 
                 values.update(sale_values_rm)
@@ -154,6 +156,34 @@ class StockInvoiceOnshipping(models.TransientModel):
 
         return key
 
+    def _get_fields_not_used_from_sale_line(self):
+        """Fields not used from Sale Line 'prepare' method"""
+        # Original fields from sale module
+        # Fields do get
+        #     "sequence": self.sequence,
+        #     "discount": self.discount,
+        #     "display_type": self.display_type or 'product'
+        #     "is_downpayment": self.is_downpayment
+        #     * optional_values
+        #     * 'N field' included in _prepare_invoice_line method
+        #        by another module
+
+        return {
+            # Fields from Move has priority
+            "name",
+            "product_id",
+            "product_uom_id",
+            "quantity",
+            "price_unit",
+            "tax_ids",
+            # Already get
+            "sale_line_ids",
+            "anlytic_distribution",
+            # another fields
+            "__last_update",
+            "display_name",
+        }
+
     def _get_invoice_line_values(self, moves, invoice_values, invoice):
         values = super()._get_invoice_line_values(moves, invoice_values, invoice)
         move = fields.first(moves)
@@ -168,35 +198,13 @@ class StockInvoiceOnshipping(models.TransientModel):
             # Refund case don't get values from Sale Line Dict
             # TODO: Should get any value?
             if self._get_invoice_type() != "out_refund":
-                # Original fields from sale module
-                # Fields do get
-                #     "sequence": self.sequence,
-                #     "discount": self.discount,
-                #     "display_type": self.display_type or 'product'
-                #     "is_downpayment": self.is_downpayment
-                #     * optional_values
-                #     * 'N field' included in _prepare_invoice_line method
-                #        by another module
+                # Same make above, get fields informed in Sale Line dict
+                sale_line_values = move.sale_line_id._prepare_invoice_line()
 
-                # Fields to remove
-                vals_to_remove = {
-                    # Fields from Move has priority
-                    "name",
-                    "product_id",
-                    "product_uom_id",
-                    "quantity",
-                    "price_unit",
-                    "tax_ids",
-                    # Already get
-                    "sale_line_ids",
-                    "anlytic_distribution",
-                    # another fields
-                    "__last_update",
-                    "display_name",
-                }
                 sale_line_values_rm = {
                     k: sale_line_values[k]
-                    for k in set(sale_line_values) - vals_to_remove
+                    for k in set(sale_line_values)
+                    - self._get_fields_not_used_from_sale_line()
                 }
                 values.update(sale_line_values_rm)
 


### PR DESCRIPTION
Foward Port https://github.com/OCA/account-invoicing/pull/1906

Included a method to allow other modules inform the Fields that should not be used from Sale 'prepare' methods, there are cases where Localization Projects or maybe custom modules need to remove some fields, for example to give priority to the fields came from stock.picking instead of from sale.order.

This change not affect the actual behavior just move parts of the code for this new method to be able inherit it.