### PR TITLE
[16.0][FIX] account_invoicing_pricelist: compute price recalcule

### DIFF
--- a/account_invoice_pricelist/models/account_move.py
+++ b/account_invoice_pricelist/models/account_move.py
@@ -62,12 +62,19 @@ class AccountMove(models.Model):
             lambda r: r.state == "draft"
         ).invoice_line_ids._compute_price_unit()
 
+    def action_switch_invoice_into_refund_credit_note(self):
+        return super(
+            AccountMove, self.with_context(avoid_price_unit_compute=True)
+        ).action_switch_invoice_into_refund_credit_note()
+
 
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
 
     @api.depends("quantity")
     def _compute_price_unit(self):
+        if self.env.context.get("avoid_price_unit_compute", False):
+            return True
         res = super()._compute_price_unit()
         for line in self:
             if not line.move_id.pricelist_id:

--- a/account_invoice_pricelist/tests/test_account_move_pricelist.py
+++ b/account_invoice_pricelist/tests/test_account_move_pricelist.py
@@ -316,3 +316,11 @@ class TestAccountMovePricelist(BaseCommon):
             self.invoice.with_context(force_check_currecy=True).write(
                 {"currency_id": self.usd_currency.id}
             )
+
+    def test_switch_invoice_into_refund_credit_note(self):
+        self.invoice.pricelist_id = self.sale_pricelist_with_discount.id
+        self.invoice.invoice_line_ids.write({"price_unit": -100.00})
+        self.invoice.action_switch_invoice_into_refund_credit_note()
+        self.assertEqual(self.invoice.move_type, "out_refund")
+        self.assertEqual(self.invoice.invoice_line_ids[0].price_unit, -100.00)
+        self.assertEqual(self.invoice.amount_total, 230.00)


### PR DESCRIPTION
This change is to prevent the unit price from being recalculated since when making a refund invoice the price is recalculated and the price of the product is taken.