### PR TITLE
[16.0][FIX] partner_invoicing_mode: fix invalid invoice grouping key.

### DIFF
--- a/partner_invoicing_mode/README.rst
+++ b/partner_invoicing_mode/README.rst
@@ -38,7 +38,7 @@ the invoices for standard invoicing mode.
 In core, Odoo is grouping invoicing from a group of sale orders on:
 
 - Company
-- Partner
+- Invoiced partner
 - Currency
 
 This module uses grouping on those keys:

--- a/partner_invoicing_mode/models/sale_order.py
+++ b/partner_invoicing_mode/models/sale_order.py
@@ -87,16 +87,11 @@ class SaleOrder(models.Model):
     def _get_invoice_grouping_keys(self) -> list:
         """
         We override the standard (in sale) grouping function in order to
-        add some missing keys. We remove also the partner_id key.
+        add some missing keys.
         """
         keys = super()._get_invoice_grouping_keys()
-        if "partner_invoice_id" not in keys:
-            keys.append("partner_invoice_id")
         if "payment_term_id" not in keys:
             keys.append("payment_term_id")
-        # Removing unwanted keys as we group on invoiced partner
-        if "partner_id" in keys:
-            keys.remove("partner_id")
         return keys
 
     def _get_generated_invoices(self, partition):


### PR DESCRIPTION
The "partner_invoice_id" key is nowhere to be found inside the data generated by `sale_order._prepare_invoice`.

Moreover, in odoo core, the value for the key "partner_id" is already containing the SO's `partner_invoice_id` (see `sales.modes.sale_order._prepare_invoice`).

<img width="1505" height="702" alt="image" src="https://github.com/user-attachments/assets/0c987ff0-e656-43e4-98aa-3d567046e2db" />

This may be a problem for the function `sales.models.sale_order._create_invoices` when we try to sort invoice values by group key