### PR TITLE
[16.0][FIX] account_invoice_date_due: sync and update es.po translation

### DIFF
--- a/account_invoice_date_due/i18n/es.po
+++ b/account_invoice_date_due/i18n/es.po
@@ -1,21 +1,20 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-#    * account_invoice_date_due
+# 	* account_invoice_date_due
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 12.0+e\n"
+"Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-14 19:17+0000\n"
-"PO-Revision-Date: 2021-03-11 13:45+0000\n"
-"Last-Translator: Ana Suárez <ana.suarez@qubiq.es>\n"
-"Language-Team: \n"
+"PO-Revision-Date: 2025-07-02 12:03+0000\n"
+"Last-Translator: Netkia <carlos.sainz@netkia.es>\n"
+"Language-Team: none\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.3.2\n"
+"X-Generator: Weblate 5.10.2\n"
 
 #. module: account_invoice_date_due
 #: model:res.groups,name:account_invoice_date_due.allow_to_change_due_date
@@ -23,71 +22,28 @@ msgid "Allow to change due date"
 msgstr "Permitir actualizar la fecha de vencimiento"
 
 #. module: account_invoice_date_due
-#: model_terms:ir.ui.view,arch_db:account_invoice_date_due.wizard_set_due_date
-msgid "Cancel"
-msgstr "Cancelar"
+#: model:ir.model.fields,field_description:account_invoice_date_due.field_account_bank_statement_line__invoice_date_due
+#: model:ir.model.fields,field_description:account_invoice_date_due.field_account_move__invoice_date_due
+#: model:ir.model.fields,field_description:account_invoice_date_due.field_account_payment__invoice_date_due
+#: model_terms:ir.ui.view,arch_db:account_invoice_date_due.view_move_form
+msgid "Due Date"
+msgstr "Fecha de Vencimiento"
 
 #. module: account_invoice_date_due
-#: model:ir.actions.act_window,name:account_invoice_date_due.action_show_wizard_set_due_date
-msgid "Change due date"
-msgstr "Cambiar fecha de vencimiento"
+#: model:ir.model.fields,field_description:account_invoice_date_due.field_account_bank_statement_line__invoice_date_due_payment_term
+#: model:ir.model.fields,field_description:account_invoice_date_due.field_account_move__invoice_date_due_payment_term
+#: model:ir.model.fields,field_description:account_invoice_date_due.field_account_payment__invoice_date_due_payment_term
+msgid "Due Date Payment Term"
+msgstr "Término de pago del vencimiento"
 
 #. module: account_invoice_date_due
-#: model:ir.model.fields,field_description:account_invoice_date_due.field_account_invoice_set_due_date__create_uid
-msgid "Created by"
-msgstr "Creado por"
+#: model:ir.model,name:account_invoice_date_due.model_account_move
+msgid "Journal Entry"
+msgstr "Asiento Contable"
 
 #. module: account_invoice_date_due
-#: model:ir.model.fields,field_description:account_invoice_date_due.field_account_invoice_set_due_date__create_date
-msgid "Created on"
-msgstr "Creado el"
-
-#. module: account_invoice_date_due
-#: model:ir.model.fields,field_description:account_invoice_date_due.field_account_invoice_set_due_date__display_name
-msgid "Display Name"
-msgstr "Nombre mostrado"
-
-#. module: account_invoice_date_due
-#: model:ir.model.fields,field_description:account_invoice_date_due.field_account_invoice_set_due_date__id
-msgid "ID"
-msgstr "ID"
-
-#. module: account_invoice_date_due
-#: model:ir.model.fields,field_description:account_invoice_date_due.field_account_invoice_set_due_date____last_update
-msgid "Last Modified on"
-msgstr "Última modificación en"
-
-#. module: account_invoice_date_due
-#: model:ir.model.fields,field_description:account_invoice_date_due.field_account_invoice_set_due_date__write_uid
-msgid "Last Updated by"
-msgstr "Última actualización por"
-
-#. module: account_invoice_date_due
-#: model:ir.model.fields,field_description:account_invoice_date_due.field_account_invoice_set_due_date__write_date
-msgid "Last Updated on"
-msgstr "Última actualización el"
-
-#. module: account_invoice_date_due
-#: model:ir.model.fields,field_description:account_invoice_date_due.field_account_invoice_set_due_date__date_due
-msgid "New Due Date"
-msgstr "Nueva Fecha de Vencimiento"
-
-#. module: account_invoice_date_due
-#: model:ir.model.fields,help:account_invoice_date_due.field_account_invoice_set_due_date__date_due
-msgid "New date to be set to the invoice's due date."
-msgstr "Nueva fecha a establecer para la fecha de vencimiento de la factura."
-
-#. module: account_invoice_date_due
-#: model_terms:ir.ui.view,arch_db:account_invoice_date_due.wizard_set_due_date
-msgid "Set Due Date"
-msgstr "Colocar Fecha de Vencimiento"
-
-#. module: account_invoice_date_due
-#: model_terms:ir.ui.view,arch_db:account_invoice_date_due.wizard_set_due_date
-msgid "Set a new due date on selected invoices."
-msgstr "Colocar una nueva fecha de vencimiento a las facturas seleccionadas."
-
-#. module: account_invoice_date_due
-#: model:ir.model,name:account_invoice_date_due.model_account_invoice_set_due_date
-msgid "Wizard to set due date"
-msgstr "Asistente para configurar nueva fecha de vencimiento"
+#. odoo-python
+#: code:addons/account_invoice_date_due/models/account_move.py:0
+#, python-format
+msgid "You are not allowed to change the due date."
+msgstr "No está autorizado para cambiar la fecha de vencimiento."


### PR DESCRIPTION
This PR updates the es.po translation file for the account_invoice_date_due module.

Although the standard procedure is to use Weblate for translation contributions, in this case it was not possible, because the current es.po file in the repository is not in sync with the .pot template. As a result, some field strings do not appear in Weblate and cannot be translated from there.

The issue likely stems from the migration of the module, where the .pot file may have been updated, but the es.po file was not regenerated accordingly.

To fix this:

    The .pot file was used to regenerate a fresh and complete es.po.

    The translation file was then updated with the correct Spanish translations for all available terms.

This approach ensures that:

    All strings present in the module are now available in the Spanish translation.

    Weblate will be able to work correctly after this sync.

Let me know if there's any objection to this manual update — I’m happy to adjust the approach if needed.