### PR TITLE
[16.0][FIX] partner_last_invoice_date: fix invalid invoice_date write in tests

### DIFF
--- a/partner_last_invoice_date/tests/test_partner_last_invoice_date.py
+++ b/partner_last_invoice_date/tests/test_partner_last_invoice_date.py
@@ -41,8 +41,8 @@ class TestPartnerLastInvoiceDate(AccountTestInvoicingCommon):
                 ],
             }
         )
-        cls.invoice.action_post()
         cls.invoice.write({"invoice_date": "2025-01-01"})
+        cls.invoice.action_post()
         cls.bill_1 = cls.account_move_model.create(
             {
                 "partner_id": cls.partner.id,


### PR DESCRIPTION
@BinhexTeam

Problem:
The test suite of partner_last_invoice_date was writing invoice_date
on an already posted customer invoice.

In Odoo 16, modifying invoice_date after action_post() is no longer
allowed, as it breaks the date-based sequence integrity enforced by
account.move.

This resulted in test failures such as:
	•	date/sequence mismatch errors
	•	inconsistent sequence numbers
	•	CI failures depending on execution order

Root Cause:
The test setup performed the following invalid flow:
	•	create invoice
	•	post invoice (action_post())
	•	write invoice_date

This is not a supported accounting operation in Odoo 16 and triggers
sequence validation errors.

Solution:
Update the test setup to assign invoice_date before calling
action_post().

This reflects a valid business flow and complies with Odoo’s accounting
constraints.

No functional code was changed; only the test setup was corrected.

Tests:
	•	Existing test logic preserved
	•	Test behavior unchanged
	•	Tests now pass reliably and are CI-safe

Scope & Compatibility:
	•	Test-only fix
	•	No functional or behavioral change
	•	Fully backward compatible
	•	Aligns tests with Odoo 16 accounting rules

Conclusion:
This PR fixes an invalid test setup that relied on unsupported accounting
operations.

The result is a stable, deterministic test suite fully compliant with
Odoo core constraints.