### PR TITLE
[16.0][FIX] purchase_invoicing_no_zero_line: use default UoM precision when filtering zero-qty lines

### DIFF
--- a/purchase_invoicing_no_zero_line/models/account_move.py
+++ b/purchase_invoicing_no_zero_line/models/account_move.py
@@ -17,10 +17,14 @@ class AccountMove(models.Model):
         purchase = self.purchase_vendor_bill_id.purchase_order_id
         res = super()._onchange_purchase_auto_complete()
         if purchase and self.journal_id and self.journal_id.avoid_zero_lines:
+            precision_digits = self.env["decimal.precision"].precision_get(
+                "Product Unit of Measure"
+            )
+            rounding = 10 ** (-precision_digits)
             zero_lines = self.invoice_line_ids.filtered(
                 lambda x: float_is_zero(
                     x.quantity,
-                    precision_rounding=x.product_uom_id.rounding,
+                    precision_rounding=x.product_uom_id.rounding or rounding,
                 )
                 and x.purchase_line_id.order_id == purchase
             )

--- a/purchase_invoicing_no_zero_line/tests/test_purchase_invoicing_no_zero_line.py
+++ b/purchase_invoicing_no_zero_line/tests/test_purchase_invoicing_no_zero_line.py
@@ -1,7 +1,7 @@
 # Copyright 2022 Tecnativa - Carlos Roca
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import fields
+from odoo import Command, fields
 from odoo.tests.common import Form, TransactionCase
 
 
@@ -109,3 +109,32 @@ class TestPurchaseInvoicingNoZeroLine(TransactionCase):
         self.purchase_order.order_line[0].qty_received = 5
         invoice = self._create_invoice_from_po_ref()
         self.assertEqual(len(invoice.invoice_line_ids), 1)
+
+    def test_undefined_product_uom(self):
+        """
+        ensure that zero-quantity filtering does not crash when product_uom_id is unset
+        and falls back to the default UoM decimal precision
+        """
+        self.journal.avoid_zero_lines = True
+        self.purchase_order.button_confirm()
+        self.purchase_order.flush_model()
+        vendor_bill = self.env["account.move"].create(
+            {
+                "move_type": "in_invoice",
+                "partner_id": self.vendor.id,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "account_id": self.account_expense.id,
+                            "price_unit": 1000.0,
+                            "product_uom_id": False,
+                        },
+                    )
+                ],
+            }
+        )
+        vendor_bill.purchase_vendor_bill_id = self.env["purchase.bill.union"].browse(
+            -self.purchase_order.id
+        )
+        vendor_bill._onchange_purchase_auto_complete()
+        self.assertEqual(len(vendor_bill.invoice_line_ids), 1)


### PR DESCRIPTION
When avoid_zero_lines is enabled, zero-quantity invoice lines are filtered
using the product UoM rounding. If the invoice line has no UoM, the rounding
value is 0, which causes float_is_zero to fail

Fallback to the default "Product Unit of Measure" decimal precision to ensure
a strictly positive rounding value