### PR TITLE
[16.0][IMP] account_invoice_supplier_self_invoice: compute payment_reference in case of self invoice

### DIFF
--- a/account_invoice_supplier_self_invoice/models/account_move.py
+++ b/account_invoice_supplier_self_invoice/models/account_move.py
@@ -55,6 +55,20 @@ class AccountMove(models.Model):
             move.set_self_invoice = partner_self_invoice
             move.can_self_invoice = partner_self_invoice
 
+    def _compute_payment_reference(self):
+        # Put this before call to "super" so as not to trigger
+        # call to `_inverse_payment_reference` (from main function) too early
+        for move in self.filtered(
+            lambda m: m.state == "posted"
+            and not m.payment_reference
+            and m.move_type == "in_invoice"
+            and m.set_self_invoice
+        ):
+            move.payment_reference = move._get_invoice_computed_reference()
+
+        res = super()._compute_payment_reference()
+        return res
+
     def _post(self, soft=True):
         # Set today for invoice date in self invoices
         self.filtered(

--- a/account_invoice_supplier_self_invoice/tests/test_self_invoice.py
+++ b/account_invoice_supplier_self_invoice/tests/test_self_invoice.py
@@ -117,6 +117,7 @@ class TestSelfInvoice(common.TransactionCase):
         self.invoice.with_user(self.user.id).action_post()
         self.assertTrue(self.invoice.invoice_date)
         self.assertTrue(self.invoice.self_invoice_number)
+        self.assertTrue(self.invoice.payment_reference)
 
     def test_self_invoice_child(self):
         with Form(self.partner) as f:
@@ -131,3 +132,4 @@ class TestSelfInvoice(common.TransactionCase):
         self.invoice.with_user(self.user.id).action_post()
         self.assertTrue(self.invoice.invoice_date)
         self.assertTrue(self.invoice.self_invoice_number)
+        self.assertTrue(self.invoice.payment_reference)


### PR DESCRIPTION
Ensures that the `payment_reference` field is automatically computed for supplier invoices generated as self-invoices.