### PR TITLE
[16.0][FIX] sale_order_invoicing_grouping_criteria: Post-install test + fallback to load CoA

### DIFF
--- a/sale_order_invoicing_grouping_criteria/tests/test_sale_order_invoicing_group_criteria.py
+++ b/sale_order_invoicing_grouping_criteria/tests/test_sale_order_invoicing_group_criteria.py
@@ -1,9 +1,10 @@
 # Copyright 2019 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo.tests import TransactionCase
+from odoo.tests import TransactionCase, tagged
 
 
+@tagged("post_install", "-at_install")
 class TestSaleOrderInvoicingGroupingCriteria(TransactionCase):
     @classmethod
     def setUpClass(cls):
@@ -19,6 +20,15 @@ class TestSaleOrderInvoicingGroupingCriteria(TransactionCase):
             )
         )
         cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        if not cls.env.company.chart_template_id:
+            # Load a CoA if there's none in current company
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                # Load the first available CoA
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            coa.try_loading(company=cls.env.company, install_demo=False)
         cls.partner = cls.env["res.partner"].create({"name": "Test partner"})
         cls.partner2 = cls.env["res.partner"].create({"name": "Other partner"})
         cls.product = cls.env["product.product"].create(


### PR DESCRIPTION
Since odoo/odoo@d0342c8, the default existing company is not getting a CoA automatically, provoking than the current tests fail with the error:

```
odoo.exceptions.UserError: No journal could be found in company My Company (San Francisco) for any of those types: sale
```

Thus, we put tests post-install for being sure localization modules are installed, the same as AccountTestInvoicingCommon does, but we don't inherit from it, as it creates an overhead creating 2 new companies and loading their CoA and some more stuff, while we don't need all of that.

Besides, if you don't have `l10n_generic_coa` installed, you can't use another CoA (like `l10n_es`) easily, so we put little code to select the first available CoA.

@Tecnativa 