### PR TITLE
[16.0][FIX] account invoice triple discount report after refactoring

### DIFF
--- a/account_invoice_triple_discount/report/invoice.xml
+++ b/account_invoice_triple_discount/report/invoice.xml
@@ -10,6 +10,18 @@
         </xpath>
         <xpath expr="//t[@t-set='display_discount']" position="after">
             <t
+                t-set="display_discount1"
+                t-value="any(l.discount1 for l in o.invoice_line_ids)"
+            />
+            <t
+                t-set="display_discount2"
+                t-value="any(l.discount2 for l in o.invoice_line_ids)"
+            />
+            <t
+                t-set="display_discount3"
+                t-value="any(l.discount3 for l in o.invoice_line_ids)"
+            />
+            <t
                 t-set="discount_class"
                 t-value="'text-end %s' % ('d-none d-md-table-cell' if report_type == 'html' else '')"
             />
@@ -17,34 +29,34 @@
         <xpath expr="//th[@name='th_price_unit']" position="after">
             <th
                 name="th_discount1"
-                t-if="display_discount"
+                t-if="display_discount1"
                 t-att-class="discount_class"
             >
-                <span>Disc.1 %</span>
+                <span>Disc.%</span>
             </th>
             <th
                 name="th_discount2"
-                t-if="display_discount"
+                t-if="display_discount2"
                 t-att-class="discount_class"
             >
                 <span>Disc.2 %</span>
             </th>
             <th
                 name="th_discount3"
-                t-if="display_discount"
+                t-if="display_discount3"
                 t-att-class="discount_class"
             >
                 <span>Disc.3 %</span>
             </th>
         </xpath>
         <xpath expr="//td[span[@t-field='line.discount']]" position="after">
-            <td t-if="display_discount" t-att-class="discount_class">
+            <td t-if="display_discount1" t-att-class="discount_class">
                 <span class="text-nowrap" t-field="line.discount1" />
             </td>
-            <td t-if="display_discount" t-att-class="discount_class">
+            <td t-if="display_discount2" t-att-class="discount_class">
                 <span class="text-nowrap" t-field="line.discount2" />
             </td>
-            <td t-if="display_discount" t-att-class="discount_class">
+            <td t-if="display_discount3" t-att-class="discount_class">
                 <span class="text-nowrap" t-field="line.discount3" />
             </td>
         </xpath>

--- a/account_invoice_triple_discount/report/invoice.xml
+++ b/account_invoice_triple_discount/report/invoice.xml
@@ -14,9 +14,6 @@
                 t-value="'text-end %s' % ('d-none d-md-table-cell' if report_type == 'html' else '')"
             />
         </xpath>
-        <xpath expr="//th[@name='th_price_unit']" position="attributes">
-            <attribute name="style">visibility: hidden;</attribute>
-        </xpath>
         <xpath expr="//th[@name='th_price_unit']" position="after">
             <th
                 name="th_discount1"
@@ -39,9 +36,6 @@
             >
                 <span>Disc.3 %</span>
             </th>
-        </xpath>
-        <xpath expr="//td[span[@t-field='line.discount']]" position="attributes">
-            <attribute name="style">visibility: hidden;</attribute>
         </xpath>
         <xpath expr="//td[span[@t-field='line.discount']]" position="after">
             <td t-if="display_discount" t-att-class="discount_class">


### PR DESCRIPTION
- [FIX] account_invoice_triple_discount: do not hide column that are hidden, because display_discount is False
- [FIX] account_invoice_triple_discount: discounts fields was hidden, because was t-if display_discount (that is False).
- [IMP] account_invoice_triple_discount: display only discount column with not null discount

This is regression introduced by #1638 / #1840.

CC : @grindtildeath