### PR TITLE
[16.0][FIX] account_invoice_alternate_payer: Add missing move_id field to outstanding credits widget data

### DIFF
--- a/account_invoice_alternate_payer/models/account_move.py
+++ b/account_invoice_alternate_payer/models/account_move.py
@@ -131,6 +131,7 @@ class AccountMove(models.Model):
                         "amount": amount_to_show,
                         "currency": currency_id.symbol,
                         "id": line.id,
+                        "move_id": line.move_id.id,
                         "position": currency_id.position,
                         "digits": [69, move.currency_id.decimal_places],
                         "payment_date": fields.Date.to_string(line.date),


### PR DESCRIPTION
The custom _compute_payments_widget_to_reconcile_info method was missing the move_id field in the widget content data structure, causing undefined moveId errors when clicking outstanding credits in invoice forms.