### PR TITLE
[18.0][FIX] product_customerinfo_invoice error on invoice_view column_invisible

### DIFF
--- a/product_customerinfo_invoice/views/account_move_view.xml
+++ b/product_customerinfo_invoice/views/account_move_view.xml
@@ -17,10 +17,10 @@
                 expr="//field[@name='invoice_line_ids']/list/field[@name='product_id']"
                 position="after"
             >
-                <field name="partner_show_customer_code" column_invisible="True" />
+                <field name="partner_show_customer_code" invisible="True" />
                 <field
                     name="product_customer_code"
-                    column_invisible="not partner_show_customer_code"
+                    invisible="not partner_show_customer_code"
                 />
             </xpath>
         </field>


### PR DESCRIPTION
product_customerinfo_invoice

If I open an invoice in the interface I get this error:

OwlError: The following error occurred in onWillRender: "Can not evaluate python expression: (bool(not partner_show_customer_code)) Error: Name 'partner_show_customer_code' is not defined" Error

Fixed it with changing column_invisible to invisible.