### PR TITLE
[16.0][IMP] account_invoice_show_currency_rate: add option to choose currency rate display format

### DIFF
--- a/account_invoice_show_currency_rate/README.rst
+++ b/account_invoice_show_currency_rate/README.rst
@@ -53,6 +53,11 @@ Some rates must be defined (and be distinct to 1.0) for currencies different fro
 #. Go to Rates smart-button
 #. Update 01/01/2010 record and change rate to 1.5
 
+To change the currency rate display style on invoices:
+
+- Go to Accounting (or Invoicing) → Configuration → Settings.
+- In the Invoice Rate Display Type section, select the default display type for all currencies.
+
 Usage
 =====
 
@@ -87,6 +92,11 @@ Contributors
 
   * Pedro M. Baeza
   * Víctor Martínez
+
+* `Quartle <https://www.quartile.co>`_:
+
+  * Aung Ko Ko Lin
+  * Yoshi Tashiro
 
 Maintainers
 ~~~~~~~~~~~

--- a/account_invoice_show_currency_rate/__manifest__.py
+++ b/account_invoice_show_currency_rate/__manifest__.py
@@ -11,5 +11,8 @@
     "installable": True,
     "depends": ["account"],
     "maintainers": ["victoralmau"],
-    "data": ["views/account_move_view.xml"],
+    "data": [
+        "views/account_move_view.xml",
+        "views/res_config_settings_views.xml",
+    ],
 }

--- a/account_invoice_show_currency_rate/models/__init__.py
+++ b/account_invoice_show_currency_rate/models/__init__.py
@@ -1,1 +1,3 @@
 from . import account_move
+from . import res_company
+from . import res_config_settings

