### PR TITLE
[FIX] account_invoice_alternate_payer: Add missing move_id field to o…

### DIFF
--- a/account_invoice_alternate_payer/models/account_move.py
+++ b/account_invoice_alternate_payer/models/account_move.py
@@ -131,6 +131,7 @@ class AccountMove(models.Model):
                         "amount": amount_to_show,
                         "currency": currency_id.symbol,
                         "id": line.id,
+                        "move_id": line.move_id.id,
                         "position": currency_id.position,
                         "digits": [69, move.currency_id.decimal_places],
                         "payment_date": fields.Date.to_string(line.date),


### PR DESCRIPTION
…utstanding credits widget data

  The custom _compute_payments_widget_to_reconcile_info method was missing
  the move_id field in the widget content data structure, causing undefined
  moveId errors when clicking outstanding credits in invoice forms.

(cherry picked from commit bd79d9b33756661fb6377c66782bce9b3f62fe14)