### PR TITLE
[19.0][FIX] Fix the tests rounding accuracy

### DIFF
--- a/account_invoice_pricelist/models/account_move.py
+++ b/account_invoice_pricelist/models/account_move.py
@@ -132,15 +132,16 @@ class AccountMoveLine(models.Model):
                 line.price_unit = 0.0
             else:
                 price = line._get_display_price()
-                line.with_context(
-                    check_move_validity=False
-                ).price_unit = line.product_id._get_tax_included_unit_price_from_price(
+                price_unit = line.product_id._get_tax_included_unit_price_from_price(
                     price,
                     product_taxes=line.product_id.taxes_id.filtered(
                         lambda tax, line=line: tax.company_id == line.env.company
                     ),
                     fiscal_position=line.move_id.fiscal_position_id,
                 )
+                line.with_context(
+                    check_move_validity=False
+                ).price_unit = line.currency_id.round(price_unit)
         return res
 
     def _get_display_price(self):


### PR DESCRIPTION
In order to fix the error in account_invoice_pricelist that blocks all the other pr's, I did a rounding adjustment to prevent this: 
```
errors that caused failure (5):
2026-02-11 08:05:59,427 306 ERROR odoo odoo.addons.account_invoice_pricelist.tests.test_account_move_pricelist: FAIL: TestAccountMovePricelist.test_06_account_invoice_pricelist_with_discount_secondary_currency
Traceback (most recent call last):
  File "/__w/account-invoicing/account-invoicing/account_invoice_pricelist/tests/test_account_move_pricelist.py", line 388, in test_06_account_invoice_pricelist_with_discount_secondary_currency
    self.assertAlmostEqual(invoice_line.price_unit, 75.55)
AssertionError: 75.54772097708386 != 75.55 within 7 places (0.002279022916141571 difference)
 
2026-02-11 08:05:59,718 306 ERROR odoo odoo.addons.account_invoice_pricelist.tests.test_account_move_pricelist: FAIL: TestAccountMovePricelist.test_07_account_invoice_pricelist_without_discount_secondary_currency
Traceback (most recent call last):
  File "/__w/account-invoicing/account-invoicing/account_invoice_pricelist/tests/test_account_move_pricelist.py", line 396, in test_07_account_invoice_pricelist_without_discount_secondary_currency
    self.assertAlmostEqual(invoice_line.price_unit, 83.94)
AssertionError: 83.94191219675984 != 83.94 within 7 places (0.0019121967598465517 difference)
```
 