### PR TITLE
[18.0] partner_invoicing_mode_at_shipping: fix missing job function

### DIFF
--- a/partner_invoicing_mode_at_shipping/data/queue_job_data.xml
+++ b/partner_invoicing_mode_at_shipping/data/queue_job_data.xml
@@ -12,4 +12,12 @@
         <field name="method">_invoicing_at_shipping</field>
         <field name="channel_id" ref="invoice_at_shipping" />
     </record>
+    <record
+        id="job_function_validate_per_shipping_generated_invoices"
+        model="queue.job.function"
+    >
+        <field name="model_id" ref="sale.model_sale_order" />
+        <field name="method">_validate_per_shipping_generated_invoices</field>
+        <field name="channel_id" ref="invoice_at_shipping" />
+    </record>
 </odoo>


### PR DESCRIPTION
This method is delayed but there's no job func definition