### PR TITLE
[16.0][FIX] account_invoice_pricelist + sale_timesheet_invoice_description: Post-install test + fallback to load CoA

### DIFF
--- a/account_invoice_pricelist/tests/test_account_move_pricelist.py
+++ b/account_invoice_pricelist/tests/test_account_move_pricelist.py
@@ -1,14 +1,25 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo.exceptions import UserError
+from odoo.tests import tagged
 
 from odoo.addons.base.tests.common import BaseCommon
 
 
+@tagged("-at_install", "post_install")
 class TestAccountMovePricelist(BaseCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        if not cls.env.company.chart_template_id:
+            # Load a CoA if there's none in current company
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                # Load the first available CoA
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            coa.try_loading(company=cls.env.company, install_demo=False)
         cls.AccountMove = cls.env["account.move"]
         cls.ProductPricelist = cls.env["product.pricelist"]
         cls.FiscalPosition = cls.env["account.fiscal.position"]

--- a/sale_timesheet_invoice_description/tests/test_sale_timesheet_description.py
+++ b/sale_timesheet_invoice_description/tests/test_sale_timesheet_description.py
@@ -4,14 +4,24 @@
 
 from datetime import datetime
 
-from odoo.tests import common
+from odoo.tests import common, tagged
 from odoo.tools.float_utils import float_compare
 
 
+@tagged("-at_install", "post_install")
 class TestSaleTimesheetDescription(common.TransactionCase):
     @classmethod
     def setUpClass(cls):
         super(TestSaleTimesheetDescription, cls).setUpClass()
+        if not cls.env.company.chart_template_id:
+            # Load a CoA if there's none in current company
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                # Load the first available CoA
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            coa.try_loading(company=cls.env.company, install_demo=False)
         # Make sure user is in English
         cls.env.user.lang = "en_US"
         cls.partner = cls.env["res.partner"].create({"name": "Test partner"})


### PR DESCRIPTION
Since odoo/odoo@d0342c8, the default existing company is not getting a CoA automatically, provoking than the current tests fail with the error:

`odoo.exceptions.UserError: No journal could be found in company My Company (San Francisco) for any of those types: sale`

Thus, we put tests post-install for being sure localization modules are installed, the same as AccountTestInvoicingCommon does, but we don't inherit from it, as it creates an overhead creating 2 new companies and loading their CoA and some more stuff, while we don't need all of that.

Besides, if you don't have `l10n_generic_coa` installed, you can't use another CoA (like `l10n_es`) easily, so we put little code to select the first available CoA.

@Tecnativa