### PR TITLE
[16.0][FIX] pin cryptography<37 for pyopenssl 20.0.1 compatibility

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,4 @@
+# google-cloud-documentai depends on google-auth, which depends on cryptography.
+# odoo relies on pyopenssl==20.0.1 which uses internal cryptography bindings
+# (X509_V_FLAG_CB_ISSUER_CHECK, X509_V_FLAG_NOTIFY_POLICY) removed in 37.0.0.
+cryptography<37


### PR DESCRIPTION
## Summary                                                                                                                                           
                                                                                                                                                     
  - Pin `cryptography<37` to fix pyopenssl 20.0.1 incompatibility                                                                                      
                                                                                                                                                       
  ## Problem 1: cryptography upgrade breaks pyopenssl                                                                                                
                                               
  The `google-cloud-documentai` package (dependency of `account_invoice_google_document_ai`)
  pulls in `google-auth 2.48.0`, which requires `cryptography>=38.0.3`. This upgrades
  `cryptography` from the pre-installed 3.4.8 to 46.0.4.

  Odoo 16.0 depends on `pyopenssl==20.0.1`, which uses internal cryptography bindings
  (`X509_V_FLAG_CB_ISSUER_CHECK`, `X509_V_FLAG_NOTIFY_POLICY`) that were removed in
  `cryptography 37.0.0`. pip doesn't upgrade `pyopenssl` because it declares no upper
  bound on `cryptography`.

  So jobs are failing with [this error](https://github.com/OCA/account-invoicing/actions/runs/21757205678/job/62770699819):

```
2026-02-06 16:08:47,364 570 ERROR ? odoo.service.server: Failed to load server-wide module `base`. 
Traceback (most recent call last):
  File "/opt/odoo/odoo/service/server.py", line 1281, in load_server_wide_modules
    odoo.modules.module.load_openerp_module(m)
  File "/opt/odoo/odoo/modules/module.py", line 471, in load_openerp_module
    __import__('odoo.addons.' + module_name)
  File "/opt/odoo/odoo/addons/base/__init__.py", line 5, in <module>
    from . import models
  File "/opt/odoo/odoo/addons/base/models/__init__.py", line 21, in <module>
    from . import ir_mail_server
  File "/opt/odoo/odoo/addons/base/models/ir_mail_server.py", line 19, in <module>
    from OpenSSL import crypto as SSLCrypto
  File "/opt/odoo-venv/lib/python3.10/site-packages/OpenSSL/__init__.py", line 8, in <module>
    from OpenSSL import crypto, SSL
  File "/opt/odoo-venv/lib/python3.10/site-packages/OpenSSL/crypto.py", line 1556, in <module>
    class X509StoreFlags(object):
  File "/opt/odoo-venv/lib/python3.10/site-packages/OpenSSL/crypto.py", line 1575, in X509StoreFlags
    NOTIFY_POLICY = _lib.X509_V_FLAG_NOTIFY_POLICY
AttributeError: module 'lib' has no attribute 'X509_V_FLAG_NOTIFY_POLICY'
```