### PR TITLE
[IMP] account_invoice_merge: Añadido para que el campo invoice_incoterm_id se tenga en cuenta y deba ser igual para fusionar las facturas. odoo-16/fl-v16#6679

### DIFF
--- a/account_invoice_merge/models/account_move.py
+++ b/account_invoice_merge/models/account_move.py
@@ -25,6 +25,7 @@ class AccountMove(models.Model):
             "journal_id",
             "company_id",
             "partner_bank_id",
+            "invoice_incoterm_id",
         ]
 
     @api.model


### PR DESCRIPTION
[IMP] account_invoice_merge: Añadido para que el campo invoice_incoterm_id se tenga en cuenta y deba ser igual para fusionar las facturas.
odoo-16/fl-v16#6679
