### PR TITLE
[IMP] account_invoice_section_sale_order: speed up

### DIFF
--- a/account_invoice_section_sale_order/models/__init__.py
+++ b/account_invoice_section_sale_order/models/__init__.py
@@ -3,3 +3,4 @@ from . import res_company
 from . import res_config_settings
 from . import res_partner
 from . import sale_order
+from . import sale_order_line

--- a/account_invoice_section_sale_order/models/sale_order.py
+++ b/account_invoice_section_sale_order/models/sale_order.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 from collections import OrderedDict
 
-from odoo import models
+from odoo import Command, models
 from odoo.tools.safe_eval import safe_eval, time
 
 
@@ -16,6 +16,13 @@ class SaleOrder(models.Model):
         the group name.
         Only do this for invoices targetting multiple groups
         """
+        # the context key 'current_line_sequence' is used by
+        # sale.order.line:_prepare_invoice_line to generate spaced apart sequence number
+        # for invoice lines. We use a mutable in the context because the context is an
+        # immutable dictionary: this way we can update the value of the first element on
+        # the list it and see the updated values in the different calls to
+        # _prepare_invoice_line
+        self = self.with_context(current_line_sequence=[10])
         invoices = super()._create_invoices(grouped=grouped, final=final, date=date)
         for invoice in invoices.sudo():
             if invoice.line_ids and (
@@ -26,27 +33,22 @@ class SaleOrder(models.Model):
                 == 1
             ):
                 continue
-            sequence = 10
-            # Because invoices are already created, this would require
-            # an extra read access in order to read order fields.
-            move_lines = invoice._get_ordered_invoice_lines()
             # Group move lines according to their sale order
             section_grouping_matrix = OrderedDict()
-            for move_line in move_lines:
+            for move_line in invoice.invoice_line_ids:
                 group = move_line._get_section_group()
-                section_grouping_matrix.setdefault(group, []).append(move_line.id)
+                section_grouping_matrix.setdefault(group, []).append(move_line.sequence)
             # Prepare section lines for each group
             section_lines = []
-            for group, move_line_ids in section_grouping_matrix.items():
+            for group, move_line_sequences in section_grouping_matrix.items():
                 if group:
+                    first_seq = move_line_sequences[0]
                     section_lines.append(
-                        (
-                            0,
-                            0,
+                        Command.create(
                             {
                                 "name": group._get_invoice_section_name(),
                                 "display_type": "line_section",
-                                "sequence": sequence,
+                                "sequence": first_seq - 1,
                                 # see test: test_create_invoice_with_default_journal
                                 # forcing the account_id is needed to avoid
                                 # incorrect default value
@@ -56,27 +58,13 @@ class SaleOrder(models.Model):
                                 # the total amount will be wrong
                                 # because all line do not have the same currency
                                 "currency_id": invoice.currency_id.id,
-                            },
+                            }
                         )
                     )
-                    sequence += 10
-                for move_line in (
-                    self.env["account.move.line"].sudo().browse(move_line_ids)
-                ):
-                    if move_line.display_type == "line_section":
-                        # add extra indent for existing SO Sections
-                        move_line.name = f"- {move_line.name}"
-                    move_line.sequence = sequence
-                    sequence += 10
             # Because invoices are already created, this would require
             # an extra write access in order to read order fields.
             invoice.line_ids = section_lines
         return invoices
-
-    def _get_ordered_invoice_lines(self, invoice):
-        return invoice.invoice_line_ids.sorted(
-            key=lambda r: r.sale_line_ids.order_id.id
-        )
 
     def _get_invoice_section_name(self):
         """Returns the text for the section name."""

--- a/account_invoice_section_sale_order/models/sale_order_line.py
+++ b/account_invoice_section_sale_order/models/sale_order_line.py
@@ -1,0 +1,19 @@
+# Copyright 2025 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    def _prepare_invoice_line(self, **optional_values):
+        values = super()._prepare_invoice_line(**optional_values)
+        current_sequence = self.env.context.get("current_line_sequence")
+        if current_sequence is None:
+            return values
+        # update the sequence of the invoice lines, add some space between lines so that
+        # we can insert the sections afterwards.
+        values["sequence"] = current_sequence[0]
+        current_sequence[0] += 10
+        return values


### PR DESCRIPTION
On large invoices, at least on 17.0, rewriting the sequence of the invoice lines is very slow, as it triggers a flush to database for each line (this is even worse when the database is lot running on the same server).

This commit implements a different method for inserting the sections in the invoice lines: we precreate the lines with spaced out sequence numbers, and then we can add the sections between the existing lines, which is much faster.

Test: 47 sale orders for 2 customers, generation of 2 invoices with 1200 and 900 lines respectively

Without patch: 9678 SQL queries,  6.868s in SQL 461.969s in Python, total time: 469s

With patch: 5660 SQL queries 1.934 in SQL,  24.167s in Python, total time 26s


