### PR TITLE
[18.0][FIX] account_invoice_custom_rounding: keep tax base-line contract

### DIFF
--- a/account_invoice_auto_send_by_email/tests/test_account_invoice_auto_send_by_email.py
+++ b/account_invoice_auto_send_by_email/tests/test_account_invoice_auto_send_by_email.py
@@ -54,6 +54,7 @@ class TestAccountInvoiceAutoSendByEmail(TransactionCase):
                 "acc_number": "300.300.300",
                 "acc_holder_name": "AccountHolderName",
                 "partner_id": cls.company.partner_id.id,
+                "allow_out_payment": True,
             }
         )
         cls.invoice = cls.AccountMove.create(

--- a/account_invoice_custom_rounding/models/account_tax.py
+++ b/account_invoice_custom_rounding/models/account_tax.py
@@ -10,13 +10,14 @@ class AccountTax(models.Model):
 
     @api.model
     def _prepare_base_line_for_taxes_computation(self, record, **kwargs):
-        record = record.exists()
-        if not record:
-            return {}
+        if isinstance(record, models.Model):
+            record = record.exists()
+            if not record:
+                record = None
         try:
             res = super()._prepare_base_line_for_taxes_computation(record, **kwargs)
         except MissingError:
-            return {}
+            res = super()._prepare_base_line_for_taxes_computation(None, **kwargs)
         tax_calculation = self._get_base_line_field_value_from_record(
             record, "tax_calculation_rounding_method", kwargs, "round_globally"
         )

--- a/account_invoice_custom_rounding/models/account_tax.py
+++ b/account_invoice_custom_rounding/models/account_tax.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import api, models
+from odoo.exceptions import MissingError
 
 
 class AccountTax(models.Model):
@@ -9,7 +10,13 @@ class AccountTax(models.Model):
 
     @api.model
     def _prepare_base_line_for_taxes_computation(self, record, **kwargs):
-        res = super()._prepare_base_line_for_taxes_computation(record, **kwargs)
+        record = record.exists()
+        if not record:
+            return {}
+        try:
+            res = super()._prepare_base_line_for_taxes_computation(record, **kwargs)
+        except MissingError:
+            return {}
         tax_calculation = self._get_base_line_field_value_from_record(
             record, "tax_calculation_rounding_method", kwargs, "round_globally"
         )

--- a/account_invoice_custom_rounding/tests/test_account_invoice_custom_rounding.py
+++ b/account_invoice_custom_rounding/tests/test_account_invoice_custom_rounding.py
@@ -1,6 +1,10 @@
 # Copyright 2024 Manuel Regidor <manuel.regidor@sygel.es>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from unittest.mock import patch
+
+from odoo.exceptions import MissingError
+
 from .common import TestAccountInvoiceCustomRoundingCommon
 
 
@@ -98,3 +102,28 @@ class TestAccountInvoiceCustomRounding(TestAccountInvoiceCustomRoundingCommon):
         reverse_move = invoice._reverse_moves()
         self.assertEqual(reverse_move.tax_calculation_rounding_method, "round_per_line")
         self.assertAlmostEqual(reverse_move.amount_total, 15086.95, places=2)
+
+    def test_prepare_base_line_handles_stale_record(self):
+        invoice = self.create_invoice()
+        line = invoice.invoice_line_ids[:1]
+        line_id = line.id
+        line.unlink()
+        stale_line = self.env["account.move.line"].browse(line_id)
+
+        res = self.env["account.tax"]._prepare_base_line_for_taxes_computation(
+            stale_line
+        )
+        self.assertIn("tax_calculation_rounding_method", res)
+        self.assertEqual(res["tax_calculation_rounding_method"], "round_globally")
+
+    def test_prepare_base_line_recovers_from_missing_error(self):
+        with patch(
+            "odoo.addons.account.models.account_tax.AccountTax."
+            "_prepare_base_line_for_taxes_computation",
+            side_effect=[MissingError("missing"), {}],
+        ):
+            res = self.env["account.tax"]._prepare_base_line_for_taxes_computation(
+                None, tax_calculation_rounding_method="round_per_line"
+            )
+
+        self.assertEqual(res["tax_calculation_rounding_method"], "round_per_line")


### PR DESCRIPTION
## Summary
- Harden tax base line preparation in account_invoice_custom_rounding.
- Handle missing transient records safely while preserving expected tax computation keys.
- Add focused tests for missing-record fallback behavior.

## Why
Avoid fragile behavior in rounding-related tax computation paths and keep contract stable.

## Changes
- account_invoice_custom_rounding/models/account_tax.py
- account_invoice_custom_rounding/tests/test_account_invoice_custom_rounding.py

## Merge order
3/4 (after PR 1 and PR 2)

Depends on:
- https://github.com/OCA/account-invoicing/pull/2271
- https://github.com/OCA/account-invoicing/pull/2272
