### PR TITLE
[15.0][FIX] account_invoice_anglo_saxon_no_cogs_deferral: tests

### DIFF
--- a/account_invoice_anglo_saxon_no_cogs_deferral/tests/test_account_invoice_anglo_saxon_no_cogs_deferral.py
+++ b/account_invoice_anglo_saxon_no_cogs_deferral/tests/test_account_invoice_anglo_saxon_no_cogs_deferral.py
@@ -18,11 +18,18 @@ class TestAccountAngloSaxonNoCogsDeferral(TransactionCase):
         self.supplier_location = self.env.ref("stock.stock_location_suppliers")
         self.uom_unit = self.env.ref("uom.product_uom_unit")
         self.partner = self.env["res.partner"].create({"name": "Test partner"})
+        self.categ = self.env["product.category"].create(
+            {
+                "name": "Test category",
+                "property_valuation": "real_time",
+                "property_cost_method": "fifo",
+            }
+        )
         self.product1 = self.env["product.product"].create(
             {
                 "name": "Product A",
                 "type": "product",
-                "categ_id": self.env.ref("product.product_category_all").id,
+                "categ_id": self.categ.id,
                 "standard_price": 5,
             }
         )


### PR DESCRIPTION
Branch 15.0 is read because of this!

The reason was the rely on the demo data product category all, values were changed in the middle.