### PR TITLE
[16.0][Fix] account_billing test_create_billing_from_selected_invoices

### DIFF
--- a/account_billing/tests/test_account_billing.py
+++ b/account_billing/tests/test_account_billing.py
@@ -37,6 +37,7 @@ class TestAccountBilling(AccountTestInvoicingCommon):
             invoice_amount=100,
             currency_id=cls.currency_eur_id,
             partner_id=cls.partner_a.id,
+            date_invoice=fields.Date.context_today(cls.env.user),
             payment_term_id=cls.payment_term.id,
             auto_validate=True,
         )


### PR DESCRIPTION
### Context 
CI unit test is currently falling : 
```
TestAccountBilling.test_4_create_billing_from_selected_invoices
Traceback (most recent call last):
  File "/__w/account-invoicing/account-invoicing/account_billing/tests/test_account_billing.py", line 128, in test_4_create_billing_from_selected_invoices
    with self.assertRaises(ValidationError):
  File "/usr/lib/python3.10/contextlib.py", line 142, in __exit__
    next(self.gen)
  File "/opt/odoo/odoo/tests/common.py", line 387, in _assertRaises
    with ExitStack() as inner:
  File "/usr/lib/python3.10/contextlib.py", line 576, in __exit__
    raise exc_details[1]
  File "/usr/lib/python3.10/contextlib.py", line 561, in __exit__
    if cb(*exc_details):
AssertionError: ValidationError not raised
```
Because payment terms are setup to 15days, depending on the day you run this test you get a different result.

[threshold_date](https://github.com/OCA/account-invoicing/blob/7207e6e26a87963ceb058e74180001ba9c9b703c/account_billing/models/account_billing.py#L148) is calculated based on [invoice_date_due](https://github.com/OCA/account-invoicing/blob/7207e6e26a87963ceb058e74180001ba9c9b703c/account_invoice_date_due/models/account_move.py#L14). That field is computed based on account.move `date_maturity` that depends of today's date and the payment terms

https://github.com/odoo/odoo/blob/b0be89a67d0ce458db99f4331e21ed56d3c4774a/addons/account/models/account_move.py#L819