### PR TITLE
[16.0][IMP] account_invoice_force_number: Avoid move name assign if already…

### DIFF
--- a/account_invoice_force_number/models/account_move.py
+++ b/account_invoice_force_number/models/account_move.py
@@ -32,6 +32,7 @@ class AccountMove(models.Model):
 
     def _post(self, soft=True):
         for move in self:
-            if move.move_name:
-                move.write({"name": move.move_name})
+            move_name = move.move_name
+            if move_name and move.name != move_name:
+                move.write({"name": move_name})
         return super(AccountMove, self)._post(soft=soft)


### PR DESCRIPTION
… has same name

If invoice is set to draft after being posted, invoice will keep the name.
If posting again, writing the same name can be avoided

Error cases: Spanish SII, when you try to post again and invoice you will get an error because invoice's name cannot be modified once it has been sent.