### PR TITLE
[16.0][FIX] stock_account_move_reset_to_draft: only consider generated SVLs from account move line

### DIFF
--- a/stock_account_move_reset_to_draft/README.rst
+++ b/stock_account_move_reset_to_draft/README.rst
@@ -94,6 +94,11 @@ Contributors
   * Víctor Martínez
   * Pedro M. Baeza
 
+* `Quartile <https://www.quartile.co>`_:
+
+  * Yoshi Tashiro
+  * Aung Ko Ko Lin
+
 Maintainers
 ~~~~~~~~~~~
 

--- a/stock_account_move_reset_to_draft/models/account_move.py
+++ b/stock_account_move_reset_to_draft/models/account_move.py
@@ -42,7 +42,9 @@ class AccountMove(models.Model):
                                 line_name=line.display_name,
                             )
                         )
-                    svls = origin_svl.stock_valuation_layer_ids
+                    svls = origin_svl.stock_valuation_layer_ids.filtered(
+                        "account_move_line_id"
+                    )
                     value = sum(svls.mapped("value"))
                     if not float_is_zero(
                         value, precision_rounding=line.currency_id.rounding

--- a/stock_account_move_reset_to_draft/readme/CONTRIBUTORS.rst
+++ b/stock_account_move_reset_to_draft/readme/CONTRIBUTORS.rst
@@ -2,3 +2,8 @@
 
   * Víctor Martínez
   * Pedro M. Baeza
+
+* `Quartile <https://www.quartile.co>`_:
+
+  * Yoshi Tashiro
+  * Aung Ko Ko Lin

--- a/stock_account_move_reset_to_draft/static/description/index.html
+++ b/stock_account_move_reset_to_draft/static/description/index.html
@@ -8,11 +8,10 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
+:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
-Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +274,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: gray; } /* line numbers */
+pre.code .ln { color: grey; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +300,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic, pre.problematic {
+span.problematic {
   color: red }
 
 span.section-subtitle {
@@ -440,14 +439,17 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Pedro M. Baeza</li>
 </ul>
 </li>
+<li><a class="reference external" href="https://www.quartile.co">Quartile</a>:<ul>
+<li>Yoshi Tashiro</li>
+<li>Aung Ko Ko Lin</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org">
-<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
-</a>
+<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/stock_account_move_reset_to_draft/tests/test_stock_account_move_reset_to_draft.py
+++ b/stock_account_move_reset_to_draft/tests/test_stock_account_move_reset_to_draft.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Tecnativa - Víctor Martínez
+# Copyright 2025 Quartile (https://www.quartile.co)
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 
@@ -37,28 +38,42 @@ class TestStockAccountMoveResetToDraft(BaseCommon):
         )
         cls.partner = cls.env["res.partner"].create({"name": "Test partner"})
 
-    @mute_logger("odoo.models.unlink")
-    def test_purchase_order_flow_01(self):
+    def create_and_confirm_order(self, price=10, qty=1):
         order_form = Form(self.env["purchase.order"])
         order_form.partner_id = self.partner
         with order_form.order_line.new() as line_form:
             line_form.product_id = self.product
-            line_form.price_unit = 10
+            line_form.product_qty = qty
+            line_form.price_unit = price
             line_form.taxes_id.clear()
         order = order_form.save()
         order.button_confirm()
-        res = order.picking_ids.button_validate()
+        return order
+
+    def process_picking(self, picking, qty_done=None):
+        if qty_done is not None:
+            picking.move_ids_without_package.quantity_done = qty_done
+        res = picking.button_validate()
         wizard = self.env[res["res_model"]].with_context(**res["context"]).create({})
         wizard.process()
-        self.assertEqual(order.picking_ids.state, "done")
+        self.assertEqual(picking.state, "done")
+
+    def create_and_post_invoice(self, order, price=10, qty=1):
         res_invoice = order.action_create_invoice()
         invoice = self.env[res_invoice["res_model"]].browse(res_invoice["res_id"])
         self.assertEqual(invoice.state, "draft")
         invoice.invoice_date = order.date_approve
-        invoice.invoice_line_ids.price_unit = 12
-        # Upon confirmation, a SVL will be created for the difference (2=12-10)
+        invoice.invoice_line_ids.write({"quantity": qty, "price_unit": price})
         invoice.action_post()
         self.assertEqual(invoice.state, "posted")
+        return invoice
+
+    @mute_logger("odoo.models.unlink")
+    def test_purchase_order_flow_01(self):
+        order = self.create_and_confirm_order(price=10, qty=1)
+        self.process_picking(order.picking_ids)
+        invoice = self.create_and_post_invoice(order, price=12, qty=1)
+        # Upon confirmation, a SVL will be created for the difference (2=12-10)
         self.assertEqual(len(invoice.invoice_line_ids.stock_valuation_layer_ids), 1)
         svl_1 = invoice.invoice_line_ids.stock_valuation_layer_ids
         self.assertEqual(svl_1.value, 2)
@@ -106,67 +121,66 @@ class TestStockAccountMoveResetToDraft(BaseCommon):
     @mute_logger("odoo.models.unlink")
     def test_purchase_order_flow_02(self):
         # PO for a product: 2 pcs at EUR10
-        order_form = Form(self.env["purchase.order"])
-        order_form.partner_id = self.partner
-        with order_form.order_line.new() as line_form:
-            line_form.product_id = self.product
-            line_form.price_unit = 10
-            line_form.product_qty = 2
-            line_form.taxes_id.clear()
-        order = order_form.save()
-        order.button_confirm()
+        order = self.create_and_confirm_order(price=10, qty=2)
         # Receive 1 pc and create a backorder
         picking = order.picking_ids
-        picking.move_ids_without_package.quantity_done = 1
-        res = picking.button_validate()
-        wizard = self.env[res["res_model"]].with_context(**res["context"]).create({})
-        wizard.process()
-        # Receive 1 pc
+        self.process_picking(picking, qty_done=1)
         extra_picking = order.picking_ids - picking
-        res = extra_picking.button_validate()
-        wizard = self.env[res["res_model"]].with_context(**res["context"]).create({})
-        wizard.process()
-        # Create a bill for 2 pcs at EUR12 and post
-        res_invoice = order.action_create_invoice()
-        invoice = self.env[res_invoice["res_model"]].browse(res_invoice["res_id"])
-        self.assertEqual(invoice.state, "draft")
-        invoice.invoice_date = order.date_approve
-        invoice.invoice_line_ids.price_unit = 12
-        invoice.action_post()
-        self.assertEqual(invoice.state, "posted")
+        self.process_picking(extra_picking)
+        invoice = self.create_and_post_invoice(order, price=12, qty=2)
         self.assertEqual(len(invoice.invoice_line_ids.stock_valuation_layer_ids), 2)
         svls_1 = invoice.invoice_line_ids.stock_valuation_layer_ids
-        self.assertEqual(sum(svls_1.mapped("value")), 24)
+        self.assertEqual(sum(svls_1.mapped("value")), 4)
         self.assertTrue(invoice.show_reset_to_draft_button)
         # Reset the bill to draft
         invoice.button_draft()
         self.assertEqual(invoice.state, "draft")
         self.assertEqual(len(invoice.invoice_line_ids.stock_valuation_layer_ids), 4)
         svls_1_negative = invoice.invoice_line_ids.stock_valuation_layer_ids - svls_1
-        self.assertEqual(sum(svls_1.mapped("value")), 24)
-        self.assertEqual(sum(svls_1_negative.mapped("value")), -24)
+        self.assertEqual(sum(svls_1.mapped("value")), 4)
+        self.assertEqual(sum(svls_1_negative.mapped("value")), -4)
         # Change the bill content to 1 pc at EUR15 and post
-        invoice.invoice_line_ids.quantity = 1
-        invoice.invoice_line_ids.price_unit = 8
+        invoice.invoice_line_ids.write({"quantity": 1, "price_unit": 15})
         invoice.action_post()
         self.assertEqual(invoice.state, "posted")
         self.assertEqual(len(invoice.invoice_line_ids.stock_valuation_layer_ids), 4)
         # Create another bill for 1 pc at EUR8 and post
-        res_invoice = order.action_create_invoice()
-        invoice_extra = self.env[res_invoice["res_model"]].browse(res_invoice["res_id"])
-        self.assertEqual(invoice_extra.state, "draft")
-        invoice_extra.invoice_date = order.date_approve
-        invoice_extra.invoice_line_ids.price_unit = 8
-        invoice_extra.action_post()
-        self.assertEqual(invoice_extra.state, "posted")
+        invoice_extra = self.create_and_post_invoice(order, price=8, qty=1)
         self.assertEqual(
             len(invoice_extra.invoice_line_ids.stock_valuation_layer_ids), 1
         )
         self.assertEqual(
-            invoice_extra.invoice_line_ids.stock_valuation_layer_ids.value, 8
+            invoice_extra.invoice_line_ids.stock_valuation_layer_ids.value, -2
         )
         self.assertTrue(invoice.show_reset_to_draft_button)
         # Reset the first bill to draft -> User error to prevent valuation inconsistencies
         with self.assertRaises(UserError):
             invoice.button_draft()
-        # Delivery 1 pc
+
+    @mute_logger("odoo.models.unlink")
+    def test_purchase_order_flow_03(self):
+        order = self.create_and_confirm_order(price=10, qty=1)
+        self.process_picking(order.picking_ids)
+        invoice = self.create_and_post_invoice(order, price=12, qty=1)
+        self.assertEqual(
+            sum(invoice.invoice_line_ids.mapped("stock_valuation_layer_ids.value")), 2
+        )
+        # Manually create an SVL linked to the original SVL.
+        # This simulates cases such as applying a landed cost to a receipt.
+        svl = order.picking_ids.move_ids.stock_valuation_layer_ids
+        self.env["stock.valuation.layer"].create(
+            {
+                "product_id": self.product.id,
+                "value": 5,
+                "quantity": 1,
+                "description": "Manual SVL",
+                "stock_move_id": False,
+                "stock_valuation_layer_id": svl.id,
+                "company_id": self.env.company.id,
+            }
+        )
+        invoice.button_draft()
+        self.assertEqual(invoice.state, "draft")
+        self.assertEqual(
+            sum(invoice.invoice_line_ids.mapped("stock_valuation_layer_ids.value")), 0
+        )


### PR DESCRIPTION
Before the fix, when a vendor bill was linked to a landed cost and reset to draft, the generated Stock Valuation Layer (SVL) incorrectly included the landed cost value along with the price difference.

This PR fixes the issue by ensuring that only SVLs related to the product price difference are considered—explicitly excluding those associated with landed costs.

@qrtl QT5479