### PR TITLE
[14.0] [IMP] stock_picking_invoicing: restrict picking cancellation

### DIFF
--- a/stock_picking_invoicing/README.rst
+++ b/stock_picking_invoicing/README.rst
@@ -31,6 +31,10 @@ Stock Picking Invoicing
 This module allows to create invoices directly from picking, without having to
 use sale or purchase orders.
 
+Additionally, the cancellation of stock moves already linked to invoices or
+bills is restricted to users who belong to the "Allow to cancel stock moves
+linked to invoices/bills" group.
+
 **Table of contents**
 
 .. contents::
@@ -52,9 +56,15 @@ To use this module, you need to:
 #. Into the Tree view, you can select many pickings and create a grouped invoice;
 #. If at least an invoice is created for a picking, a new "Invoicing" tab appears.
 
-
 If an invoice (not refund) is cancelled or deleted, invoice status of related picking is automatically
 updated to "To be invoiced".
+
+Also about the cancellation of stock moves linked to invoices/bills:
+
+* Attempt to cancel a picking linked to invoices/bills.
+* If the user is not part of the group "Allow to cancel stock move linked to invoice/bill",
+  an error will be raised, preventing the cancellation.
+* Members of the group can proceed with the cancellation without restrictions.
 
 Changelog
 =========

