### PR TITLE
[FIX]  account_invoice_pricelist: add new calculate discount condition

### DIFF
--- a/account_invoice_pricelist/models/account_move.py
+++ b/account_invoice_pricelist/models/account_move.py
@@ -75,7 +75,9 @@ class AccountMoveLine(models.Model):
         return res
 
     def _calculate_discount(self, base_price, final_price):
-        discount = (base_price - final_price) / base_price * 100
+        discount = 0.0
+        if base_price > 0.0:
+            discount = (base_price - final_price) / base_price * 100
         if (discount < 0 and base_price > 0) or (discount > 0 and base_price < 0):
             discount = 0.0
         return discount

--- a/account_invoice_pricelist/tests/test_account_move_pricelist.py
+++ b/account_invoice_pricelist/tests/test_account_move_pricelist.py
@@ -315,3 +315,21 @@ class TestAccountMovePricelist(common.TransactionCase):
             self.invoice.with_context(force_check_currecy=True).write(
                 {"currency_id": self.usd_currency.id}
             )
+
+    def test_account_invoice_with_discount_and_taxes(self):
+        tax = self.env["account.tax"].create(
+            {
+                "name": "Test Tax",
+                "amount": 10.0,
+                "amount_type": "percent",
+                "type_tax_use": "sale",
+            }
+        )
+        self.product.taxes_id = [(6, 0, [tax.id])]
+        self.invoice.pricelist_id = self.sale_pricelist_with_discount.id
+        for line in self.invoice.invoice_line_ids:
+            line.tax_ids = [(6, 0, [tax.id])]
+        self.invoice.button_update_prices_from_pricelist()
+        invoice_line = self.invoice.invoice_line_ids[:1]
+        self.assertEqual(invoice_line.discount, 0.0)
+        self.assertAlmostEqual(invoice_line.price_unit, 90.0)


### PR DESCRIPTION
To replicate the error, the steps to follow are:

- Create a sale order and confirm it.
- Create a downpayment invoice and validate it.
- Validate the delivery.
- Once the delivery is validated, create the invoice for the delivered products.
- At this point, the error is reported.

![image](https://github.com/user-attachments/assets/3957d475-9631-4f92-9ba7-df731155c53a)

An important point to keep in mind: The pricelist is based on other pricelists; they are built into one another until the last one is based on the sales price of the product. Also, keep in mind that the pricelist in the sales order has a discount policy of "Show public price & discount to the customer."

![image](https://github.com/user-attachments/assets/e05fd020-a46f-4aa8-abba-6f5f86ae664e)
