### PR TITLE
[18.0] account_invoice_auto_send_by_email: fix missing job function

### DIFF
--- a/account_invoice_auto_send_by_email/__manifest__.py
+++ b/account_invoice_auto_send_by_email/__manifest__.py
@@ -12,6 +12,7 @@
     "website": "https://github.com/OCA/account-invoicing",
     "data": [
         "data/ir_cron.xml",
+        "data/queue_job_data.xml",
     ],
     "installable": True,
 }

--- a/account_invoice_auto_send_by_email/data/queue_job_data.xml
+++ b/account_invoice_auto_send_by_email/data/queue_job_data.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <!-- Queue Job Channel -->
+    <record id="invoice_auto_send" model="queue.job.channel">
+        <field name="name">invoice_auto_send</field>
+        <field name="parent_id" ref="queue_job.channel_root" />
+    </record>
+
+    <!-- Job Functions -->
+    <record id="job_function_execute_invoice_sent_wizard" model="queue.job.function">
+        <field name="model_id" ref="account.model_account_move" />
+        <field name="method">_execute_invoice_sent_wizard</field>
+        <field name="channel_id" ref="invoice_auto_send" />
+    </record>
+</odoo>


### PR DESCRIPTION
This method is delayed but there's no job func definition