### PR TITLE
[16.0][IMP] account_billing: refactor _get_moves() for the extensibility

### DIFF
--- a/account_billing/models/account_billing.py
+++ b/account_billing/models/account_billing.py
@@ -117,18 +117,19 @@ class AccountBilling(models.Model):
                 line.payment_state == "paid" for line in rec.billing_line_ids
             )
 
+    def _get_moves_domain(self, date=False, types=False):
+        return [
+            ("partner_id", "=", self.partner_id.id),
+            ("state", "=", "posted"),
+            ("payment_state", "!=", "paid"),
+            ("currency_id", "=", self.currency_id.id),
+            ("date", "<=", self.threshold_date),
+            ("move_type", "in", types),
+        ]
+
     def _get_moves(self, date=False, types=False):
-        moves = self.env["account.move"].search(
-            [
-                ("partner_id", "=", self.partner_id.id),
-                ("state", "=", "posted"),
-                ("payment_state", "!=", "paid"),
-                ("currency_id", "=", self.currency_id.id),
-                ("date", "<=", self.threshold_date),
-                ("move_type", "in", types),
-            ]
-        )
-        return moves
+        domain = self._get_moves_domain(date=date, types=types)
+        return self.env["account.move"].search(domain)
 
     def _compute_invoice_related_count(self):
         self.invoice_related_count = len(self.billing_line_ids)


### PR DESCRIPTION
This PR includes

- Extract search domain into _get_moves_domain() method to allow downstream modules to extend the domain via super().

@qrtl QT5088