### PR TITLE
[17.0][IMP] account_move_tier_validation: Change the use of the validated field to validation_status

### DIFF
--- a/account_move_tier_validation/views/account_move_view.xml
+++ b/account_move_tier_validation/views/account_move_view.xml
@@ -24,7 +24,7 @@
                 <filter
                     name="validation_not_started"
                     string="Validation Not Started"
-                    domain="[('reviewer_ids', '=', False), ('state', 'not in', ['posted', 'cancel']), ('validated', '=', False), ('rejected', '=', False)]"
+                    domain="[('reviewer_ids', '=', False), ('state', 'not in', ['posted', 'cancel']), ('validation_status', '!=', 'validated'), ('validation_status', '!=', 'rejected')]"
                     help="Invoices where validation has not started"
                 />
                 <filter
@@ -36,7 +36,7 @@
                 <filter
                     name="tier_validated"
                     string="Validated"
-                    domain="[('validated', '=', True)]"
+                    domain="[('validation_status', '=', 'validated')]"
                     help="Invoices validated and ready to be confirmed"
                 />
             </filter>


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/account-invoicing/pull/2068

Change the use of the `validated` field to `validation_status`

Related to https://github.com/OCA/server-ux/pull/1084

Locked by:
- [ ] `base_tier_validation`: https://github.com/OCA/server-ux/pull/1136

Please @pedrobaeza can you review it?

@Tecnativa