### PR TITLE
[18][FIX] account_invoice_show_currency_rate: ensure compute currency rate

### DIFF
--- a/account_invoice_show_currency_rate/models/account_move.py
+++ b/account_invoice_show_currency_rate/models/account_move.py
@@ -32,6 +32,16 @@ class AccountMove(models.Model):
             )
         return res
 
+    # Add the 'state', 'line_ids.amount_currency', and 'line_ids.balance'
+    # dependencies to the base dependencies to recalculate the expected exchange rate.
+    #
+    # Without this change, which causes expected_currency_rate and invoice_currency_rate
+    # to be updated simultaneously, invoice_currency_rate is updated with an outdated
+    # expected_currency_rate value in account.move.
+    @api.depends("state", "line_ids.amount_currency", "line_ids.balance")
+    def _compute_expected_currency_rate(self):
+        return super()._compute_expected_currency_rate()
+
 
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"


### PR DESCRIPTION
Ensure compute account.move expected and invoice currency rate

Exchange rate calculation improvements:

* [`account_invoice_show_currency_rate/models/account_move.py`](diffhunk://#diff-ee533360d49925261ed634c9ff33d6e837de0f75ddf0a87bb19373ba78171c05R35-R38): Added the `_compute_expected_currency_rate` method to the `AccountMove` model, adding the `state`, `line_ids.amount_currency`, and `line_ids.balance` dependencies to the base dependencies to recalculate the expected exchange rate.

Without this change, which causes `expected_currency_rate` and `invoice_currency_rate` to be updated simultaneously, `invoice_currency_rate` is updated with an outdated `expected_currency_rate` value in `account.move`.

It is related to this change: https://github.com/odoo/odoo/commit/2d486fb93ba6d06821837a8f635b8efe44dde00e