### PR TITLE
[16.0][FIX] account_invoice_date_due: Handle multi records on write

### DIFF
--- a/account_invoice_date_due/models/account_move.py
+++ b/account_invoice_date_due/models/account_move.py
@@ -35,8 +35,9 @@ class AccountMove(models.Model):
         res = super().write(vals)
         # Propagate due date to move lines
         # that correspont to the receivable/payable account
-        if "invoice_date_due" in vals and self.state == "posted":
-            payment_term_lines = self.line_ids.filtered(
+        posted_moves = self.filtered(lambda x: x.state == "posted")
+        if "invoice_date_due" in vals and posted_moves:
+            payment_term_lines = posted_moves.line_ids.filtered(
                 lambda line: line.account_id.account_type
                 in ("asset_receivable", "liability_payable")
             )


### PR DESCRIPTION
Fixes singleton error when writing over `invoice_date_due` on multiple records.

Error is reproduced in shell, couldn't reproduce it on runboat without `server_action_mass_edit` from `server-ux`

Without this fix:

```bash
>>> invoice1 = self.env["account.move"].search([], limit=2, order='id desc')[0]
>>> invoice2 = self.env["account.move"].search([], limit=2, order='id desc')[1]
>>> invoice1.invoice_date_due
datetime.date(2025, 8, 11)
>>> invoice2.invoice_date_due
datetime.date(2025, 8, 11)
>>> invoices = invoice1 + invoice2
>>> invoices.write({"invoice_date_due": "2025-09-11"})

  File "/mnt/code/development/account-invoicing/account_invoice_date_due/models/account_move.py", line 39, in write
    if "invoice_date_due" in vals and self.state == "posted":
  File "/mnt/environment/odoo-server/odoo/fields.py", line 1154, in __get__
    record.ensure_one()
  File "/mnt/environment/odoo-server/odoo/models.py", line 5251, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: account.move(50331, 50330)
```
With this fix:

```bash
>>> invoice1 = self.env["account.move"].search([], limit=2, order='id desc')[0]
>>> invoice2 = self.env["account.move"].search([], limit=2, order='id desc')[1]
>>> invoice1.invoice_date_due
datetime.date(2025, 8, 11)
>>> invoice2.invoice_date_due
datetime.date(2025, 8, 11)
>>> invoices = invoice1 + invoice2
>>> invoices.write({"invoice_date_due": "2025-09-11"})
True
```
