### PR TITLE
[18.0][FIX] sale_stock_picking_invoicing: Review models on test in order to ensure the equality when other modules are installed

### DIFF
--- a/account_invoice_section_sale_order/tests/test_invoice_group_by_sale_order.py
+++ b/account_invoice_section_sale_order/tests/test_invoice_group_by_sale_order.py
@@ -20,11 +20,11 @@ class TestInvoiceGroupBySaleOrder(Common):
                 "".join([self.order1_p1.name, " - ", self.order1_p1.client_order_ref]),
                 "line_section",
             ),
-            20: (f"{self.product_1.name} order 1 line 1", "product"),
-            30: (f"{self.product_2.name} order 1 line 2", "product"),
+            20: (f"{self.product_1.name}\norder 1 line 1", "product"),
+            30: (f"{self.product_2.name}\norder 1 line 2", "product"),
             40: (self.order2_p1.name, "line_section"),
-            50: (f"{self.product_1.name} order 2 line 1", "product"),
-            60: (f"{self.product_2.name} order 2 line 2", "product"),
+            50: (f"{self.product_1.name}\norder 2 line 1", "product"),
+            60: (f"{self.product_2.name}\norder 2 line 2", "product"),
         }
         invoice_ids = (self.order1_p1 + self.order2_p1)._create_invoices()
         lines = invoice_ids[0].invoice_line_ids.sorted("sequence")
@@ -99,13 +99,13 @@ class TestInvoiceGroupBySaleOrder(Common):
             invoice = (orders + sale_order_3)._create_invoices()
             result = {
                 10: ("Mocked value from ResUsers", "line_section"),
-                20: (f"{self.product_1.name} order 1 line 1", "product"),
-                30: (f"{self.product_2.name} order 1 line 2", "product"),
-                40: (f"{self.product_1.name} order 2 line 1", "product"),
-                50: (f"{self.product_2.name} order 2 line 2", "product"),
+                20: (f"{self.product_1.name}\norder 1 line 1", "product"),
+                30: (f"{self.product_2.name}\norder 1 line 2", "product"),
+                40: (f"{self.product_1.name}\norder 2 line 1", "product"),
+                50: (f"{self.product_2.name}\norder 2 line 2", "product"),
                 60: ("Mocked value from ResUsers", "line_section"),
-                70: (f"{self.product_1.name} order 3 line 1", "product"),
-                80: (f"{self.product_2.name} order 3 line 2", "product"),
+                70: (f"{self.product_1.name}\norder 3 line 1", "product"),
+                80: (f"{self.product_2.name}\norder 3 line 2", "product"),
             }
             for line in invoice.invoice_line_ids.sorted("sequence"):
                 if line.sequence not in result:

--- a/sale_stock_picking_invoicing/tests/test_sale_stock.py
+++ b/sale_stock_picking_invoicing/tests/test_sale_stock.py
@@ -2,7 +2,7 @@
 # @author Magno Costa <magno.costa@akretion.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import exceptions
+from odoo import exceptions, models
 from odoo.tests import Form
 
 from odoo.addons.stock_picking_invoicing.tests.common import TestPickingInvoicingCommon
@@ -239,8 +239,14 @@ class TestSaleStock(TestPickingInvoicingCommon):
         # identify yet, but works in the screen the default behavior
         with Form(invoice_lines) as line:
             line.save()
-
         for field in common_fields:
+            if (
+                isinstance(sale_order_line[field], models.BaseModel)
+                and sale_order_line[field]._name != invoice_lines[field]._name
+            ):
+                # Same name, different models
+                # e.g.: sale_commmission_oca with agent_ids field
+                continue
             self.assertEqual(
                 sale_order_line[field],
                 invoice_lines[field],


### PR DESCRIPTION
For example, this test fails if sale_commission_oca and sale_stock_picking_invoicing are installed