### PR TITLE
[17.0][FIX] account_invoice_date_due: Handle multi records on write

### DIFF
--- a/account_invoice_date_due/models/account_move.py
+++ b/account_invoice_date_due/models/account_move.py
@@ -35,8 +35,9 @@ class AccountMove(models.Model):
         res = super().write(vals)
         # Propagate due date to move lines
         # that correspond to the receivable/payable account
-        if "invoice_date_due" in vals and self.state == "posted":
-            payment_term_lines = self.line_ids.filtered(
+        posted_moves = self.filtered(lambda x: x.state == "posted")
+        if "invoice_date_due" in vals and posted_moves:
+            payment_term_lines = posted_moves.line_ids.filtered(
                 lambda line: line.account_id.account_type
                 in ("asset_receivable", "liability_payable")
             )


### PR DESCRIPTION
The write method failed with a singleton error when updating a batch of records.
This was caused by accessing `self.state` on the entire recordset.

The logic is now fixed to first filter for `posted` moves, and then apply the due date propagation only to that safe subset. This ensures batch operations no longer crash.

fw-port from https://github.com/OCA/account-invoicing/pull/2076