### PR TITLE
[16.0][FIX] account_invoice_recipient_bank_currency: adapt to upstream changes

### DIFF
--- a/account_invoice_recipient_bank_currency/models/account_move.py
+++ b/account_invoice_recipient_bank_currency/models/account_move.py
@@ -17,6 +17,7 @@ class AccountMove(models.Model):
                         not bank.company_id or bank.company_id == move.company_id
                     )
                     and (not bank.currency_id or bank.currency_id == move.currency_id)
+                    and bank.allow_out_payment
                 )
                 bank_ids = bank_ids.sorted(key=lambda bank: bank.sequence)
                 move.partner_bank_id = bank_ids[0] if bank_ids else move.partner_bank_id

--- a/account_invoice_recipient_bank_currency/tests/test_account_invoice_recipient_bank_currency.py
+++ b/account_invoice_recipient_bank_currency/tests/test_account_invoice_recipient_bank_currency.py
@@ -36,6 +36,7 @@ class TestAccountInvoiceRecipientBankCurrency(TransactionCase):
                 "partner_id": cls.partner.id,
                 "currency_id": cls.env.ref("base.USD").id,
                 "sequence": 1,
+                "allow_out_payment": True,
             }
         )
         cls.bank_acc2 = cls.partner_bank_model.create(
@@ -44,6 +45,7 @@ class TestAccountInvoiceRecipientBankCurrency(TransactionCase):
                 "partner_id": cls.partner.id,
                 "currency_id": cls.env.ref("base.EUR").id,
                 "sequence": 2,
+                "allow_out_payment": True,
             }
         )
         cls.bank_acc3 = cls.partner_bank_model.create(
@@ -52,6 +54,7 @@ class TestAccountInvoiceRecipientBankCurrency(TransactionCase):
                 "partner_id": cls.partner.id,
                 "currency_id": cls.env.ref("base.USD").id,
                 "sequence": 3,
+                "allow_out_payment": True,
             }
         )
         cls.bank_acc4 = cls.partner_bank_model.create(
@@ -60,6 +63,7 @@ class TestAccountInvoiceRecipientBankCurrency(TransactionCase):
                 "partner_id": cls.partner.id,
                 "currency_id": cls.env.ref("base.EUR").id,
                 "sequence": 4,
+                "allow_out_payment": True,
             }
         )
 


### PR DESCRIPTION
since https://github.com/OCA/OCB/commit/7763099c91383745464f55b3a8ef13eb0d7f31f2, bank accounts are only autoselected if the `allow_out_payment` flag is set