### PR TITLE
[18.0][FIX] account_manual_currency: total_company_currency conversion date

### DIFF
--- a/account_manual_currency/models/account_move.py
+++ b/account_manual_currency/models/account_move.py
@@ -54,7 +54,7 @@ class AccountMove(models.Model):
                     rec.amount_total,
                     rec.company_currency_id,
                     rec.company_id,
-                    fields.Date.today(),
+                    rec._get_invoice_currency_rate_date(),
                 )
 
     def _get_label_currency_name(self):


### PR DESCRIPTION
Use invoice's currency rate date instead of always today's date.