### PR TITLE
[16.0][FIX] partner_last_invoice_date test for > 2025

### DIFF
--- a/partner_last_invoice_date/tests/test_partner_last_invoice_date.py
+++ b/partner_last_invoice_date/tests/test_partner_last_invoice_date.py
@@ -3,6 +3,8 @@
 
 import datetime
 
+from freezegun import freeze_time
+
 from odoo.tests import tagged
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
@@ -11,6 +13,7 @@ from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 @tagged("post_install", "-at_install")
 class TestPartnerLastInvoiceDate(AccountTestInvoicingCommon):
     @classmethod
+    @freeze_time("2025-01-01")
     def setUpClass(cls):
         super().setUpClass()
         cls.partner_model = cls.env["res.partner"]


### PR DESCRIPTION
Test failed for an other PR, linked to this module and the fact that we are in 2026 now :-D 


I never used the freeze-time function, maybe that's not the right way to do it, thanks for your help