### PR TITLE
[18.0][FIX]account_move_tier_validation: Allow to send invoice after validation

### DIFF
--- a/account_move_tier_validation/models/account_move.py
+++ b/account_move_tier_validation/models/account_move.py
@@ -28,7 +28,16 @@ class AccountMove(models.Model):
         # otherwise editing manually the values on lines dirties the field at onchange
         # since it's not in readonly because readonly="not(review_ids)", it's then
         # sent at save, and will override the values set by the user
-        return res + ["amount_total"]
+        # The other exclusions are needed to be able to generate the pdf
+        # and send the invoice by email
+        am_exceptions = [
+            "amount_total",
+            "needed_terms_dirty",
+            "is_manually_modified",
+            "is_move_sent",
+            "sending_data",
+        ]
+        return res + am_exceptions
 
     def _get_to_validate_message_name(self):
         name = super()._get_to_validate_message_name()

--- a/account_move_tier_validation/models/account_move.py
+++ b/account_move_tier_validation/models/account_move.py
@@ -36,6 +36,8 @@ class AccountMove(models.Model):
             "is_manually_modified",
             "is_move_sent",
             "sending_data",
+            "matched_payment_ids",
+            "payment_state",
         ]
         return res + am_exceptions
 

--- a/account_move_tier_validation/tests/test_tier_validation.py
+++ b/account_move_tier_validation/tests/test_tier_validation.py
@@ -30,6 +30,32 @@ class TestAccountTierValidation(BaseCommon):
         )
         cls.account_move_model = cls.env["ir.model"]._get("account.move")
 
+        # Ensure the company has a document layout configured.
+        if not cls.company.external_report_layout_id:
+            # Try to find a common default layout by XML ID
+            default_layout = cls.env.ref(
+                "web.external_layout_standard", raise_if_not_found=False
+            )
+            if not default_layout:
+                # Fallback: try other common layouts if standard
+                # is not found by that XML ID directly
+                common_layouts_xml_ids = [
+                    "web.external_layout_boxed",
+                    "web.external_layout_bold",
+                ]
+                for layout_xml_id in common_layouts_xml_ids:
+                    default_layout = cls.env.ref(
+                        layout_xml_id, raise_if_not_found=False
+                    )
+                    if default_layout:
+                        break
+            if not default_layout:
+                # As a last resort, find the first available report.layout
+                default_layout = cls.env["report.layout"].search([], limit=1)
+
+            if default_layout:
+                cls.company.external_report_layout_id = default_layout.id
+
     def test_01_tier_definition_models(self):
         res = self.env["tier.definition"]._get_tier_validation_model_names()
         self.assertIn("account.move", res)
@@ -81,3 +107,34 @@ class TestAccountTierValidation(BaseCommon):
         # Calls _post method by passing context skip_validation_check set to True
         invoice.action_post()
         self.assertEqual(invoice.state, "posted")
+
+        # --- Simulate Sending Invoice by Email ---
+        # The 'action_invoice_sent' method on 'account.move' usually returns
+        # an action to open the 'account.move.send.wizard' wizard.
+        action = invoice.action_invoice_sent()
+        self.assertTrue(
+            action, "Action 'action_invoice_sent' should return an action dictionary."
+        )
+        self.assertEqual(
+            action.get("res_model"),
+            "account.move.send.wizard",
+            "Action should open 'account.move.send.wizard' wizard.",
+        )
+
+        # Get the context from the action to create the wizard instance
+        wizard_context = action.get("context", {})
+        mail_composer = (
+            self.env["account.move.send.wizard"]
+            .with_context(**wizard_context)
+            .create({})
+        )
+
+        # we should test action_send_and_print because that fails if
+        # not all necesary fields are excluded
+        if hasattr(mail_composer, "action_send_and_print"):
+            mail_composer.action_send_and_print()
+        else:
+            self.fail(
+                "Could not find a 'action_send_and_print' "
+                "action on the account.move.send.wizard."
+            )


### PR DESCRIPTION
Fixes: https://github.com/OCA/account-invoicing/issues/1998

Depends on: https://github.com/OCA/server-ux/pull/1076

Before this PR: Unable to send an invoice by email after validation has finished.
After this PR: Invoice can be sent.

Included unit tests, so if/when module breaks in the future it can be detected.