### PR TITLE
[18.0][IMP] account_invoice_warn_message: show warning for vendor invoices too

### DIFF
--- a/account_invoice_warn_message/models/account_move.py
+++ b/account_invoice_warn_message/models/account_move.py
@@ -19,7 +19,8 @@ class AccountMove(models.Model):
         for rec in self:
             if (
                 rec.partner_id
-                and rec.move_type in ("out_invoice", "out_refund")
+                and rec.move_type
+                in ("out_invoice", "out_refund", "in_invoice", "in_refund")
                 and rec.state == "draft"
             ):
                 if (

--- a/account_invoice_warn_message/tests/test_account_invoice_warn_message.py
+++ b/account_invoice_warn_message/tests/test_account_invoice_warn_message.py
@@ -103,7 +103,7 @@ class TestAccountInvoiceWarnMessage(BaseCommon):
                 ],
             }
         )
-        self.assertFalse(invoice.invoice_warn_msg)
+        self.assertTrue(invoice.invoice_warn_msg)
 
     def test_compute_invoice_warn_msg_posted_state(self):
         invoice = self.env["account.move"].create(


### PR DESCRIPTION
The warning already shows in the standard Odoo onchange_partner method but the banner is not in vendor bills. I think it should be there.

It shows the warning anyway:
<img width="1258" height="279" alt="image" src="https://github.com/user-attachments/assets/a5bab2b7-d119-438d-9c44-d5f77ad65a7a" />

no harm to show the banner:
<img width="776" height="206" alt="image" src="https://github.com/user-attachments/assets/7a3a1825-b926-4925-ac63-598fead57c1d" />

