### PR TITLE
[16.0][FIX] account_invoice_pricelist: currency_id field readonly if not d…

### DIFF
--- a/account_invoice_pricelist/views/account_invoice_view.xml
+++ b/account_invoice_pricelist/views/account_invoice_view.xml
@@ -20,7 +20,7 @@
             >
                 <attribute
                     name="attrs"
-                >{'readonly': [('pricelist_id', '!=', False)]}</attribute>
+                >{'readonly': ['|', ('state', '!=', 'draft'), ('pricelist_id', '!=', False)]}</attribute>
             </xpath>
             <xpath
                 expr="//group[@id='header_right_group']/field[@name='currency_id']"
@@ -28,7 +28,7 @@
             >
                 <attribute
                     name="attrs"
-                >{'readonly': [('pricelist_id', '!=', False)]}</attribute>
+                >{'readonly': ['|', ('state', '!=', 'draft'), ('pricelist_id', '!=', False)]}</attribute>
             </xpath>
             <xpath expr="//div[field[@name='journal_id']]" position="after">
                 <field


### PR DESCRIPTION
…raft

Core's `('state', '!=', 'draft')` condition was being lost on the inheritance