### PR TITLE
[14.0][IMP] account_invoice_section_sale_order add ability to localize datetime

### DIFF
--- a/account_invoice_section_sale_order/__manifest__.py
+++ b/account_invoice_section_sale_order/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Acccount Invoice Section Sale Order",
-    "version": "14.0.1.3.2",
+    "version": "14.0.1.3.3",
     "summary": "For invoices targetting multiple sale order add"
     "sections with sale order name.",
     "author": "Camptocamp, Odoo Community Association (OCA)",

--- a/account_invoice_section_sale_order/models/sale_order.py
+++ b/account_invoice_section_sale_order/models/sale_order.py
@@ -1,6 +1,10 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+import re
 from collections import OrderedDict
+from datetime import datetime
+
+import pytz
 
 from odoo import models
 from odoo.tools.safe_eval import safe_eval, time
@@ -69,6 +73,18 @@ class SaleOrder(models.Model):
             invoice.line_ids = section_lines
         return invoices
 
+    def localize(self, date_to_localize=None, strftime_var="%m-%d-%Y"):
+        tz = self.env.user.tz
+        if tz:
+            local_tz = pytz.timezone(tz)
+        else:
+            local_tz = pytz.utc
+        return (
+            pytz.utc.localize(date_to_localize)
+            .astimezone(local_tz)
+            .strftime(strftime_var)
+        )
+
     def _get_invoice_section_name(self):
         """Returns the text for the section name."""
         self.ensure_one()
@@ -76,6 +92,28 @@ class SaleOrder(models.Model):
             self.partner_invoice_id.invoice_section_name_scheme
             or self.company_id.invoice_section_name_scheme
         )
+
+        if naming_scheme and "object" in naming_scheme:
+            fields_to_localize = re.finditer(r"object.(\w+)", naming_scheme)
+            for field_to_localize in fields_to_localize:
+                object_field_name = field_to_localize.group(0).replace("object.", "")
+                if not hasattr(self, object_field_name):
+                    continue
+                object_field = getattr(self, object_field_name)
+                if isinstance(object_field, datetime):
+                    strftime_pattern = re.compile(r".strftime\(.*?\)")
+                    strftime_match = strftime_pattern.search(
+                        naming_scheme, field_to_localize.end()
+                    )
+                    if strftime_match:
+                        strftime_var = strftime_match.group(0)
+                        naming_scheme = naming_scheme.replace(
+                            f"{field_to_localize.group(0)}{strftime_var}",
+                            self.localize(
+                                object_field,
+                                strftime_var.replace(".strftime(", "").replace(")", ""),
+                            ),
+                        )
         if naming_scheme:
             return safe_eval(naming_scheme, {"object": self, "time": time})
         elif self.client_order_ref:

--- a/account_invoice_section_sale_order/static/description/index.html
+++ b/account_invoice_section_sale_order/static/description/index.html
@@ -8,11 +8,10 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
+:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
-Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +274,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: gray; } /* line numbers */
+pre.code .ln { color: grey; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +300,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic, pre.problematic {
+span.problematic {
   color: red }
 
 span.section-subtitle {
@@ -427,9 +426,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org">
-<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
-</a>
+<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION
Without this PR setting a datetime in naming_schema like:

`object.date_order.strftime('%d/%m/%Y')`

in a timezone different from UTC will produce a date not localized and sometimes wrong.