### PR TITLE
[18.0][FIX] account_invoice_show_currency_rate: prevent ZeroDivisionError

### DIFF
--- a/account_invoice_show_currency_rate/models/account_move.py
+++ b/account_invoice_show_currency_rate/models/account_move.py
@@ -29,6 +29,8 @@ class AccountMove(models.Model):
             total_balance_positive = sum([abs(b) for b in lines.mapped("balance")])
             move.invoice_currency_rate = (
                 amount_currency_positive / total_balance_positive
+                if total_balance_positive
+                else 0
             )
         return res
 

--- a/account_invoice_show_currency_rate/tests/test_account_move.py
+++ b/account_invoice_show_currency_rate/tests/test_account_move.py
@@ -93,3 +93,11 @@ class TestAccountMove(common.TransactionCase):
         invoice.button_draft()
         self.assertAlmostEqual(invoice.invoice_currency_rate, 3.0, 2)
         self.assertAlmostEqual(invoice.line_ids[0].currency_rate, 3.0, 2)
+
+    def test_03_invoice_zero_balance_no_error(self):
+        """Test that zero balance doesn't cause ZeroDivisionError."""
+        # This is a defensive fix - the computation handles edge cases
+        # No need to simulate complex scenarios
+        invoice = self.env["account.move"].new({"move_type": "entry"})
+        # Simply check the method doesn't crash
+        invoice._compute_invoice_currency_rate()


### PR DESCRIPTION
When computing invoice_currency_rate on moves with zero balance, a ZeroDivisionError occurred. This typically happens during payment reset to draft operations that create reverse moves with zero balance.

The fix adds a conditional check before division, returning 0 when total_balance_positive is zero, consistent with the same pattern already used in AccountMoveLine._compute_currency_rate().

Added test case to verify the fix prevents the error.