### PR TITLE
[16.0][FIX] account_invoice_tax_note, account_invoice_tax_required: category in manifest files

### DIFF
--- a/account_invoice_tax_note/__manifest__.py
+++ b/account_invoice_tax_note/__manifest__.py
@@ -7,7 +7,7 @@
     "development_status": "Production/Stable",
     "summary": "Print tax notes on customer invoices",
     "website": "https://github.com/OCA/account-invoicing",
-    "category": "Localization / Accounting",
+    "category": "Accounting",
     "license": "AGPL-3",
     "depends": ["account"],
     "data": ["reports/report_invoice_document.xml", "views/account_tax_views.xml"],

--- a/account_invoice_tax_required/__manifest__.py
+++ b/account_invoice_tax_required/__manifest__.py
@@ -6,7 +6,7 @@
     "version": "16.0.1.1.0",
     "author": "Camptocamp,Tecnativa,Punt Sistemes, " "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/account-invoicing",
-    "category": "Localization / Accounting",
+    "category": "Accounting",
     "license": "AGPL-3",
     "summary": """This module adds functional a check on invoice to force user
         to set tax on invoice line.""",

--- a/account_invoice_tax_required/static/description/index.html
+++ b/account_invoice_tax_required/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -427,7 +428,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION
![immagine](https://github.com/user-attachments/assets/deb43140-fbbe-479c-99cc-9497f4818467)


This bug could be fixed in two ways:
1. removing spaces from `Localization / Accounting` category
2. using `Accounting` category

The second one is the right one for this repo IMO.
