### PR TITLE
[19.0][FIX] account_invoice_pricelist fix test pricelist assignment issue

### DIFF
--- a/account_invoice_pricelist/tests/test_account_move_pricelist.py
+++ b/account_invoice_pricelist/tests/test_account_move_pricelist.py
@@ -99,6 +99,7 @@ class TestAccountMovePricelist(common.TransactionCase):
         cls.sale_pricelist = cls.ProductPricelist.create(
             {
                 "name": "Test Sale pricelist",
+                "sequence": 14,
                 "item_ids": [
                     Command.create(
                         {
@@ -114,6 +115,7 @@ class TestAccountMovePricelist(common.TransactionCase):
         cls.sale_pricelist2 = cls.ProductPricelist.create(
             {
                 "name": "Test Sale pricelist 2",
+                "sequence": 1,
                 "item_ids": [
                     Command.create(
                         {
@@ -129,6 +131,7 @@ class TestAccountMovePricelist(common.TransactionCase):
         cls.sale_pricelist3 = cls.ProductPricelist.create(
             {
                 "name": "Test Sale pricelist 3",
+                "sequence": 2,
                 "item_ids": [
                     Command.create(
                         {
@@ -144,6 +147,7 @@ class TestAccountMovePricelist(common.TransactionCase):
         cls.sale_pricelist4 = cls.ProductPricelist.create(
             {
                 "name": "Test Sale pricelist 4",
+                "sequence": 3,
                 "item_ids": [
                     Command.create(
                         {
@@ -167,6 +171,7 @@ class TestAccountMovePricelist(common.TransactionCase):
         cls.sale_pricelist_fixed_without_discount = cls.ProductPricelist.create(
             {
                 "name": "Test Sale pricelist",
+                "sequence": 4,
                 "item_ids": [
                     Command.create(
                         {
@@ -182,6 +187,7 @@ class TestAccountMovePricelist(common.TransactionCase):
         cls.sale_pricelist_with_discount = cls.ProductPricelist.create(
             {
                 "name": "Test Sale pricelist - 2",
+                "sequence": 5,
                 "item_ids": [
                     Command.create(
                         {
@@ -197,6 +203,7 @@ class TestAccountMovePricelist(common.TransactionCase):
         cls.sale_pricelist_without_discount = cls.ProductPricelist.create(
             {
                 "name": "Test Sale pricelist - 3",
+                "sequence": 6,
                 "item_ids": [
                     Command.create(
                         {
@@ -218,6 +225,7 @@ class TestAccountMovePricelist(common.TransactionCase):
             {
                 "name": "Test Sale pricelist - 4",
                 "currency_id": cls.euro_currency.id,
+                "sequence": 7,
                 "item_ids": [
                     Command.create(
                         {
@@ -234,6 +242,7 @@ class TestAccountMovePricelist(common.TransactionCase):
             {
                 "name": "Test Sale pricelist - 5",
                 "currency_id": cls.euro_currency.id,
+                "sequence": 8,
                 "item_ids": [
                     Command.create(
                         {
@@ -250,6 +259,7 @@ class TestAccountMovePricelist(common.TransactionCase):
             {
                 "name": "Test Sale pricelist - 6",
                 "currency_id": cls.euro_currency.id,
+                "sequence": 9,
                 "item_ids": [
                     Command.create(
                         {
@@ -266,6 +276,7 @@ class TestAccountMovePricelist(common.TransactionCase):
             {
                 "name": "Test Sale pricelist - 7",
                 "currency_id": cls.euro_currency.id,
+                "sequence": 10,
                 "item_ids": [
                     Command.create(
                         {
@@ -278,6 +289,7 @@ class TestAccountMovePricelist(common.TransactionCase):
                 ],
             }
         )
+
         cls.invoice = cls.AccountMove.create(
             {
                 "partner_id": cls.partner.id,


### PR DESCRIPTION
Due to some changes in this odoo pr: (https://github.com/odoo/odoo/commit/fbdcb07f50c1c6ba3449afcf41f0144a08413a11)

The way it assign the default pricelist has changed, the solution is move the partner creation under all the pricelist, because the sequence was:
pricelist (1,2,3,4)
partner.create
When you create the partner this function is triggered. 
<img width="1596" height="182" alt="image" src="https://github.com/user-attachments/assets/91c8a2d3-b9d8-4d29-b50b-fa73eb437d61" />
And set false because default is 1. 
Default pricelist is resetted as 8, or 9 (depends on the final sequence bellow)
pricelist (8, 9, 1, 2, 3, 4, 5, 6, 7, 10, 11, 12, 13) 