### PR TITLE
[16.0][REF] stock_picking_invoicing: tracking_disable in tests (faster tests)

### DIFF
--- a/stock_picking_invoicing/tests/test_picking_invoicing.py
+++ b/stock_picking_invoicing/tests/test_picking_invoicing.py
@@ -10,6 +10,7 @@ class TestPickingInvoicing(TestPickingInvoicingCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
         cls.picking_model = cls.env["stock.picking"]
         cls.move_model = cls.env["stock.move"]
         cls.invoice_model = cls.env["account.move"]


### PR DESCRIPTION
speed up tests with tracking_disable=True in tests. Note that this test class is often inherited (like in 3 modules in OCA/l10n-brazil), so this setting will also speed up the tests in these other modules.

before:
`Module stock_picking_invoicing loaded in 10.40s (incl. 9.37s test), 687 queries (+8809 test, +687 other)`
https://github.com/OCA/account-invoicing/actions/runs/16199081487/job/46159172831#step:8:1038

after:
`Module stock_picking_invoicing loaded in 9.71s (incl. 8.65s test), 687 queries (+8510 test, +687 other) `
https://github.com/OCA/account-invoicing/actions/runs/16425159816/job/46413486889?pr=2062#step:8:1037

so 399 less queries in tests.

NOTE: the test currently failing is in account_billing.tests.test_account_billing and is unrelated.
https://github.com/OCA/account-invoicing/actions/runs/16425159816/job/46413486889?pr=2062#step:8:1141
with fixed proposed here https://github.com/OCA/account-invoicing/pull/2061