### PR TITLE
[16.0][FIX] account_invoice_supplier_self_invoice: use name over ref in reports

### DIFF
--- a/account_invoice_supplier_self_invoice/views/report_self_invoice.xml
+++ b/account_invoice_supplier_self_invoice/views/report_self_invoice.xml
@@ -159,15 +159,6 @@
                 name="t-if"
             >o.invoice_date_due and (o.move_type == 'out_invoice' or (o.move_type == 'in_invoice' and o.set_self_invoice)) and o.state == 'posted'</attribute>
         </xpath>
-        <!-- Reference -->
-        <xpath
-            expr="//div[@id='informations']/div[@name='reference']"
-            position="attributes"
-        >
-            <attribute
-                name="t-if"
-            >o.ref and (o.move_type not in ('in_invoice', 'in_refund') or not o.set_self_invoice)</attribute>
-        </xpath>
     </template>
 
     <!-- Report: Invoices with payments -->

--- a/account_invoice_supplier_self_invoice/views/report_self_invoice.xml
+++ b/account_invoice_supplier_self_invoice/views/report_self_invoice.xml
@@ -129,7 +129,7 @@
         </xpath>
         <xpath
             expr="//div[hasclass('page')]/h2/span[@t-field='o.name']"
-            position="replace"
+            position="before"
         >
             <span
                 t-if="o.set_self_invoice and o.move_type == 'in_refund'"
@@ -137,8 +137,6 @@
             <span
                 t-if="o.set_self_invoice and o.move_type == 'in_invoice'"
             >Self-bill Invoice</span>
-            <span t-if="not o.set_self_invoice and o.name != '/'" t-field="o.name" />
-            <span t-if="o.set_self_invoice and o.ref != '/'" t-field="o.ref" />
         </xpath>
         <!-- Invoice date text -->
         <xpath


### PR DESCRIPTION
The invoice 'ref' field is an external identifier provided by the vendor, not the primary internal identifier for the record. For consistency and proper identification, the 'name' field (Invoice Number) should always be displayed on the report regardless of the document type.

