### PR TITLE
[16.0][FIX] account_billing: fix issue when create billings from refunds

### DIFF
--- a/account_billing/models/account_move.py
+++ b/account_billing/models/account_move.py
@@ -21,11 +21,16 @@ class AccountMove(models.Model):
             billing_lines = bl_obj.search([("move_id", "=", rec.id)])
             rec.billing_ids = billing_lines.mapped("billing_id")
 
+    def _get_billing_type(self):
+        outbound_types = {"out_invoice", "out_refund", "out_receipt"}
+        move_types = set(self.mapped("move_type"))
+        return "out_invoice" if move_types.issubset(outbound_types) else "in_invoice"
+
     def _create_billing(self, partner):
         billing = self.env["account.billing"].create(
             {
                 "partner_id": partner.id,
-                "bill_type": list(set(self.mapped("move_type")))[0],
+                "bill_type": self._get_billing_type(),
                 "billing_line_ids": [
                     Command.create(
                         {


### PR DESCRIPTION
This PR fixes an issue that occurs when creating billings from the list view of credit notes, or when creating credit notes and invoices together by calling `_create_billing` from dependency modules or test cases.

@qrtl QT6260