### PR TITLE
[FIX] Fix error on account.TestAccountEarlyPaymentDiscount

### DIFF
--- a/account_invoice_fixed_discount/models/account_tax.py
+++ b/account_invoice_fixed_discount/models/account_tax.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 
 from odoo import api, models
+from odoo.tools.float_utils import float_is_zero
 
 
 class AccountTax(models.Model):
@@ -10,6 +11,30 @@ class AccountTax(models.Model):
     @api.model
     def _prepare_base_line_for_taxes_computation(self, record, **kwargs):
         res = super()._prepare_base_line_for_taxes_computation(record, **kwargs)
+
+        def load(field, fallback, from_base_line=False):
+            return self._get_base_line_field_value_from_record(
+                record, field, kwargs, fallback, from_base_line=from_base_line
+            )
+
+        if isinstance(record, dict):
+            currency = (
+                load("currency_id", None)
+                or load("company_currency_id", None)
+                or load("company_id", self.env["res.company"]).currency_id
+                or self.env["res.currency"]
+            )
+            discount_fixed = load("discount_fixed", 0.0)
+            price_unit = load("price_unit", 0.0)
+
+            if float_is_zero(
+                discount_fixed, precision_rounding=currency.rounding
+            ) or float_is_zero(price_unit, precision_rounding=currency.rounding):
+                res["discount"] = 0.0
+            else:
+                res["discount"] = (discount_fixed / price_unit) * 100
+            return res
+
         if record and record._name == "account.move.line" and record.discount_fixed:
             res["discount"] = record._get_discount_from_fixed_discount()
         return res


### PR DESCRIPTION
## **Why is this change needed?**

To fix error when running the following test cases
- account.TestAccountEarlyPaymentDiscount::test_mixed_epd_with_draft_invoice
- account.TestAccountEarlyPaymentDiscount::test_mixed_epd_with_tax_included

These errors occurs on Odoo Enterprise.

Traceback below of `TestAccountEarlyPaymentDiscount.test_mixed_epd_with_draft_invoice`

```
ERROR: TestAccountEarlyPaymentDiscount.test_mixed_epd_with_draft_invoice
Traceback (most recent call last):
  File "/home/odoo/src/odoo/addons/account/tests/test_early_payment_discount.py", line 473, in test_mixed_epd_with_draft_invoice
    with invoice.invoice_line_ids.new() as line_form:
  File "/home/odoo/src/odoo/odoo/tests/form.py", line 425, in __exit__
    self.save()
  File "/home/odoo/src/odoo/odoo/tests/form.py", line 677, in save
    proxy._form._perform_onchange(proxy._field)
  File "/home/odoo/src/odoo/odoo/tests/form.py", line 567, in _perform_onchange
    result = record.onchange(values, field_names, self._view['fields_spec'])
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/addons/account/models/account_move.py", line 3415, in onchange
    return super().onchange(values, field_names, fields_spec)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/addons/web/models/models.py", line 1015, in onchange
    if field_name not in done and snapshot0.has_changed(field_name)
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/addons/web/models/models.py", line 1129, in has_changed
    return self[field_name].keys() != set(self.record[field_name]._ids) or any(
                                          ~~~~~~~~~~~^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/models.py", line 7075, in __getitem__
    return self._fields[key].__get__(self)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/fields.py", line 3059, in __get__
    return super().__get__(records, owner)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/fields.py", line 1303, in __get__
    self.compute_value(recs)
  File "/home/odoo/src/odoo/odoo/fields.py", line 1485, in compute_value
    records._compute_field_value(self)
  File "/home/odoo/src/odoo/addons/mail/models/mail_thread.py", line 427, in _compute_field_value
    return super()._compute_field_value(field)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/models.py", line 5294, in _compute_field_value
    fields.determine(field.compute, self)
  File "/home/odoo/src/odoo/odoo/fields.py", line 110, in determine
    return needle(*args)
           ^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/addons/account/models/account_move.py", line 1863, in _compute_duplicated_ref_ids
    move_to_duplicate_move = self._fetch_duplicate_reference()
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/addons/account/models/account_move.py", line 1889, in _fetch_duplicate_reference
    values['amount_total'] = self.tax_totals.get('total_amount_currency', 0)
                             ^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/fields.py", line 1303, in __get__
    self.compute_value(recs)
  File "/home/odoo/src/odoo/odoo/fields.py", line 2576, in compute_value
    super().compute_value(records)
  File "/home/odoo/src/odoo/odoo/fields.py", line 1485, in compute_value
    records._compute_field_value(self)
  File "/home/odoo/src/odoo/addons/mail/models/mail_thread.py", line 427, in _compute_field_value
    return super()._compute_field_value(field)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/models.py", line 5294, in _compute_field_value
    fields.determine(field.compute, self)
  File "/home/odoo/src/odoo/odoo/fields.py", line 110, in determine
    return needle(*args)
           ^^^^^^^^^^^^^
  File "/home/odoo/src/enterprise/account_external_tax/models/account_move.py", line 14, in _compute_tax_totals
    super()._compute_tax_totals()
  File "/home/odoo/src/odoo/addons/account/models/account_move.py", line 1617, in _compute_tax_totals
    base_lines, _tax_lines = move._get_rounded_base_and_tax_lines()
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/addons/account/models/account_move.py", line 1595, in _get_rounded_base_and_tax_lines
    base_lines += self._prepare_epd_base_lines_for_taxes_computation_from_base_lines(base_amls)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/addons/account/models/account_move.py", line 1509, in _prepare_epd_base_lines_for_taxes_computation_from_base_lines
    epd_lines.append(self.env['account.tax']._prepare_base_line_for_taxes_computation(
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/user/OCA/account-invoicing/account_invoice_fixed_discount/models/account_tax.py", line 13, in _prepare_base_line_for_taxes_computation
    if record and record._name == "account.move.line" and record.discount_fixed:
                  ^^^^^^^^^^^^
AttributeError: 'dict' object has no attribute '_name'
```

