### PR TITLE
[REF] account_invoice_triple_discount : integrate triple.discount.mixin, previously in purchase_triple_discount module. (OCA/purchase-workflow)

### DIFF
--- a/account_invoice_triple_discount/models/__init__.py
+++ b/account_invoice_triple_discount/models/__init__.py
@@ -1,1 +1,2 @@
+from . import triple_discount_mixin
 from . import account_move_line

--- a/account_invoice_triple_discount/models/account_move_line.py
+++ b/account_invoice_triple_discount/models/account_move_line.py
@@ -2,86 +2,9 @@
 # Copyright 2023 Simone Rubino - Aion Tech
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-import functools
-
-from odoo import api, fields, models
+from odoo import models
 
 
 class AccountMoveLine(models.Model):
-
-    _inherit = "account.move.line"
-
-    # core discount field is now a computed field
-    # based on the 3 discounts defined below.
-    # the digits limitation is removed, to make
-    # the computation of the subtotal exact.
-    # For exemple, if discounts are 05%, 09% and 13%
-    # the main discount is 24.7885 % (and not 24.79)
-    discount = fields.Float(
-        string="Total discount",
-        compute="_compute_discount",
-        store=True,
-        readonly=True,
-        digits=None,
-    )
-    discount1 = fields.Float(
-        string="Discount 1 (%)",
-        digits="Discount",
-    )
-    discount2 = fields.Float(
-        string="Discount 2 (%)",
-        digits="Discount",
-    )
-    discount3 = fields.Float(
-        string="Discount 3 (%)",
-        digits="Discount",
-    )
-
-    @api.depends("discount1", "discount2", "discount3")
-    def _compute_discount(self):
-        for line in self:
-            line.discount = line._get_aggregated_multiple_discounts(
-                [line[x] for x in line._get_multiple_discount_field_names()]
-            )
-
-    def _get_aggregated_multiple_discounts(self, discounts):
-        """
-        Returns the aggregate discount corresponding to any number of discounts.
-        For exemple, if discounts is [11.0, 22.0, 33.0]
-        It will return 46.5114
-        """
-        discount_values = []
-        for discount in discounts:
-            discount_values.append(1 - (discount or 0.0) / 100.0)
-        aggregated_discount = (
-            1 - functools.reduce((lambda x, y: x * y), discount_values)
-        ) * 100
-        return aggregated_discount
-
-    @api.model
-    def _get_multiple_discount_field_names(self):
-        return ["discount1", "discount2", "discount3"]
-
-    def _fix_triple_discount_values(self, values):
-        res = values
-        if "discount" in values and "discount1" not in values:
-            res = values.copy()
-            res["discount1"] = res.pop("discount")
-        return res
-
-    # In case sale is installed but not sale_triple_discount, Odoo
-    #  will propagate sale.order.line.discount into account.move.line.discount
-    #  but account.move.line.discount1 will not be set properly
-    # Override create/write and only in case discount is set but not
-    #  discount1, move its value to discount1
-    @api.model_create_multi
-    def create(self, vals_list):
-        for i, vals in enumerate(vals_list):
-            new_vals = self._fix_triple_discount_values(vals)
-            if new_vals:
-                vals_list[i] = new_vals
-        return super().create(vals_list)
-
-    def write(self, vals):
-        vals = self._fix_triple_discount_values(vals)
-        return super().write(vals)
+    _name = "account.move.line"
+    _inherit = ["account.move.line", "triple.discount.mixin"]