--- a/stock_picking_invoicing/__manifest__.py
+++ b/stock_picking_invoicing/__manifest__.py
@@ -10,6 +10,7 @@
     "depends": ["stock", "account", "stock_picking_invoice_link"],
     "data": [
         "security/ir.model.access.csv",
+        "security/stock_picking_invoicing_security.xml",
         "wizards/stock_invoice_onshipping_view.xml",
         "wizards/stock_return_picking_view.xml",
         "views/stock_move.xml",

--- a/stock_picking_invoicing/i18n/ca.po
+++ b/stock_picking_invoicing/i18n/ca.po
@@ -303,6 +303,14 @@ msgid "True"
 msgstr ""
 
 #. module: stock_picking_invoicing
+#: code:addons/stock_picking_invoicing/models/stock_move.py:0
+#, python-format
+msgid ""
+"You cannot cancel a stock move linked to invoices/bills. Only members of the "
+"\"%(group_name)s\" group can perform this action. References: %(references)s"
+msgstr ""
+
+#. module: stock_picking_invoicing
 #: model_terms:ir.ui.view,arch_db:stock_picking_invoicing.view_stock_invoice_onshipping
 msgid "or"
 msgstr ""

--- a/stock_picking_invoicing/i18n/de.po
+++ b/stock_picking_invoicing/i18n/de.po
@@ -303,6 +303,14 @@ msgid "True"
 msgstr ""
 
 #. module: stock_picking_invoicing
+#: code:addons/stock_picking_invoicing/models/stock_move.py:0
+#, python-format
+msgid ""
+"You cannot cancel a stock move linked to invoices/bills. Only members of the "
+"\"%(group_name)s\" group can perform this action. References: %(references)s"
+msgstr ""
+
+#. module: stock_picking_invoicing
 #: model_terms:ir.ui.view,arch_db:stock_picking_invoicing.view_stock_invoice_onshipping
 msgid "or"
 msgstr ""

--- a/stock_picking_invoicing/i18n/es.po
+++ b/stock_picking_invoicing/i18n/es.po
@@ -313,9 +313,16 @@ msgid "True"
 msgstr "Verdadero"
 
 #. module: stock_picking_invoicing
+#: code:addons/stock_picking_invoicing/models/stock_move.py:0
+#, python-format
+msgid ""
+"You cannot cancel a stock move linked to invoices/bills. Only members of the "
+"\"%(group_name)s\" group can perform this action. References: %(references)s"
+msgstr ""
+"No puede cancelar un movimiento de stock vinculado a facturas. Solo los miembros del "
+"grupo \"%(group_name)s\" pueden realizar esta acción. Referencias: %(references)s"
+
+#. module: stock_picking_invoicing
 #: model_terms:ir.ui.view,arch_db:stock_picking_invoicing.view_stock_invoice_onshipping
 msgid "or"
 msgstr "o"
-
-#~ msgid "Invoice"
-#~ msgstr "Factura"

--- a/stock_picking_invoicing/i18n/fr.po
+++ b/stock_picking_invoicing/i18n/fr.po
@@ -324,41 +324,16 @@ msgid "True"
 msgstr ""
 
 #. module: stock_picking_invoicing
+#: code:addons/stock_picking_invoicing/models/stock_move.py:0
+#, python-format
+msgid ""
+"You cannot cancel a stock move linked to invoices/bills. Only members of the "
+"\"%(group_name)s\" group can perform this action. References: %(references)s"
+msgstr ""
+"Vous ne pouvez pas annuler un mouvement de stock lié à des factures. Seuls les membres du "
+"groupe \"%(group_name)s\" peuvent effectuer cette action. Références : %(references)s"
+
+#. module: stock_picking_invoicing
 #: model_terms:ir.ui.view,arch_db:stock_picking_invoicing.view_stock_invoice_onshipping
 msgid "or"
 msgstr "ou"
-
-#~ msgid "Invoice"
-#~ msgstr "Facture"
-
-#~ msgid "Invoice Line"
-#~ msgstr "Ligne de facture"
-
-#~ msgid "Invoice ids"
-#~ msgstr "Factures"
-
-#~ msgid "Picking ids"
-#~ msgstr "Pickings"
-
-#~ msgid "Purchase refund journal"
-#~ msgstr "Journal note de crédits d'achat"
-
-#, fuzzy
-#~ msgid "Sale refund journal"
-#~ msgstr "Journal note de crédits d'achat"
-
-#, fuzzy
-#~ msgid "Show Refund Purchase Journal"
-#~ msgstr "Journal d'achat"
-
-#~ msgid "Stock moves"
-#~ msgstr "Mouvements de stock"
-
-#~ msgid "Procurement"
-#~ msgstr "Approvisionnement"
-
-#~ msgid "Procurement Rule"
-#~ msgstr "Règle d'approvisionnement"
-
-#~ msgid "Pushed Flow"
-#~ msgstr "Flux poussés"

--- a/stock_picking_invoicing/i18n/it.po
+++ b/stock_picking_invoicing/i18n/it.po
@@ -93,7 +93,8 @@ msgid ""
 "Group pickings/moves to create invoice(s):\n"
 "Picking: One invoice per picking;\n"
 "Partner: One invoice for each picking's partner;\n"
-"Partner/Product: One invoice per picking's partner and group product into a single invoice line."
+"Partner/Product: One invoice per picking's partner and group product into a "
+"single invoice line."
 msgstr ""
 
 #. module: stock_picking_invoicing
@@ -299,6 +300,14 @@ msgstr ""
 #. module: stock_picking_invoicing
 #: model_terms:ir.ui.view,arch_db:stock_picking_invoicing.view_picking_form
 msgid "True"
+msgstr ""
+
+#. module: stock_picking_invoicing
+#: code:addons/stock_picking_invoicing/models/stock_move.py:0
+#, python-format
+msgid ""
+"You cannot cancel a stock move linked to invoices/bills. Only members of the "
+"\"%(group_name)s\" group can perform this action. References: %(references)s"
 msgstr ""
 
 #. module: stock_picking_invoicing

--- a/stock_picking_invoicing/i18n/pt_BR.po
+++ b/stock_picking_invoicing/i18n/pt_BR.po
@@ -314,9 +314,17 @@ msgid "True"
 msgstr "Verdadeiro"
 
 #. module: stock_picking_invoicing
+#: code:addons/stock_picking_invoicing/models/stock_move.py:0
+#, python-format
+msgid ""
+"You cannot cancel a stock move linked to invoices/bills. Only members of the "
+"\"%(group_name)s\" group can perform this action. References: %(references)s"
+msgstr ""
+"Você não pode cancelar um movimento de estoque vinculado a faturas/contas. "
+"Apenas membros do grupo \"%(group_name)s\" podem realizar esta ação. "
+"Referências: %(references)s"
+
+#. module: stock_picking_invoicing
 #: model_terms:ir.ui.view,arch_db:stock_picking_invoicing.view_stock_invoice_onshipping
 msgid "or"
 msgstr "ou"
-
-#~ msgid "Invoice"
-#~ msgstr "Fatura"

--- a/stock_picking_invoicing/i18n/sl.po
+++ b/stock_picking_invoicing/i18n/sl.po
@@ -17,8 +17,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || "
-"n%100==4 ? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n"
+"%100==4 ? 2 : 3);\n"
 
 #. module: stock_picking_invoicing
 #: code:addons/stock_picking_invoicing/wizards/stock_invoice_onshipping.py:0
@@ -318,22 +318,16 @@ msgid "True"
 msgstr ""
 
 #. module: stock_picking_invoicing
+#: code:addons/stock_picking_invoicing/models/stock_move.py:0
+#, python-format
+msgid ""
+"You cannot cancel a stock move linked to invoices/bills. Only members of the "
+"\"%(group_name)s\" group can perform this action. References: %(references)s"
+msgstr ""
+"Ne morete preklicati premika zaloge, povezanega z računi/dobropisi. To dejanje "
+"lahko izvedejo samo člani skupine \"%(group_name)s\". Reference: %(references)s"
+
+#. module: stock_picking_invoicing
 #: model_terms:ir.ui.view,arch_db:stock_picking_invoicing.view_stock_invoice_onshipping
 msgid "or"
 msgstr ""
-
-#~ msgid ""
-#~ "Can't update invoice control for picking %s: It's 'to be invoiced' yet"
-#~ msgstr ""
-#~ "Nadzora obračuna za zbirnik %s ni mogoče posodobiti: ni še zaračunan"
-
-#~ msgid "Picking %s has linked invoice %s"
-#~ msgstr "Zbirnik %s je povezan z računom %s"
-
-#, fuzzy
-#~ msgid "Picking ids"
-#~ msgstr "Zbirni seznam"
-
-#, fuzzy
-#~ msgid "Stock moves"
-#~ msgstr "Premik zaloge"

--- a/stock_picking_invoicing/i18n/stock_picking_invoicing.pot
+++ b/stock_picking_invoicing/i18n/stock_picking_invoicing.pot
@@ -301,6 +301,15 @@ msgid "True"
 msgstr ""
 
 #. module: stock_picking_invoicing
+#: code:addons/stock_picking_invoicing/models/stock_move.py:0
+#, python-format
+msgid ""
+"You cannot cancel a stock move linked to invoices/bills. Only members of the"
+" \"%(group_name)s\" group can perform this action. References: "
+"%(references)s"
+msgstr ""
+
+#. module: stock_picking_invoicing
 #: model_terms:ir.ui.view,arch_db:stock_picking_invoicing.view_stock_invoice_onshipping
 msgid "or"
 msgstr ""

--- a/stock_picking_invoicing/models/stock_move.py
+++ b/stock_picking_invoicing/models/stock_move.py
@@ -1,7 +1,8 @@
 # Copyright (C) 2019-Today: Odoo Community Association (OCA)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
 
 
 class StockMove(models.Model):
@@ -75,3 +76,39 @@ class StockMove(models.Model):
         values = super()._prepare_move_split_vals(uom_qty)
         values["invoice_state"] = self.invoice_state
         return values
+
+    def _action_cancel(self):
+        res = super()._action_cancel()
+        # The allowed group is defined in a noupdate xml data section.
+        # This means that if someone updates the module to get this feature,
+        # the group won't be created.
+        allowed_group = self.env.ref(
+            "stock_picking_invoicing.group_allow_to_cancel_stock_move_linked_to_invoice_bill",
+            raise_if_not_found=False,
+        )
+        if allowed_group:
+            # done moves out, built-in workflow deals with them,
+            # also out moves linked to cancelled journal items
+            moves = self.filtered(
+                lambda it: it.state != "done"
+                and it.invoice_line_ids.filtered(
+                    lambda inv_line: inv_line.move_id.state != "cancel"
+                )
+            )
+            if moves:
+                if allowed_group not in self.env.user.groups_id:
+                    move_references = ",".join(
+                        moves.mapped(
+                            lambda it: f"{it.reference}({it.product_id.default_code})"
+                        )
+                    )
+                    raise UserError(
+                        _(
+                            "You cannot cancel a stock move linked to invoices/bills. "
+                            'Only members of the "%(group_name)s" group can perform '
+                            "this action. References: %(references)s",
+                            group_name=allowed_group.name,
+                            references=move_references,
+                        )
+                    )
+        return res

--- a/stock_picking_invoicing/readme/DESCRIPTION.rst
+++ b/stock_picking_invoicing/readme/DESCRIPTION.rst
@@ -1,2 +1,6 @@
 This module allows to create invoices directly from picking, without having to
 use sale or purchase orders.
+
+Additionally, the cancellation of stock moves already linked to invoices or
+bills is restricted to users who belong to the "Allow to cancel stock moves
+linked to invoices/bills" group.

--- a/stock_picking_invoicing/readme/USAGE.rst
+++ b/stock_picking_invoicing/readme/USAGE.rst
@@ -5,6 +5,12 @@ To use this module, you need to:
 #. Into the Tree view, you can select many pickings and create a grouped invoice;
 #. If at least an invoice is created for a picking, a new "Invoicing" tab appears.
 
-
 If an invoice (not refund) is cancelled or deleted, invoice status of related picking is automatically
 updated to "To be invoiced".
+
+Also about the cancellation of stock moves linked to invoices/bills:
+
+* Attempt to cancel a picking linked to invoices/bills.
+* If the user is not part of the group "Allow to cancel stock move linked to invoice/bill",
+  an error will be raised, preventing the cancellation.
+* Members of the group can proceed with the cancellation without restrictions.

--- a/stock_picking_invoicing/security/stock_picking_invoicing_security.xml
+++ b/stock_picking_invoicing/security/stock_picking_invoicing_security.xml
@@ -1,0 +1,18 @@
+<odoo noupdate="1">
+    <!-- This raises the question of how to handle already installed deployments. Setting noupdate="1" would cause this to be ignored. -->
+    <record
+        id="group_allow_to_cancel_stock_move_linked_to_invoice_bill"
+        model="res.groups"
+    >
+        <field name="name">Allow to cancel stock moves linked to invoices/bills</field>
+        <field name="category_id" ref="base.module_category_hidden" />
+        <field name="users" eval="[(4, ref('base.user_root'))]" />
+    </record>
+
+    <record id="stock.group_stock_manager" model="res.groups">
+        <field
+            name="implied_ids"
+            eval="[(4, ref('group_allow_to_cancel_stock_move_linked_to_invoice_bill'))]"
+        />
+    </record>
+</odoo>

--- a/stock_picking_invoicing/static/description/index.html
+++ b/stock_picking_invoicing/static/description/index.html
@@ -372,6 +372,9 @@ ul.auto-toc {
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/account-invoicing/tree/14.0/stock_picking_invoicing"><img alt="OCA/account-invoicing" src="https://img.shields.io/badge/github-OCA%2Faccount--invoicing-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/account-invoicing-14-0/account-invoicing-14-0-stock_picking_invoicing"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/account-invoicing&amp;target_branch=14.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
 <p>This module allows to create invoices directly from picking, without having to
 use sale or purchase orders.</p>
+<p>Additionally, the cancellation of stock moves already linked to invoices or
+bills is restricted to users who belong to the “Allow to cancel stock moves
+linked to invoices/bills” group.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -409,6 +412,13 @@ use sale or purchase orders.</p>
 </ol>
 <p>If an invoice (not refund) is cancelled or deleted, invoice status of related picking is automatically
 updated to “To be invoiced”.</p>
+<p>Also about the cancellation of stock moves linked to invoices/bills:</p>
+<ul class="simple">
+<li>Attempt to cancel a picking linked to invoices/bills.</li>
+<li>If the user is not part of the group “Allow to cancel stock move linked to invoice/bill”,
+an error will be raised, preventing the cancellation.</li>
+<li>Members of the group can proceed with the cancellation without restrictions.</li>
+</ul>
 </div>
 <div class="section" id="changelog">
 <h1><a class="toc-backref" href="#toc-entry-3">Changelog</a></h1>

--- a/stock_picking_invoicing/tests/test_picking_invoicing.py
+++ b/stock_picking_invoicing/tests/test_picking_invoicing.py
@@ -1,8 +1,9 @@
 # Copyright (C) 2019-Today: Odoo Community Association (OCA)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import exceptions
-from odoo.tests import Form, SavepointCase, tagged
+from odoo.exceptions import UserError
+from odoo.tests import Form, SavepointCase, new_test_user, tagged
+from odoo.tools import mute_logger
 
 
 @tagged("post_install", "-at_install")
@@ -57,16 +58,32 @@ class TestPickingInvoicing(SavepointCase):
         )
 
         cls.tax_sale_1 = cls.tax_model.create(
-            {"name": "Sale tax 20", "type_tax_use": "sale", "amount": "20.00"}
+            {
+                "name": "Sale tax 20",
+                "type_tax_use": "sale",
+                "amount": "20.00",
+            }
         )
         cls.tax_sale_2 = cls.tax_model.create(
-            {"name": "Sale tax 10", "type_tax_use": "sale", "amount": "10.00"}
+            {
+                "name": "Sale tax 10",
+                "type_tax_use": "sale",
+                "amount": "10.00",
+            }
         )
         cls.tax_purchase_1 = cls.tax_model.create(
-            {"name": "Purchase tax 10", "type_tax_use": "purchase", "amount": "10.00"}
+            {
+                "name": "Purchase tax 10",
+                "type_tax_use": "purchase",
+                "amount": "10.00",
+            }
         )
         cls.tax_purchase_2 = cls.tax_model.create(
-            {"name": "Purchase tax 20", "type_tax_use": "purchase", "amount": "20.00"}
+            {
+                "name": "Purchase tax 20",
+                "type_tax_use": "purchase",
+                "amount": "20.00",
+            }
         )
 
         cls.product_test_1 = cls.product_model.create(
@@ -193,7 +210,7 @@ class TestPickingInvoicing(SavepointCase):
         wizard_values = wizard_obj.default_get(fields_list)
         wizard = wizard_obj.create(wizard_values)
         wizard.onchange_group()
-        with self.assertRaises(exceptions.UserError) as e:
+        with self.assertRaises(UserError) as e:
             wizard.with_context(lang="en_US").action_generate()
         msg = "No invoice created!"
         self.assertIn(msg, e.exception.args[0])
@@ -401,7 +418,7 @@ class TestPickingInvoicing(SavepointCase):
                 )
             self.assertTrue(inv_line.tax_ids, "Error to map Sale Tax in invoice.line.")
 
-    def test_picking_cancel(self):
+    def test_invoice_cancel(self):
         """
         Ensure that the invoice_state of the picking is correctly
         updated when an invoice is cancelled
@@ -945,3 +962,58 @@ class TestPickingInvoicing(SavepointCase):
             "in_refund",
             "Invoice Type should be In Refund",
         )
+
+    @mute_logger("odoo.addons.auth_signup.models.res_users")
+    def test_picking_cancel(self):
+        self.partner.write({"type": "invoice"})
+        picking = self.picking_model.create(
+            {
+                "partner_id": self.partner2.id,
+                "picking_type_id": self.pick_type_out.id,
+                "location_id": self.stock_location.id,
+                "location_dest_id": self.customers_location.id,
+            }
+        )
+        move_vals = {
+            "product_id": self.product_test_1.id,
+            "picking_id": picking.id,
+            "location_dest_id": self.customers_location.id,
+            "location_id": self.stock_location.id,
+            "name": self.product_test_1.name,
+            "product_uom_qty": 2,
+            "product_uom": self.product_test_1.uom_id.id,
+        }
+        new_move = self.move_model.create(move_vals)
+        new_move.onchange_product_id()
+        picking.set_to_be_invoiced()
+        picking.action_confirm()
+        # Check product availability
+        picking.action_assign()
+        # Force product availability
+        picking.button_validate()
+        wizard_obj = self.invoice_wizard.with_context(
+            active_ids=picking.ids,
+            active_model=picking._name,
+            active_id=picking.id,
+        )
+        fields_list = wizard_obj.fields_get().keys()
+        wizard_values = wizard_obj.default_get(fields_list)
+        wizard = wizard_obj.create(wizard_values)
+        wizard.onchange_group()
+        wizard.action_generate()
+
+        regular_user = new_test_user(
+            self.env,
+            login="regular_user",
+            groups="stock.group_stock_user,account.group_account_invoice",
+        )
+
+        # regular user cancel should raise UserError
+        with self.assertRaises(UserError):
+            picking.with_user(regular_user).action_cancel()
+
+        self.assertFalse(picking.state == "cancel")
+
+        # priviled user cancel should work as expected
+        picking.action_cancel()
+        self.assertTrue(picking.state == "cancel")


### PR DESCRIPTION
This PR proposes an improvement to the `stock_picking_invoicing` addon by introducing a restriction to prevent the cancellation of stock moves already linked to invoices or vendor bills. Only users who are members of the **"Allow to cancel stock moves linked to invoices/bills"** group will be authorized to perform this action.

## Why Restrict Cancelling Stock Moves Linked to Invoices/Bills

- **Data Integrity**: Prevents inconsistencies between inventory and accounting.
- **Controlled Access**: Cancellation is still allowed, but only for users in the designated security group.
- **Legal and Financial Compliance**: Avoids issues with invoiced or billed records.
- **Auditability**: Maintains a clear and traceable record of exceptional actions.
- **Best Practice**: Encourages using proper workflows like credit notes or returns.

## ROADMAP

- [x] Create security group
- [x] Restrict cancellation at the stock move model level
- [x] Update translations
- [x] Create a test

@BinhexTeam