### PR TITLE
[16.0][FIX] account_invoice_supplierinfo_update: product_id write in tests

### DIFF
--- a/account_invoice_supplierinfo_update/tests/test_module.py
+++ b/account_invoice_supplierinfo_update/tests/test_module.py
@@ -88,7 +88,7 @@ class TestModule(AccountTestInvoicingCommon):
         )
 
         # Set the variation 2 on the invoice and run the wizard
-        self.line_a.write({"product_id": product_a_2, "price_unit": 400})
+        self.line_a.write({"product_id": product_a_2.id, "price_unit": 400})
         vals_wizard = self.invoice.check_supplierinfo().get("context", {})
         line_ids = vals_wizard.get("default_line_ids", {})
 


### PR DESCRIPTION
@BinhexTeam

Problem

The test suite of the module account_invoice_supplierinfo_update fails on Odoo 16 during CI execution (Codecov / runbot).

The failure occurs in test_get_the_right_variant_supplierinfo, when writing a new product variant on an existing invoice line:
	•	The test passes a recordset to a many2one field (product_id) in a write() call.
	•	In Odoo 16, the accounting framework (account.move._field_will_change) strictly expects IDs (integers) in write() values.
	•	This results in a type mismatch and causes the test to fail with warnings and errors during coverage execution.

Root Cause

In Odoo 16, the method _field_will_change() compares:
record[field_name].id != vals[field_name]

When vals[field_name] is a recordset instead of an integer, the comparison becomes invalid and triggers a runtime warning / failure.

The test was implicitly relying on older permissive behavior, which is no longer valid in Odoo 16.

Solution

Update the test to comply with the Odoo ORM API by always passing IDs (integers) when writing to many2one fields.

Specifically:
	•	Replace the recordset assignment to product_id with its .id.

This is a minimal, safe, and fully backward-compatible fix that restores test stability without altering any functional behavior.

Implementation Details
	•	Update the failing test to write product_id as an integer:
	self.line_a.write({"product_id": product_a_2.id, "price_unit": 400})

	•	No changes are made to business logic, models, or wizards.
	•	The fix is limited strictly to the test code.

Tests
	•	Existing tests now pass successfully on Odoo 16.
	•	No new tests were required, as this change restores correctness in an existing regression test.

Scope & Compatibility
	•	Test-only fix.
	•	No functional or behavioral changes.
	•	Fully compatible with Odoo 16 and aligned with OCA coding standards.
	•	Prevents CI and Codecov failures.

Conclusion

This PR fixes a test incompatibility introduced by stricter ORM behavior in Odoo 16 by ensuring that many2one fields are written using integer IDs, as required by the framework.

The change is minimal, correct, and keeps the test suite reliable and CI-safe.