### PR TITLE
[16.0][FIX] account_invoice_supplier_self_invoice: fix self-invoice report layout

### DIFF
--- a/account_invoice_supplier_self_invoice/views/report_self_invoice.xml
+++ b/account_invoice_supplier_self_invoice/views/report_self_invoice.xml
@@ -23,7 +23,7 @@
                     class="float-start"
                     alt="Logo"
                 />
-                <div t-if="o.partner_id" t-attf-class="'col-5 ' + {{image_offset}}">
+                <div t-if="o.partner_id" t-attf-class="col-5 {{image_offset}}">
                     <span
                         t-field="o.partner_id"
                         t-options='{"widget": "contact", "fields": ["name", "address"], "no_marker": True}'

--- a/account_invoice_supplier_self_invoice/views/report_self_invoice.xml
+++ b/account_invoice_supplier_self_invoice/views/report_self_invoice.xml
@@ -44,10 +44,16 @@
             expr="//div[contains(@t-attf-class,'footer')]/div/ul/div"
             position="replace"
         >
-            <div t-field="o.partner_id.self_invoice_report_footer" />
             <span t-if="o.state != 'posted'">
                 <strong>This Self-bill is not valid</strong>
             </span>
+            <t t-else="">
+                <div
+                    t-if="o.partner_id.self_invoice_report_footer"
+                    t-field="o.partner_id.self_invoice_report_footer"
+                />
+                <div t-else="" t-field="company.report_footer" />
+            </t>
         </xpath>
     </template>
 

--- a/account_invoice_supplier_self_invoice/views/report_self_invoice.xml
+++ b/account_invoice_supplier_self_invoice/views/report_self_invoice.xml
@@ -104,21 +104,22 @@
         >
             <t t-if="o.set_self_invoice">
                 <t t-set="address">
-                    <address
-                        class="mb-0"
-                        t-field="o.company_id.partner_id"
-                        t-options='{"widget": "contact", "fields": ["name", "address"], "no_marker": True}'
+                    <t
+                        t-call="account_invoice_supplier_self_invoice.self_invoice_address_block"
                     />
-                    <div t-if="o.company_id.partner_id.vat">
-                        <t
-                            t-if="o.company_id.account_fiscal_country_id.vat_label"
-                            t-esc="o.company_id.account_fiscal_country_id.vat_label"
-                            id="inv_tax_id_label"
-                        />
-                        <t t-else="">Tax ID</t>: <span
-                            t-field="o.company_id.partner_id.vat"
-                        />
-                    </div>
+                </t>
+            </t>
+        </xpath>
+
+        <xpath
+            expr="//t/div[@name='address_not_same_as_shipping']/t[@t-set='address']"
+            position="after"
+        >
+            <t t-if="o.set_self_invoice">
+                <t t-set="address">
+                    <t
+                        t-call="account_invoice_supplier_self_invoice.self_invoice_address_block"
+                    />
                 </t>
             </t>
         </xpath>
@@ -176,6 +177,24 @@
                 name="t-if"
             >o.ref and (o.move_type not in ('in_invoice', 'in_refund') or not o.set_self_invoice)</attribute>
         </xpath>
+    </template>
+
+    <template id="self_invoice_address_block">
+        <address
+            class="mb-0"
+            t-field="o.company_id.partner_id"
+            t-options='{"widget": "contact", "fields": ["name", "address"], "no_marker": True}'
+        />
+        <div t-if="o.company_id.partner_id.vat">
+            <t
+                t-if="o.company_id.account_fiscal_country_id.vat_label"
+                t-esc="o.company_id.account_fiscal_country_id.vat_label"
+                id="inv_tax_id_label"
+            />
+                        <t t-else="">Tax ID</t>: <span
+                t-field="o.company_id.partner_id.vat"
+            />
+        </div>
     </template>
 
     <!-- Report: Invoices with payments -->


### PR DESCRIPTION
**Before:**

<img width="720" height="897" alt="image" src="https://github.com/user-attachments/assets/5933fd35-f905-4b46-bde8-e08b091abf92" />


**After:**

<img width="720" height="897" alt="image" src="https://github.com/user-attachments/assets/135a6068-99d6-4f7a-8a19-e96a417e2ec9" />

---

**NB:** 
You can test the generated pdf using the "report" endpoint like so:

    http://localhost:8069/report/pdf/account.report_invoice_with_payments/<account_move_id>

Similarly, you can view the genrated html like so:

    http://localhost:8069/report/html/account.report_invoice_with_payments/<account_move_id>
