### PR TITLE
[18.0][FIX] account_manual_currency: handle float division by zero

### DIFF
--- a/account_manual_currency/models/account_move.py
+++ b/account_manual_currency/models/account_move.py
@@ -168,7 +168,10 @@ class AccountMoveLine(models.Model):
     def _compute_currency_rate(self):
         res = super()._compute_currency_rate()
         for line in self:
-            if not line.move_id.manual_currency:
+            if not (
+                line.move_id.manual_currency
+                and line.move_id._origin.manual_currency_rate
+            ):
                 continue
             # Currency Rate on move line use 'company_rate'
             rate = (


### PR DESCRIPTION
Steps to reproduce the  error

1. Create a Purchase Order with foreign currency (company currency = USD, PO currency = THB)
<img width="1397" height="717" alt="image" src="https://github.com/user-attachments/assets/57287211-cd33-417e-a441-5aedacc0fcf7" />

2. After validate stock picking -> Create bill from PO -> select `Manual Currency` and switch `Currency per 1 USD` to `USD per 1 Currency`
<img width="1404" height="698" alt="image" src="https://github.com/user-attachments/assets/b3ca607e-1917-4cf5-bbe5-7f29775a489b" />

Then error occurred as below



```python
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 2166, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "/opt/odoo/custom/src/odoo/odoo/service/model.py", line 156, in retrying
    result = func()
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 2133, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 2381, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_http.py", line 333, in _dispatch
    result = endpoint(**request.params)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 754, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/opt/odoo/auto/addons/web/controllers/dataset.py", line 36, in call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 535, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "/opt/odoo/auto/addons/account/models/account_move.py", line 3527, in onchange
    return super().onchange(values, field_names, fields_spec)
  File "/opt/odoo/auto/addons/web/models/models.py", line 1012, in onchange
    todo = [
  File "/opt/odoo/auto/addons/web/models/models.py", line 1015, in <listcomp>
    if field_name not in done and snapshot0.has_changed(field_name)
  File "/opt/odoo/auto/addons/web/models/models.py", line 1129, in has_changed
    return self[field_name].keys() != set(self.record[field_name]._ids) or any(
  File "/opt/odoo/auto/addons/web/models/models.py", line 1130, in <genexpr>
    line_snapshot.has_changed(subname)
  File "/opt/odoo/auto/addons/web/models/models.py", line 1128, in has_changed
    return self[field_name] != self.record[field_name]
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 7078, in __getitem__
    return self._fields[key].__get__(self)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1305, in __get__
    self.compute_value(recs)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1487, in compute_value
    records._compute_field_value(self)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 5297, in _compute_field_value
    fields.determine(field.compute, self)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 110, in determine
    return needle(*args)
  File "/opt/odoo/auto/addons/account_manual_currency/models/account_move.py", line 177, in _compute_currency_rate
    else (1.0 / line.move_id._origin.manual_currency_rate)
ZeroDivisionError: float division by zero
```