--- a/account_invoice_show_currency_rate/models/account_move.py
+++ b/account_invoice_show_currency_rate/models/account_move.py
@@ -32,6 +32,7 @@ class AccountMove(models.Model):
         - Case C: Get expected rate (according to date) to show some value in creation.
         """
         self.currency_rate_amount = 1
+        inverse = self.env.company.invoice_rate_display_type == "inverse_rate"
         for item in self.filtered("show_currency_rate_amount"):
             lines = item.line_ids.filtered(lambda x: abs(x.amount_currency) > 0)
             if item.state == "posted" and lines:
@@ -40,11 +41,19 @@ class AccountMove(models.Model):
                 )
                 total_balance_positive = sum([abs(b) for b in lines.mapped("balance")])
                 item.currency_rate_amount = (
-                    amount_currency_positive / total_balance_positive
+                    (amount_currency_positive / total_balance_positive)
+                    if not inverse
+                    else (total_balance_positive / amount_currency_positive)
                 )
             else:
                 rates = item.currency_id._get_rates(item.company_id, item.date)
-                item.currency_rate_amount = rates.get(item.currency_id.id)
+                item.currency_rate_amount = (
+                    rates.get(item.currency_id.id)
+                    if not inverse
+                    else item.currency_id._convert(
+                        1.0, item.company_id.currency_id, item.company_id, item.date
+                    )
+                )
 
     @api.depends("currency_id", "currency_id.rate_ids", "company_id")
     def _compute_show_currency_rate_amount(self):

--- a/account_invoice_show_currency_rate/models/res_company.py
+++ b/account_invoice_show_currency_rate/models/res_company.py
@@ -1,0 +1,23 @@
+# Copyright 2025 Quartile (https://www.quartile.co)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    invoice_rate_display_type = fields.Selection(
+        [
+            ("normal", "Unit per Company Currency"),
+            ("inverse_rate", "Company Currency per Unit"),
+        ],
+        default="normal",
+        required=True,
+        help=(
+            "Select how to display exchange rates on invoices.\n"
+            "Example (company currency: JPY; 1 USD = 150 JPY):\n"
+            "- Unit per company currency → 0.0066 (USD per JPY)\n"
+            "- Company currency per unit → 150 (JPY per USD)"
+        ),
+    )

--- a/account_invoice_show_currency_rate/models/res_config_settings.py
+++ b/account_invoice_show_currency_rate/models/res_config_settings.py
@@ -1,0 +1,12 @@
+# Copyright 2025 Quartile (https://www.quartile.co)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    invoice_rate_display_type = fields.Selection(
+        related="company_id.invoice_rate_display_type", readonly=False
+    )

--- a/account_invoice_show_currency_rate/readme/CONFIGURE.rst
+++ b/account_invoice_show_currency_rate/readme/CONFIGURE.rst
@@ -12,3 +12,8 @@ Some rates must be defined (and be distinct to 1.0) for currencies different fro
 #. Go to Invoicing > Configuration > Currencies and go to EUR
 #. Go to Rates smart-button
 #. Update 01/01/2010 record and change rate to 1.5
+
+To change the currency rate display style on invoices:
+
+- Go to Accounting (or Invoicing) → Configuration → Settings.
+- In the Invoice Rate Display Type section, select the default display type for all currencies.

--- a/account_invoice_show_currency_rate/readme/CONTRIBUTORS.rst
+++ b/account_invoice_show_currency_rate/readme/CONTRIBUTORS.rst
@@ -2,3 +2,8 @@
 
   * Pedro M. Baeza
   * Víctor Martínez
+
+* `Quartle <https://www.quartile.co>`_:
+
+  * Aung Ko Ko Lin
+  * Yoshi Tashiro

--- a/account_invoice_show_currency_rate/static/description/index.html
+++ b/account_invoice_show_currency_rate/static/description/index.html
@@ -8,11 +8,10 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
+:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
-Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +274,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: gray; } /* line numbers */
+pre.code .ln { color: grey; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +300,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic, pre.problematic {
+span.problematic {
   color: red }
 
 span.section-subtitle {
@@ -402,6 +401,11 @@ ul.auto-toc {
 <li>Go to Rates smart-button</li>
 <li>Update 01/01/2010 record and change rate to 1.5</li>
 </ol>
+<p>To change the currency rate display style on invoices:</p>
+<ul class="simple">
+<li>Go to Accounting (or Invoicing) → Configuration → Settings.</li>
+<li>In the Invoice Rate Display Type section, select the default display type for all currencies.</li>
+</ul>
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#toc-entry-2">Usage</a></h1>
@@ -436,14 +440,17 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Víctor Martínez</li>
 </ul>
 </li>
+<li><a class="reference external" href="https://www.quartile.co">Quartle</a>:<ul>
+<li>Aung Ko Ko Lin</li>
+<li>Yoshi Tashiro</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org">
-<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
-</a>
+<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/account_invoice_show_currency_rate/tests/test_account_move.py
+++ b/account_invoice_show_currency_rate/tests/test_account_move.py
@@ -92,3 +92,16 @@ class TestAccountMove(common.TransactionCase):
         invoice.button_draft()
         self.assertAlmostEqual(invoice.currency_rate_amount, 3.0, 2)
         self.assertAlmostEqual(invoice.line_ids[0].currency_rate, 3.0, 2)
+
+    def test_02_invoice_currency_extra_inverse_rate(self):
+        self.partner.property_product_pricelist = self.pricelist_currency_extra
+        self.env.company.invoice_rate_display_type = "inverse_rate"
+        invoice = self._create_invoice(self.currency_extra)
+        self.assertAlmostEqual(invoice.currency_rate_amount, 0.5, 2)
+        rate_custom = self.currency_extra.rate_ids.filtered(
+            lambda x: x.name == fields.Date.from_string("2000-01-01")
+        )
+        rate_custom.rate = 3.0
+        self.assertAlmostEqual(invoice.currency_rate_amount, 0.5, 2)
+        invoice.button_draft()
+        self.assertAlmostEqual(invoice.currency_rate_amount, 0.33, 2)

--- a/account_invoice_show_currency_rate/views/res_config_settings_views.xml
+++ b/account_invoice_show_currency_rate/views/res_config_settings_views.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="account.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[@id='main_currency']" position="after">
+                <div
+                    class="col-12 col-lg-6 o_setting_box"
+                    id="invoice_rate_display_type"
+                >
+                    <div class="o_setting_right_pane">
+                        <label for="invoice_rate_display_type" />
+                        <div class="text-muted">
+                            Currency Rate Display Type on Invoice
+                        </div>
+                        <div class="content-group">
+                            <div class="mt16">
+                                <field
+                                    name="invoice_rate_display_type"
+                                    class="o_light_label mt16"
+                                    widget="radio"
+                                />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This PR adds an option to display the exchange rate either as company currency per unit or unit per company currency.

Example (company currency: JPY; 1 USD = 150 JPY):

- (Default) Unit per Company Currency → 0.0066 (USD/JPY)
- Company Currency per Unit → 150 (JPY/USD)

@qrtl QT5684