### PR TITLE
[FIX] account_mail_autosubscribe: support for invoice sending wizards

### DIFF
--- a/account_mail_autosubscribe/README.rst
+++ b/account_mail_autosubscribe/README.rst
@@ -66,6 +66,10 @@ Contributors
 
      - Iván Todorovich <ivan.todorovich@gmail.com>
 
+- `Scalizer <https://www.scalizer.fr/>`__
+
+     - Julien Hémono <julien@scalizer.fr>
+
 Maintainers
 -----------
 

--- a/account_mail_autosubscribe/__init__.py
+++ b/account_mail_autosubscribe/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/account_mail_autosubscribe/models/__init__.py
+++ b/account_mail_autosubscribe/models/__init__.py
@@ -1,0 +1,1 @@
+from . import account_move_send

--- a/account_mail_autosubscribe/models/account_move_send.py
+++ b/account_mail_autosubscribe/models/account_move_send.py
@@ -1,0 +1,19 @@
+# Copyright 2026 Scalizer (<https://www.scalizer.fr>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import api, models
+
+
+class AccountMoveSend(models.AbstractModel):
+    _inherit = "account.move.send"
+
+    @api.model
+    def _get_default_mail_partner_ids(self, move, mail_template, mail_lang):
+        partners = super()._get_default_mail_partner_ids(move, mail_template, mail_lang)
+        autosubscribe_followers = (
+            mail_template.use_autosubscribe_followers
+            and not self.env.context.get("no_autosubscribe_followers")
+        )
+        if autosubscribe_followers and partners:
+            ResModel = self.env[mail_template.model]
+            partners |= ResModel._message_get_autosubscribe_followers(partners)
+        return partners

--- a/account_mail_autosubscribe/readme/CONTRIBUTORS.md
+++ b/account_mail_autosubscribe/readme/CONTRIBUTORS.md
@@ -1,3 +1,7 @@
 - [Camptocamp](https://www.camptocamp.com)
 
   > - Iván Todorovich \<ivan.todorovich@gmail.com\>
+
+- [Scalizer](https://www.scalizer.fr/)
+
+  > - Julien Hémono \<julien@scalizer.fr\>

--- a/account_mail_autosubscribe/static/description/index.html
+++ b/account_mail_autosubscribe/static/description/index.html
@@ -415,6 +415,13 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </blockquote>
 </li>
+<li><p class="first"><a class="reference external" href="https://www.scalizer.fr/">Scalizer</a></p>
+<blockquote>
+<ul class="simple">
+<li>Julien Hémono &lt;<a class="reference external" href="mailto:julien&#64;scalizer.fr">julien&#64;scalizer.fr</a>&gt;</li>
+</ul>
+</blockquote>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/account_mail_autosubscribe/tests/__init__.py
+++ b/account_mail_autosubscribe/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_account_move_send

--- a/account_mail_autosubscribe/tests/test_account_move_send.py
+++ b/account_mail_autosubscribe/tests/test_account_move_send.py
@@ -1,0 +1,86 @@
+# Copyright 2021 Camptocamp (http://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("-at_install", "post_install")
+class AccountMoveSendWizard(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        # Email Template
+        mail_template_model = cls.env["mail.template"].with_context(
+            test_mail_autosubscribe=True
+        )
+        cls.mail_template = mail_template_model.create(
+            {
+                "model_id": cls.env.ref("account.model_account_move").id,
+                "name": "Invoice: Send by Mail",
+                "subject": "Invoice: {{object.partner_id.name}}",
+                "partner_to": "{{object.partner_id.id}}",
+                "body_html": "Hello, this is an invoice",
+            }
+        )
+        # Partners
+        cls.commercial_partner = cls.env.ref("base.res_partner_4")
+        cls.partner_1 = cls.env.ref("base.res_partner_address_13")
+        cls.partner_2 = cls.env.ref("base.res_partner_address_14")
+        cls.partner_3 = cls.env.ref("base.res_partner_address_24")
+        # Autosubscribe rules
+        cls.autosubscribe_move = cls.env.ref(
+            "account_mail_autosubscribe.mail_autosubscribe_account_move"
+        )
+        cls.partner_3.mail_autosubscribe_ids = [(4, cls.autosubscribe_move.id)]
+        # Invoice
+        cls.invoice = cls.env["account.move"].create(
+            {
+                "partner_id": cls.partner_2.id,
+                "invoice_date": fields.Date.today(),
+                "move_type": "out_invoice",
+                "invoice_line_ids": [
+                    fields.Command.create(
+                        {
+                            "product_id": cls.env.ref("product.product_product_7").id,
+                            "price_unit": 100.0,
+                        },
+                    )
+                ],
+            }
+        )
+        cls.invoice.action_post()
+
+    def _send_invoice(self):
+        composer = (
+            self.env["account.move.send.wizard"]
+            .with_context(active_model="account.move", active_ids=self.invoice.ids)
+            .create(
+                {
+                    "sending_methods": ["email"],
+                    "mail_template_id": self.mail_template.id,
+                }
+            )
+        )
+        composer.action_send_and_print()
+        return self.invoice.message_ids[0]
+
+    def test_mail_message_composer(self):
+        """Test invoice sending wizard with an autosubscribe follower."""
+        message = self._send_invoice()
+        self.assertEqual(message.partner_ids, self.partner_2 | self.partner_3)
+
+    def test_mail_message_composer_disabled(self):
+        """Test invoice sending wizard with no autosubscribe follower."""
+        self.partner_3.mail_autosubscribe_ids = [(5, False)]
+        message = self._send_invoice()
+        self.assertEqual(message.partner_ids, self.partner_2)
+
+    def test_mail_message_composer_no_autosubscribe_followers(self):
+        """Test invoice sending wizard with autosubscribe disabled on the template."""
+        self.mail_template.use_autosubscribe_followers = False
+        message = self._send_invoice()
+        self.assertEqual(message.partner_ids, self.partner_2)


### PR DESCRIPTION
Invoice sending wizards based on account.move.send don't get partner recipients in the way that mail_autosubscribe overrides to add auto-subscribe followers. (It instead calls the low-level mail.composer.mixin._render_field() method which
 is a bit too low-level to override) This change extends account.move.send to
 add auto-subscribe followers.