### PR TITLE
[16.0][FIX] stock_picking_invoicing: fails to update invoice_state in stock.move

### DIFF
--- a/stock_picking_invoicing/wizards/stock_invoice_onshipping.py
+++ b/stock_picking_invoicing/wizards/stock_invoice_onshipping.py
@@ -474,7 +474,7 @@ class StockInvoiceOnshipping(models.TransientModel):
         :param pickings: stock.picking recordset
         :return: stock.picking recordset
         """
-        return pickings._set_as_invoiced()
+        return pickings.set_as_invoiced()
 
     def ungroup_moves(self, grouped_moves_list):
         """Ungroup your moves, split them again, grouping by


### PR DESCRIPTION
# Current scenario:

When creating an invoice from a stock.picking, the invoice_state field in stock.move is not updated.

# Causes

The [stock_invoice_onshipping](https://github.com/OCA/account-invoicing/blob/16.0/stock_picking_invoicing/wizards/stock_invoice_onshipping.py#L477) wizard method is calling _set_as_invoiced method from [stock.invoice.state.mixin](https://github.com/OCA/account-invoicing/blob/16.0/stock_picking_invoicing/models/stock_invoice_state_mixin.py#L29) instead call the method set_as_invoiced  from [stock.picking](https://github.com/OCA/account-invoicing/blob/16.0/stock_picking_invoicing/models/stock_picking.py#L21C9-L21C24)