### PR TITLE
[16.0][FIX]account_invoice_triple_discount: Unfilled ‘discount1’ field on the invoice

### DIFF
--- a/account_invoice_triple_discount/models/triple_discount_mixin.py
+++ b/account_invoice_triple_discount/models/triple_discount_mixin.py
@@ -77,9 +77,7 @@ class TripleDiscountMixin(models.AbstractModel):
     @api.model_create_multi
     def create(self, vals_list):
         for vals in vals_list:
-            if vals.get("discount") and not any(
-                vals.get(field) for field in self._get_multiple_discount_field_names()
-            ):
+            if "discount" in vals and "discount1" not in vals:
                 vals["discount1"] = vals.pop("discount")
         return super().create(vals_list)
 


### PR DESCRIPTION
I have made this change because if in the sales order you fill in the `discount` and `discount2` fields, when creating the invoice it does not translate the information from the `discount` field to `discount1`.

SALE ORDER:
![image](https://github.com/user-attachments/assets/ed25a73f-acee-41ef-9898-1e0045124ad2)

INVOICE:
![image](https://github.com/user-attachments/assets/30f9a710-5ae4-435b-80ef-e375e7a365a3)
