### PR TITLE
[18.0][FIX] account_invoice_pricelist: avoid override _compute_discount

### DIFF
--- a/account_invoice_pricelist/models/account_move.py
+++ b/account_invoice_pricelist/models/account_move.py
@@ -88,8 +88,7 @@ class AccountMoveLine(models.Model):
         self.ensure_one()
         return self.move_id.invoice_date
 
-    @api.depends("product_id", "product_uom_id", "quantity")
-    def _compute_discount(self):
+    def _calculate_discount(self):
         discount_enabled = self.env[
             "product.pricelist.item"
         ]._is_discount_feature_enabled()
@@ -173,7 +172,7 @@ class AccountMoveLine(models.Model):
 
         base_price = self._get_pricelist_price_before_discount()
 
-        self._compute_discount()
+        self._calculate_discount()
 
         # negative discounts (= surcharge) are included in the display price
         return max(base_price, pricelist_price)

--- a/account_invoice_pricelist/tests/test_account_move_pricelist.py
+++ b/account_invoice_pricelist/tests/test_account_move_pricelist.py
@@ -432,10 +432,12 @@ class TestAccountMovePricelist(common.TransactionCase):
     def test_12_account_invoice_without_pricelist(self):
         self.env.user.write({"groups_id": [(4, self.group_discount.id)]})
         self.invoice.pricelist_id = self.sale_pricelist2.id
-        self.invoice.invoice_line_ids[:1]._compute_discount()
+        self.invoice.invoice_line_ids[:1].quantity = 0.0
+        self.invoice.invoice_line_ids[:1].quantity = 1.0
         self.assertEqual(self.invoice.invoice_line_ids[:1].discount, 0.0)
         self.invoice.pricelist_id = False
-        self.invoice.invoice_line_ids[:1]._compute_discount()
+        self.invoice.invoice_line_ids[:1].quantity = 0.0
+        self.invoice.invoice_line_ids[:1].quantity = 1.0
         self.assertEqual(self.invoice.invoice_line_ids[:1].discount, 0.0)
 
     def test_13_account_invoice_pricelist_with_discount(self):
@@ -444,13 +446,15 @@ class TestAccountMovePricelist(common.TransactionCase):
         self.assertEqual(invoice_line.price_unit, 100.00)
         self.assertEqual(invoice_line.discount, 0.00)
 
-    def test_14_compute_discount(self):
+    def test_14_calculate_discount(self):
         self.env.user.write({"groups_id": [(4, self.group_discount.id)]})
         self.product.write({"list_price": 0.00})
         self.invoice.pricelist_id = self.sale_pricelist3.id
-        self.invoice.invoice_line_ids[0]._compute_discount()
+        self.invoice.invoice_line_ids[0].quantity = 0.0
+        self.invoice.invoice_line_ids[0].quantity = 1.0
         self.assertEqual(self.invoice.invoice_line_ids[0].discount, 0.0)
         self.product.write({"list_price": 100.00})
         self.invoice.pricelist_id = self.sale_pricelist4.id
-        self.invoice.invoice_line_ids[0]._compute_discount()
+        self.invoice.invoice_line_ids[0].quantity = 0.0
+        self.invoice.invoice_line_ids[0].quantity = 1.0
         self.assertEqual(self.invoice.invoice_line_ids[0].discount, 0)


### PR DESCRIPTION
By default, the discount field on invoice lines is not a computed field. When other modules are installed, such as account_invoice_triple_discount, this compute function is added, and it was being overridden in this module. The decision was made to modify the function name in this module so they can coexist without overriding each other.

It has been tested in an environment with only this module installed and also with both modules installed.