### PR TITLE
[16.0][FIX] purchase_invoicing_no_zero_line: invoices lines with no product

### DIFF
--- a/purchase_invoicing_no_zero_line/models/account_move.py
+++ b/purchase_invoicing_no_zero_line/models/account_move.py
@@ -18,7 +18,7 @@ class AccountMove(models.Model):
         res = super()._onchange_purchase_auto_complete()
         if purchase and self.journal_id and self.journal_id.avoid_zero_lines:
             zero_lines = self.invoice_line_ids.filtered(
-                lambda x: float_is_zero(
+                lambda x: x.product_uom_id and float_is_zero(
                     x.quantity,
                     precision_rounding=x.product_uom_id.rounding,
                 )


### PR DESCRIPTION
Products are not required on invoice lines. When they are not set, the  method `_onchange_purchase_auto_complete()` which is overwritten by this module fails by throwing a Python error, because it needs to access `product_uom_id.rounding` for `float_is_zero`.

This PR simply ignore lines without product in `_onchange_purchase_auto_complete()` when searching for lines with zero qty.

Error currently returned:
```

    return self.browse([rec.id for rec in self if func(rec)])
  File "/home/odoo/o16/addons-oca/account-invoicing/purchase_invoicing_no_zero_line/models/account_move.py", line 21, in <lambda>
    lambda x: float_is_zero(
  File "/home/odoo/o16/odoo/tools/float_utils.py", line 123, in float_is_zero
    epsilon = _float_check_precision(precision_digits=precision_digits,
  File "/home/odoo/o16/odoo/tools/float_utils.py", line 29, in _float_check_precision
    assert precision_rounding is None or precision_rounding > 0,\
AssertionError: precision_rounding must be positive, got 0.0
```

