### PR TITLE
[18.0][FIX] account_move_cancel_confirm: remove assert related to payment state in test

### DIFF
--- a/account_move_cancel_confirm/tests/test_account_move_cancel_confirm.py
+++ b/account_move_cancel_confirm/tests/test_account_move_cancel_confirm.py
@@ -84,7 +84,6 @@ class TestAccountMoveCancelConfirm(TransactionCase):
         payment = payment_register_form.save()
         payment.action_create_payments()
         payment = self.payment_model.search([], order="id desc", limit=1)
-        self.assertEqual(payment.state, "paid")
         # Click cance, cancel confirm wizard will open. Type in cancel_reason
         res = payment.action_cancel()
         ctx = res.get("context")


### PR DESCRIPTION
This assert is not related to the module, because this module doesn’t change anything related to the payment state, and this assert becomes problematic, so we removed it.

Technically: when a vendor bill is paid, the payment state remains in_process instead of paid. This occurs because in _compute_state, when considering whether all invoices are paid, it uses the field reconciled_invoice_ids, which only takes sales documents.
See https://github.com/odoo/odoo/blob/1cac54db8634267a780b4011291f1e8a80ac5f5b/addons/account/models/account_payment.py#L428

https://github.com/odoo/odoo/blob/1cac54db8634267a780b4011291f1e8a80ac5f5b/addons/account/models/account_payment.py#L699

<img width="1469" height="473" alt="image" src="https://github.com/user-attachments/assets/0ce673f6-123d-473e-9be4-774eb551e699" />


This PR fixes all CI failures in V18, such as: https://github.com/OCA/account-invoicing/pull/2140 https://github.com/OCA/account-invoicing/pull/2135 https://github.com/OCA/account-invoicing/pull/2133 https://github.com/OCA/account-invoicing/pull/2063

@Tecnativa @pedrobaeza @sabrinaRMartin could you review this please?