### PR TITLE
[16.0][FIX] account_billing: fix domain of _get_move()

### DIFF
--- a/account_billing/models/account_billing.py
+++ b/account_billing/models/account_billing.py
@@ -117,13 +117,13 @@ class AccountBilling(models.Model):
                 line.payment_state == "paid" for line in rec.billing_line_ids
             )
 
-    def _get_moves_domain(self, date=False, types=False):
+    def _get_moves_domain(self, date, types=False):
         return [
             ("partner_id", "=", self.partner_id.id),
             ("state", "=", "posted"),
             ("payment_state", "!=", "paid"),
             ("currency_id", "=", self.currency_id.id),
-            ("date", "<=", self.threshold_date),
+            (date, "<=", self.threshold_date),
             ("move_type", "in", types),
         ]
 


### PR DESCRIPTION
Back port of https://github.com/OCA/account-invoicing/pull/2041/changes/2a7a2770903f5ce188241fee80b8ee7ff7381564
Before this fix, value of `threshold_date_type` is not considered when we search the moves.

@qrtl QT6484