### PR TITLE
[15.0][FIX] account_manual_currency: recompute tax include

### DIFF
--- a/account_manual_currency/models/account_move.py
+++ b/account_manual_currency/models/account_move.py
@@ -136,6 +136,34 @@ class AccountMove(models.Model):
             result["arch"] = etree.tostring(doc, encoding="unicode")
         return result
 
+    def _recompute_tax_lines(
+        self, recompute_tax_base_amount=False, tax_rep_lines_to_recompute=None
+    ):
+        """Recmpute tax with manual currency"""
+        self.ensure_one()
+        res = super()._recompute_tax_lines(
+            recompute_tax_base_amount=recompute_tax_base_amount,
+            tax_rep_lines_to_recompute=tax_rep_lines_to_recompute,
+        )
+        if self.manual_currency:
+            for line_tax in self.line_ids:
+                if not line_tax.tax_line_id:
+                    continue
+
+                rate = (
+                    self.manual_currency_rate
+                    if self.type_currency == "inverse_company_rate"
+                    else (1.0 / self.manual_currency_rate)
+                )
+                balance = line_tax.amount_currency * rate
+                line_tax.debit = balance if balance > 0.0 else 0.0
+                line_tax.credit = -balance if balance < 0.0 else 0.0
+                # Recompute again
+                if not line_tax.tax_line_id.price_include:
+                    self.line_ids._onchange_amount_currency()
+
+        return res
+
 
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"


### PR DESCRIPTION
Step to test
1. create move with **tax include** and use manual currency
<img width="1143" height="681" alt="Selection_017" src="https://github.com/user-attachments/assets/a8c3d039-8d52-4a45-874b-264561906906" />

2. Total (USD) is 50 but in Journal Items line tax still compute with old currency. So, **total amount is 63.42 is not equal 50**
<img width="1135" height="276" alt="Selection_018" src="https://github.com/user-attachments/assets/9e3c5c05-2fda-45a8-956e-93a5d55ab950" />

This PR fixed recompute tax when manual currency
<img width="1133" height="278" alt="Selection_019" src="https://github.com/user-attachments/assets/6395f3b2-d409-450e-ba12-6ab6ea0e4c7d" />
