### PR TITLE
[16.0][FIX] partner_last_invoice_date: handle new partners

### DIFF
--- a/partner_last_invoice_date/models/res_partner.py
+++ b/partner_last_invoice_date/models/res_partner.py
@@ -41,6 +41,8 @@ class ResPartner(models.Model):
         self.last_invoice_date = False
         self.last_bill_date = False
         for partner in self:
+            if isinstance(partner.id, models.NewId):
+                continue
             inv_domain = partner._last_invoice_date_domain() + [
                 ("move_type", "in", ("out_invoice", "out_refund"))
             ]


### PR DESCRIPTION
When creating a new partner from the UI, an error was thrown due to the usage of `self.id` for a search in the method `_last_invoice_date_domain`. With this commit, we avoid this problem upon initial creation.