### PR TITLE
[16.0][IMP] account_billing: Add billing_ids to invoice list and multi-company record rule

### DIFF
--- a/account_billing/__manifest__.py
+++ b/account_billing/__manifest__.py
@@ -14,6 +14,7 @@
         "data/account_billing_sequence.xml",
         "data/server_action.xml",
         "security/ir.model.access.csv",
+        "security/account_billing_security.xml",
         "views/account_billing_views.xml",
         "views/account_move_views.xml",
         "report/report_billing.xml",

--- a/account_billing/security/account_billing_security.xml
+++ b/account_billing/security/account_billing_security.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+    <record id="account_billing_company_rule" model="ir.rule">
+        <field name="name">Account Billing Multi-company</field>
+        <field name="model_id" ref="model_account_billing" />
+        <field
+            name="domain_force"
+        >['|', ('company_id', 'in', company_ids), ('company_id', '=', False)]</field>
+    </record>
+</odoo>

--- a/account_billing/static/description/index.html
+++ b/account_billing/static/description/index.html
@@ -8,11 +8,10 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
+:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
-Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +274,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: gray; } /* line numbers */
+pre.code .ln { color: grey; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +300,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic, pre.problematic {
+span.problematic {
   color: red }
 
 span.section-subtitle {
@@ -447,9 +446,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h3><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h3>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org">
-<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
-</a>
+<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/account_billing/tests/test_account_billing.py
+++ b/account_billing/tests/test_account_billing.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 from dateutil.relativedelta import relativedelta
 
-from odoo import fields
+from odoo import Command, fields
 from odoo.exceptions import UserError, ValidationError
 from odoo.tests import tagged
 
@@ -224,3 +224,23 @@ class TestAccountBilling(AccountTestInvoicingCommon):
         customer_billing = self.billing_model.browse(action["res_id"])
         self.assertEqual(customer_billing.currency_id.id, self.currency_eur_id)
         self.assertEqual(self.env.company.currency_id.id, self.currency_usd_id)
+
+    def test_7_record_rule_company_restriction(self):
+        other_company = self.env["res.company"].create({"name": "Other Company"})
+        billing_other = self.billing_model.with_company(other_company).create(
+            {
+                "bill_type": "out_invoice",
+                "partner_id": self.partner_a.id,
+                "currency_id": self.currency_eur_id,
+                "threshold_date": datetime.now(),
+                "threshold_date_type": "invoice_date_due",
+                "company_id": other_company.id,
+            }
+        )
+        self.env.user.company_ids = [Command.set([self.env.company.id])]
+        billing = self.billing_model.search([("id", "=", billing_other.id)])
+        self.assertFalse(billing, "Billing from another company should not be visible")
+        billing_with_sudo = self.billing_model.sudo().search(
+            [("id", "=", billing_other.id)]
+        )
+        self.assertTrue(billing_with_sudo, "Sudo should bypass company record rule")

--- a/account_billing/tests/test_account_billing.py
+++ b/account_billing/tests/test_account_billing.py
@@ -170,7 +170,8 @@ class TestAccountBilling(AccountTestInvoicingCommon):
             bill1.validate_billing()
 
         bill1.compute_lines()
-
+        # In case _compute_billing_ids is not triggered again after compute_lines.
+        bill1.billing_line_ids.mapped("move_id")._compute_billing_ids()
         self.assertEqual(bill1.invoice_related_count, 2)
         self.assertEqual(bill1.billing_line_ids.mapped("move_id.billing_ids"), bill1)
 

--- a/account_billing/views/account_move_views.xml
+++ b/account_billing/views/account_move_views.xml
@@ -13,4 +13,14 @@
             </xpath>
         </field>
     </record>
+    <record id="view_invoice_tree" model="ir.ui.view">
+        <field name="name">account.invoice.tree</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_invoice_tree" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='invoice_origin']" position="before">
+                <field name="billing_ids" widget="many2many_tags" optional="hide" />
+            </xpath>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
This PR does the following:

- **Add billing_ids to invoice list**

![Screenshot 2025-05-07 151114](https://github.com/user-attachments/assets/3e86a5e3-7806-47e6-81a7-90c3e52bd948)

- **Add multi-company record rule**

This is the billing created for YourCompany.

![Screenshot 2025-05-07 174310](https://github.com/user-attachments/assets/ac074908-1350-4472-8fa8-236f7dcfa777)

This is not able to see from another company.

![Screenshot 2025-05-07 151657](https://github.com/user-attachments/assets/a9fdf2b6-d0e2-4b81-8861-5777e691fa09)


@qrtl QT5339 QT5371