### PR TITLE
[IMP] account_move_sent_usability: don't show cancelled in Not Sent filter

### DIFF
--- a/account_move_sent_usability/views/account_move.xml
+++ b/account_move_sent_usability/views/account_move.xml
@@ -14,7 +14,7 @@
                 <filter
                     name="unsent"
                     string="Not Sent"
-                    domain="[('is_move_sent', '=', False)]"
+                    domain="[('is_move_sent', '=', False), ('state', '!=', 'cancel')]"
                 />
                 <filter
                     name="sent"


### PR DESCRIPTION
Such invoices will never be sent, so they pollute the list.