### PR TITLE
[16.0][FIX] account_invoice_mass_sending: Send as comment to preserve mail tracking and keep avoiding extra notifications

### DIFF
--- a/account_invoice_mass_sending/models/account_move.py
+++ b/account_invoice_mass_sending/models/account_move.py
@@ -13,7 +13,7 @@ class AccountInvoice(models.Model):
         "and it will prevent the sending of a duplicated mail.",
     )
 
-    def mass_sending(self, template=None):
+    def mass_sending(self, template=None, include_followers=False):
         """
         This method triggers the asynchronous sending for the selected
         invoices for which there is no asynchronous sending in progress
@@ -33,10 +33,13 @@ class AccountInvoice(models.Model):
                 invoice.with_delay(
                     description=description,
                     channel="root.account_invoice_mass_sending_channel",
-                )._send_invoice_individually(template=template)
+                )._send_invoice_individually(
+                    template=template,
+                    include_followers=include_followers,
+                )
         return invoices_to_send
 
-    def _send_invoice_individually(self, template=None):
+    def _send_invoice_individually(self, template=None, include_followers=False):
         self.ensure_one()
         res = self.action_invoice_sent()
         wiz_ctx = res["context"] or {}
@@ -48,7 +51,7 @@ class AccountInvoice(models.Model):
                 "active_ids": self.ids,
                 "active_id": self.id,
                 "discard_logo_check": True,
-                "account_invoice_mass_sending": True,
+                "include_followers": include_followers,
             }
         )
         wiz = self.env["account.invoice.send"].with_context(**wiz_ctx).create({})
@@ -67,3 +70,21 @@ class AccountInvoice(models.Model):
             }
         )
         return wiz.send_and_print_action()
+
+    def _notify_get_recipients(self, message, msg_vals, **kwargs):
+        recipients_data = super()._notify_get_recipients(message, msg_vals, **kwargs)
+        if self.env.context.get("include_followers", False):
+            return recipients_data
+        else:
+            msg_sudo = message.sudo()
+            pids = (
+                msg_vals.get("partner_ids", [])
+                if msg_vals
+                else msg_sudo.partner_ids.ids
+            )
+            filtered_recipients_data = [
+                recipient
+                for recipient in recipients_data
+                if recipient.get("id") in pids
+            ]
+            return filtered_recipients_data

--- a/account_invoice_mass_sending/tests/test_account_invoice_mass_sending.py
+++ b/account_invoice_mass_sending/tests/test_account_invoice_mass_sending.py
@@ -169,7 +169,7 @@ class TestAccountInvoiceMassSending(TransactionCase):
             trap.assert_jobs_count(1)
             trap.assert_enqueued_job(
                 self.first_eligible_invoice._send_invoice_individually,
-                kwargs={"template": self.mail_template_obj},
+                kwargs={"template": self.mail_template_obj, "include_followers": False},
             )
             trap.perform_enqueued_jobs()
             self.assertFalse(self.first_eligible_invoice.sending_in_progress)

--- a/account_invoice_mass_sending/wizards/account_invoice_send.py
+++ b/account_invoice_mass_sending/wizards/account_invoice_send.py
@@ -1,15 +1,24 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import _, api, models
+from odoo import _, fields, models
 
 
 class AccountInvoiceSend(models.TransientModel):
     _inherit = "account.invoice.send"
 
+    include_followers = fields.Boolean(
+        default=False,
+        help="If checked, this email will be also send to document followers. "
+        "Else, the email will be sent just to the invoice partner."
+        "\nNote: This functionality only applies for mass sending.",
+    )
+
     def enqueue_invoices(self):
         active_ids = self._context.get("active_ids")
         invoices = self.env["account.move"].browse(active_ids)
-        invoices_to_send = invoices.mass_sending(self.template_id)
+        invoices_to_send = invoices.mass_sending(
+            template=self.template_id, include_followers=self.include_followers
+        )
         ineligible_invoices = invoices - invoices_to_send
         title = _("Invoices: Mass sending")
         msg = _(
@@ -48,12 +57,3 @@ class AccountInvoiceSend(models.TransientModel):
                 }
             )
         return notification
-
-    @api.onchange("invoice_ids")
-    def _compute_composition_mode(self):
-        """Force send as mass_mail although this module sends each invoice one by one
-        to avoid extra notificactions"""
-        if not self.env.context.get("account_invoice_mass_sending", False):
-            return super()._compute_composition_mode()
-        for wizard in self:
-            wizard.composer_id.composition_mode = "mass_mail"

--- a/account_invoice_mass_sending/wizards/account_invoice_send.xml
+++ b/account_invoice_mass_sending/wizards/account_invoice_send.xml
@@ -5,6 +5,9 @@
         <field name="model">account.invoice.send</field>
         <field name="inherit_id" ref="account.account_invoice_send_wizard_form" />
         <field name="arch" type="xml">
+            <field name="template_id" position="after">
+                <field name="include_followers" />
+            </field>
             <button name="send_and_print_action" position="before">
                 <button
                     name="enqueue_invoices"


### PR DESCRIPTION
Solves https://github.com/OCA/account-invoicing/issues/2028
Also, fixes problem detected in here: https://github.com/OCA/account-invoicing/pull/1876#issuecomment-2671848093

Message is again sent as comment, in order to preserve mail track widget. And it avoids extra notifications for users, to keep the fix made here: https://github.com/OCA/account-invoicing/pull/1839