### PR TITLE
[14.0][FIX] account_invoice_purchase_picking_selection: Use commercial_partner_id instead of partner_id

### DIFF
--- a/account_invoice_purchase_picking_selection/views/account_move_views.xml
+++ b/account_invoice_purchase_picking_selection/views/account_move_views.xml
@@ -12,7 +12,7 @@
                     attrs="{'invisible': ['|', ('state','!=','draft'), ('move_type', '!=', 'in_invoice')]}"
                     class="oe_edit_only"
                     placeholder="Select a purchase reception"
-                    context="{'filter_picking_autocomplete': True, 'invoice_company_id': company_id, 'invoice_partner_id': partner_id, 'invoice_type': 'in_invoice'}"
+                    context="{'filter_picking_autocomplete': True, 'invoice_company_id': company_id, 'invoice_partner_id': commercial_partner_id, 'invoice_type': 'in_invoice'}"
                     options="{'no_create': True, 'no_open': True}"
                 />
             </xpath>


### PR DESCRIPTION
When a contact has children and one is marked as the invoice address, the partner_id is, by default, set to this invoice contact. As a result, the pickings only display records related to that invoice recipient. With this commit, we now use commercial_partner_id instead, ensuring all related records are correctly shown.

TT56280
@Tecnativa @pedrobaeza could you review this please