### PR TITLE
[18.0][FIX] account_invoice_pricelist - pricelist_id set as not readonly and compute update not triggered when already filled

### DIFF
--- a/account_invoice_pricelist/models/account_move.py
+++ b/account_invoice_pricelist/models/account_move.py
@@ -15,6 +15,7 @@ class AccountMove(models.Model):
         tracking=True,
         store=True,
         precompute=True,
+        readonly=False,
     )
 
     @api.constrains("pricelist_id", "currency_id")
@@ -39,6 +40,7 @@ class AccountMove(models.Model):
                 invoice.partner_id
                 and invoice.is_sale_document()
                 and invoice.partner_id.property_product_pricelist
+                and not invoice.pricelist_id
             ):
                 invoice.pricelist_id = invoice.partner_id.property_product_pricelist
 


### PR DESCRIPTION
In the child module account_invoice_pricelist_sale, adding the pricelist to the invoice from the sale order is broken.

Related in 17.0 : https://github.com/OCA/account-invoicing/pull/1981

Needed for https://github.com/OCA/account-invoicing/pull/1959