### PR TITLE
[FIX] sale_stock_picking_invoicing: Narration could be false

### DIFF
--- a/sale_stock_picking_invoicing/tests/test_sale_stock.py
+++ b/sale_stock_picking_invoicing/tests/test_sale_stock.py
@@ -297,6 +297,7 @@ class TestSaleStock(TestPickingInvoicingCommon):
         sale_order_2 = self.env.ref(
             "sale_stock_picking_invoicing.main_company-sale_order_2"
         )
+        sale_order_2.note = False
         sale_order_2.action_confirm()
         picking2 = sale_order_2.picking_ids
         self.picking_move_state(picking2)

--- a/sale_stock_picking_invoicing/wizards/stock_invoice_onshipping.py
+++ b/sale_stock_picking_invoicing/wizards/stock_invoice_onshipping.py
@@ -95,7 +95,8 @@ class StockInvoiceOnshipping(models.TransientModel):
                 # origins.add(sale_values["invoice_origin"])
                 payment_refs.add(sale_values["payment_reference"])
                 refs.add(sale_values["ref"])
-                narration.add(sale_values["narration"])
+                if sale_values["narration"]:
+                    narration.add(sale_values["narration"])
 
                 sale_values_rm = {
                     k: sale_values[k]


### PR DESCRIPTION
Otherwise, an error is raised if one of the Sale Orders has no note