### PR TITLE
[16.0][IMP]: account_invoice_section_sale_order add option to order section on the invoice

### DIFF
--- a/account_invoice_section_sale_order/models/res_company.py
+++ b/account_invoice_section_sale_order/models/res_company.py
@@ -21,3 +21,9 @@ class ResCompany(models.Model):
         default="sale_order",
         required=True,
     )
+
+    invoice_section_order_chronological = fields.Boolean(
+        string="Invoice section order chronological",
+        help="If checked, the invoice sections will be ordered "
+        "chronologically when creating invoice for muliple sale orders ",
+    )

--- a/account_invoice_section_sale_order/models/res_config_settings.py
+++ b/account_invoice_section_sale_order/models/res_config_settings.py
@@ -17,3 +17,8 @@ class ResConfigSettings(models.TransientModel):
         readonly=False,
         required=True,
     )
+
+    invoice_section_order_chronological = fields.Boolean(
+        related="company_id.invoice_section_order_chronological",
+        readonly=False,
+    )

--- a/account_invoice_section_sale_order/models/sale_order.py
+++ b/account_invoice_section_sale_order/models/sale_order.py
@@ -30,6 +30,10 @@ class SaleOrder(models.Model):
             for move_line in move_lines:
                 group = move_line._get_section_group()
                 section_grouping_matrix.setdefault(group, []).append(move_line.id)
+            if invoice.company_id.invoice_section_order_chronological:
+                section_grouping_matrix = OrderedDict(
+                    reversed(list(section_grouping_matrix.items()))
+                )
             # Prepare section lines for each group
             section_lines = []
             for group, move_line_ids in section_grouping_matrix.items():

--- a/account_invoice_section_sale_order/views/res_config_settings.xml
+++ b/account_invoice_section_sale_order/views/res_config_settings.xml
@@ -35,6 +35,21 @@
                         </div>
                     </div>
                 </div>
+                <div
+                    class="col-12 col-lg-6 o_setting_box"
+                    id="invoice_section_sale_order_ordering"
+                    groups="account_invoice_section_sale_order.group_sale_order_invoice_section_name"
+                >
+                    <div class="o_setting_left_pane">
+                        <field name="invoice_section_order_chronological" />
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label for="invoice_section_order_chronological" />
+                        <div class="text-muted">
+                            If checked, the invoice sections will be ordered chronologically
+                        </div>
+                    </div>
+                </div>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Currently, the module is creating the invoice section from the oldest to the newest sale.order

![sectionorder](https://github.com/user-attachments/assets/3181e2f0-c24d-4ab6-8412-abfdcb748645)
as here in the runbot 

We want to be able to sort the section in the chronological order. 