Traceback below of `TestAccountEarlyPaymentDiscount::test_mixed_epd_with_tax_included`

```
ERROR: TestAccountEarlyPaymentDiscount.test_mixed_epd_with_tax_included
Traceback (most recent call last):
  File "/Users/red/odoo/addons/account/tests/test_early_payment_discount.py", line 662, in test_mixed_epd_with_tax_included
    with invoice.invoice_line_ids.new() as line_form:
  File "/Users/red/odoo/odoo/tests/form.py", line 425, in __exit__
    self.save()
  File "/Users/red/odoo/odoo/tests/form.py", line 677, in save
    proxy._form._perform_onchange(proxy._field)
  File "/Users/red/odoo/odoo/tests/form.py", line 567, in _perform_onchange
    result = record.onchange(values, field_names, self._view['fields_spec'])
  File "/Users/red/odoo/addons/account/models/account_move.py", line 3396, in onchange
    return super().onchange(values, field_names, fields_spec)
  File "/Users/red/odoo/addons/web/models/models.py", line 1012, in onchange
    todo = [
  File "/Users/red/odoo/addons/web/models/models.py", line 1015, in <listcomp>
    if field_name not in done and snapshot0.has_changed(field_name)
  File "/Users/red/odoo/addons/web/models/models.py", line 1129, in has_changed
    return self[field_name].keys() != set(self.record[field_name]._ids) or any(
  File "/Users/red/odoo/odoo/models.py", line 7061, in __getitem__
    return self._fields[key].__get__(self)
  File "/Users/red/odoo/odoo/fields.py", line 3059, in __get__
    return super().__get__(records, owner)
  File "/Users/red/odoo/odoo/fields.py", line 1303, in __get__
    self.compute_value(recs)
  File "/Users/red/odoo/odoo/fields.py", line 1485, in compute_value
    records._compute_field_value(self)
  File "/Users/red/odoo/addons/mail/models/mail_thread.py", line 427, in _compute_field_value
    return super()._compute_field_value(field)
  File "/Users/red/odoo/odoo/models.py", line 5280, in _compute_field_value
    fields.determine(field.compute, self)
  File "/Users/red/odoo/odoo/fields.py", line 110, in determine
    return needle(*args)
  File "/Users/red/odoo/addons/account/models/account_move.py", line 1844, in _compute_duplicated_ref_ids
    move_to_duplicate_move = self._fetch_duplicate_reference()
  File "/Users/red/odoo/addons/account/models/account_move.py", line 1870, in _fetch_duplicate_reference
    values['amount_total'] = self.tax_totals.get('total_amount_currency', 0)
  File "/Users/red/odoo/odoo/fields.py", line 1303, in __get__
    self.compute_value(recs)
  File "/Users/red/odoo/odoo/fields.py", line 2576, in compute_value
    super().compute_value(records)
  File "/Users/red/odoo/odoo/fields.py", line 1485, in compute_value
    records._compute_field_value(self)
  File "/Users/red/odoo/addons/mail/models/mail_thread.py", line 427, in _compute_field_value
    return super()._compute_field_value(field)
  File "/Users/red/odoo/odoo/models.py", line 5280, in _compute_field_value
    fields.determine(field.compute, self)
  File "/Users/red/odoo/odoo/fields.py", line 110, in determine
    return needle(*args)
  File "/Users/red/odoo/custom_addons/enterprise-18.0/account_external_tax/models/account_move.py", line 14, in _compute_tax_totals
    super()._compute_tax_totals()
  File "/Users/red/odoo/addons/account/models/account_move.py", line 1598, in _compute_tax_totals
    base_lines, _tax_lines = move._get_rounded_base_and_tax_lines()
  File "/Users/red/odoo/addons/account/models/account_move.py", line 1576, in _get_rounded_base_and_tax_lines
    base_lines += self._prepare_epd_base_lines_for_taxes_computation_from_base_lines(base_amls)
  File "/Users/red/odoo/addons/account/models/account_move.py", line 1490, in _prepare_epd_base_lines_for_taxes_computation_from_base_lines
    epd_lines.append(self.env['account.tax']._prepare_base_line_for_taxes_computation(
  File "/Users/red/odoo/custom_addons/account-invoicing/account_invoice_fixed_discount/models/account_tax.py", line 38, in _prepare_base_line_for_taxes_computation
    if record and record._name == "account.move.line" and record.discount_fixed:
AttributeError: 'dict' object has no attribute '_name'
```

## **How was the change implemented?**

- Fix overriding of method `_prepare_base_line_for_taxes_computation` in `account-invoicing/account_invoice_fixed_discount/models/account_tax.py`
- Add condition to check if the `record` is an instance of dictionary.

## **Unit tests executed by the author**

- TestAccountEarlyPaymentDiscount::test_mixed_epd_with_draft_invoice
- TestAccountEarlyPaymentDiscount::test_mixed_epd_with_tax_included