--- a/account_invoice_triple_discount/models/triple_discount_mixin.py
+++ b/account_invoice_triple_discount/models/triple_discount_mixin.py
@@ -1,0 +1,90 @@
+# Copyright 2019 Tecnativa - David Vidal
+# Copyright 2019 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import functools
+
+from odoo import api, fields, models
+
+
+class TripleDiscount(models.AbstractModel):
+    # TODO: To be moved to account_invoice_triple_discount
+    _name = "triple.discount.mixin"
+    _description = "Triple discount mixin"
+
+    discount = fields.Float(
+        string="Total discount",
+        compute="_compute_discount",
+        store=True,
+        readonly=True,
+    )
+    discount1 = fields.Float(
+        string="Discount 1 (%)",
+        digits="Discount",
+    )
+    discount2 = fields.Float(
+        string="Discount 2 (%)",
+        digits="Discount",
+    )
+    discount3 = fields.Float(
+        string="Discount 3 (%)",
+        digits="Discount",
+    )
+
+    _sql_constraints = [
+        (
+            "discount1_limit",
+            "CHECK (discount1 <= 100.0)",
+            "Discount 1 must be lower than 100%.",
+        ),
+        (
+            "discount2_limit",
+            "CHECK (discount2 <= 100.0)",
+            "Discount 2 must be lower than 100%.",
+        ),
+        (
+            "discount3_limit",
+            "CHECK (discount3 <= 100.0)",
+            "Discount 3 must be lower than 100%.",
+        ),
+    ]
+
+    @api.depends(lambda self: self._get_multiple_discount_field_names())
+    def _compute_discount(self):
+        for line in self:
+            line.discount = line._get_aggregated_multiple_discounts(
+                [line[x] for x in line._get_multiple_discount_field_names()]
+            )
+
+    def _get_aggregated_multiple_discounts(self, discounts):
+        """
+        Returns the aggregate discount corresponding to any number of discounts.
+        For exemple, if discounts is [11.0, 22.0, 33.0]
+        It will return 46.5114
+        """
+        discount_values = []
+        for discount in discounts:
+            discount_values.append(1 - (discount or 0.0) / 100.0)
+        aggregated_discount = (
+            1 - functools.reduce((lambda x, y: x * y), discount_values)
+        ) * 100
+        return aggregated_discount
+
+    @api.model
+    def _get_multiple_discount_field_names(self):
+        return ["discount1", "discount2", "discount3"]
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if vals.get("discount") and not any(
+                vals.get(field) for field in self._get_multiple_discount_field_names()
+            ):
+                vals["discount1"] = vals.pop("discount")
+        return super().create(vals_list)
+
+    def write(self, vals):
+        discount_fields = self._get_multiple_discount_field_names()
+        if "discount" in vals:
+            vals["discount1"] = vals.pop("discount")
+            vals.update({field: 0 for field in discount_fields[1:]})
+        return super().write(vals)

--- a/account_invoice_triple_discount/models/triple_discount_mixin.py
+++ b/account_invoice_triple_discount/models/triple_discount_mixin.py
@@ -25,18 +25,11 @@ class TripleDiscountMixin(models.AbstractModel):
         readonly=True,
         digits=None,
     )
-    discount1 = fields.Float(
-        string="Discount 1 (%)",
-        digits="Discount",
-    )
-    discount2 = fields.Float(
-        string="Discount 2 (%)",
-        digits="Discount",
-    )
-    discount3 = fields.Float(
-        string="Discount 3 (%)",
-        digits="Discount",
-    )
+    discount1 = fields.Float(string="Discount 1 (%)", digits="Discount")
+
+    discount2 = fields.Float(string="Discount 2 (%)", digits="Discount")
+
+    discount3 = fields.Float(string="Discount 3 (%)", digits="Discount")
 
     _sql_constraints = [
         (

--- a/account_invoice_triple_discount/models/triple_discount_mixin.py
+++ b/account_invoice_triple_discount/models/triple_discount_mixin.py
@@ -1,21 +1,29 @@
 # Copyright 2019 Tecnativa - David Vidal
 # Copyright 2019 Tecnativa - Pedro M. Baeza
+# Copyright 2020 ACSONE SA/NV
+# Copyright 2023 Simone Rubino - Aion Tech
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 import functools
 
 from odoo import api, fields, models
 
 
-class TripleDiscount(models.AbstractModel):
-    # TODO: To be moved to account_invoice_triple_discount
+class TripleDiscountMixin(models.AbstractModel):
     _name = "triple.discount.mixin"
     _description = "Triple discount mixin"
 
+    # core discount field is now a computed field
+    # based on the 3 discounts defined below.
+    # the digits limitation is removed, to make
+    # the computation of the subtotal exact.
+    # For exemple, if discounts are 05%, 09% and 13%
+    # the main discount is 24.7885 % (and not 24.79)
     discount = fields.Float(
         string="Total discount",
         compute="_compute_discount",
         store=True,
         readonly=True,
+        digits=None,
     )
     discount1 = fields.Float(
         string="Discount 1 (%)",


### PR DESCRIPTION
Rational : 

- @pedrobaeza in https://github.com/OCA/purchase-workflow/pull/2599/ and @ramiadavid in https://github.com/OCA/purchase-workflow/pull/2317 introduced a new triple.discount.mixin.
- This PR move this mixin in base account_invoice_triple_discount, and makes the account.move.line model inherit from this mixin.

Once merge, we could merge https://github.com/OCA/purchase-workflow/pull/2686