### PR TITLE
[16.0][FIX] account_invoice_pricelist: prevent price_unit changes when qty inverted for credit notes

### DIFF
--- a/account_invoice_pricelist/models/account_move.py
+++ b/account_invoice_pricelist/models/account_move.py
@@ -57,6 +57,10 @@ class AccountMove(models.Model):
                 invoice.currency_id = self.pricelist_id.currency_id
         return res
 
+    def action_switch_invoice_into_refund_credit_note(self):
+        self = self.with_context(skip_compute_price_unit=True)
+        return super().action_switch_invoice_into_refund_credit_note()
+
     def button_update_prices_from_pricelist(self):
         self.filtered(
             lambda r: r.state == "draft"
@@ -68,6 +72,8 @@ class AccountMoveLine(models.Model):
 
     @api.depends("quantity")
     def _compute_price_unit(self):
+        if self.env.context.get("skip_compute_price_unit"):
+            return
         res = super()._compute_price_unit()
         for line in self:
             if not line.move_id.pricelist_id:

--- a/account_invoice_pricelist/tests/test_account_move_pricelist.py
+++ b/account_invoice_pricelist/tests/test_account_move_pricelist.py
@@ -316,3 +316,10 @@ class TestAccountMovePricelist(BaseCommon):
             self.invoice.with_context(force_check_currecy=True).write(
                 {"currency_id": self.usd_currency.id}
             )
+
+    def test_account_invoice_creditnote_line_qty_flip_when_total_negative(self):
+        self.invoice.pricelist_id = self.sale_pricelist
+        self.invoice.invoice_line_ids.write({"quantity": -1, "price_unit": 100.00})
+        self.invoice.action_switch_invoice_into_refund_credit_note()
+        for invoice_line in self.invoice.invoice_line_ids:
+            self.assertAlmostEqual(invoice_line.price_unit, 100.00)


### PR DESCRIPTION
When action_switch_invoice_into_refund_credit_note inverts line quantities for invoices with a negative
amount_total, it triggers _compute_price_unit and unintentionally updates price_unit. This change prevents
such updates while preserving intended qty changes.

action_switch_invoice_into_refund_credit_note 
https://github.com/odoo/odoo/blob/16.0/addons/account/models/account_move.py#L3727

@qrtl
QT5644, QT5480