### PR TITLE
[17.0][FIX] account_invoice_pricelist: add test_enable to not block other test

### DIFF
--- a/account_invoice_pricelist/models/account_move.py
+++ b/account_invoice_pricelist/models/account_move.py
@@ -23,7 +23,7 @@ class AccountMove(models.Model):
             not config["test_enable"]
             or (
                 config["test_enable"]
-                and self._context.get("force_check_currecy", False)
+                and self._context.get("force_check_currency", False)
             )
         ) and self.filtered(
             lambda a: a.pricelist_id
@@ -47,6 +47,12 @@ class AccountMove(models.Model):
         res = super()._compute_currency_id()
         for invoice in self:
             if (
+                not config["test_enable"]
+                or (
+                    config["test_enable"]
+                    and self._context.get("force_compute_currency", False)
+                )
+            ) and (
                 invoice.is_sale_document()
                 and invoice.pricelist_id
                 and invoice.currency_id != invoice.pricelist_id.currency_id

--- a/account_invoice_pricelist/tests/test_account_move_pricelist.py
+++ b/account_invoice_pricelist/tests/test_account_move_pricelist.py
@@ -16,6 +16,8 @@ class TestAccountMovePricelist(common.TransactionCase):
                 mail_notrack=True,
                 no_reset_password=True,
                 tracking_disable=True,
+                force_check_currency=True,
+                force_compute_currency=True,
             )
         )
         cls.AccountMove = cls.env["account.move"]


### PR DESCRIPTION
cc @Tecnativa 
ping @pedrobaeza @sergio-teruel @christian-ramos-tecnativa 

I found that overriding `_compute_currency_id` in another module will cause a collision. To mitigate this, I added `test_enable` so it doesn’t block other tests.

However, any module that tries to override this method will still be incompatible with this module.

Origin: github.com/OCA/account-invoicing/pull/2177  
