### PR TITLE
[18.0][FIX] account_billing: Change 'invisible' to 'column_invisible'

### DIFF
--- a/account_billing/views/account_billing_views.xml
+++ b/account_billing/views/account_billing_views.xml
@@ -198,11 +198,11 @@
                             />
                             <field name="billing_line_ids" readonly="state != 'draft'">
                                 <list name="billing" create="0" editable="bottom">
-                                    <field name="move_id" invisible="1" />
+                                    <field name="move_id" column_invisible="1" />
                                     <field name="name" />
                                     <field name="invoice_date" />
                                     <field name="origin" />
-                                    <field name="currency_id" invisible="1" />
+                                    <field name="currency_id" column_invisible="1" />
                                     <field
                                         name="amount_total"
                                         sum="Total Amount"


### PR DESCRIPTION
Something that we failed to take care of in the 18.0 migration. Move and currency columns are not supposed to be showing.
<img width="824" height="251" alt="image" src="https://github.com/user-attachments/assets/249cafcd-4803-4e56-8dc6-18b42403884b" />

@qrtl QT5924
