### PR TITLE
[18.0][FIX] account_invoice_auto_send_by_email: set trusted outgoing bank in tests

### DIFF
--- a/account_invoice_auto_send_by_email/tests/test_account_invoice_auto_send_by_email.py
+++ b/account_invoice_auto_send_by_email/tests/test_account_invoice_auto_send_by_email.py
@@ -54,6 +54,7 @@ class TestAccountInvoiceAutoSendByEmail(TransactionCase):
                 "acc_number": "300.300.300",
                 "acc_holder_name": "AccountHolderName",
                 "partner_id": cls.company.partner_id.id,
+                "allow_out_payment": True,
             }
         )
         cls.invoice = cls.AccountMove.create(


### PR DESCRIPTION
## Summary
- Set the test bank account as allowed for outgoing payments in `account_invoice_auto_send_by_email` tests.
- Prevent setup failures when validating invoice email sending behavior.

## Why
The test setup must use a bank account that is valid for outgoing payments in this scenario.

## Changes
- `account_invoice_auto_send_by_email/tests/test_account_invoice_auto_send_by_email.py`

## Merge order
1/4

Related PRs (recommended order):
- https://github.com/OCA/account-invoicing/pull/2272
- https://github.com/OCA/account-invoicing/pull/2273
- https://github.com/OCA/account-invoicing/pull/2274