### PR TITLE
[18.0][IMP] sale_line_refund_to_invoice_qty: compute qty_invoice_posted

### DIFF
--- a/sale_line_refund_to_invoice_qty/models/sale_order_line.py
+++ b/sale_line_refund_to_invoice_qty/models/sale_order_line.py
@@ -38,6 +38,36 @@ class SaleOrderLine(models.Model):
         return res
 
     @api.depends(
+        "invoice_lines.move_id.state",
+        "invoice_lines.quantity",
+        "invoice_lines.sale_qty_to_reinvoice",
+    )
+    def _compute_qty_invoiced_posted(self):
+        res = super()._compute_qty_invoiced_posted()
+        # Revert effect of refunds in qty_invoiced_posted when
+        # `sale_qty_to_reinvoice` is not set.
+        for line in self:
+            qty_invoiced_posted = line.qty_invoiced_posted
+            for invoice_line in line.invoice_lines:
+                if (
+                    invoice_line.move_id.state != "cancel"
+                    and invoice_line.move_id.move_type == "out_refund"
+                    and not invoice_line.sale_qty_to_reinvoice
+                    and (
+                        invoice_line.move_id.state == "posted"
+                        or invoice_line.move_id.payment_state == "invoicing_legacy"
+                    )
+                ):
+                    qty_invoiced_posted += (
+                        invoice_line.product_uom_id._compute_quantity(
+                            invoice_line.quantity, line.product_uom
+                        )
+                    )
+            if line.qty_invoiced_posted != qty_invoiced_posted:
+                line.qty_invoiced_posted = qty_invoiced_posted
+        return res
+
+    @api.depends(
         "product_uom_qty",
         "invoice_lines.move_id.state",
         "invoice_lines.quantity",

--- a/sale_line_refund_to_invoice_qty/tests/test_sale_line_refund_to_invoice_qty.py
+++ b/sale_line_refund_to_invoice_qty/tests/test_sale_line_refund_to_invoice_qty.py
@@ -50,6 +50,7 @@ class TestSaleLineRefundToInvoiceQty(TransactionCase):
         reinvoice in the sales order line, when the boolean is checked.
         """
         self.assertEqual(self.order.order_line[0].qty_invoiced, 5.0)
+        self.assertEqual(self.order.order_line[0].qty_invoiced_posted, 5.0)
         reversal_wizard = self.move_reversal_wiz(self.invoice)
         reversal_wizard.write({"sale_qty_to_reinvoice": False})
         credit_note = self.env["account.move"].browse(
@@ -58,8 +59,12 @@ class TestSaleLineRefundToInvoiceQty(TransactionCase):
         for line in credit_note.line_ids:
             self.assertFalse(line.sale_qty_to_reinvoice)
         self.assertEqual(self.order.order_line[0].qty_invoiced, 5.0)
+        self.assertEqual(self.order.order_line[0].qty_invoiced_posted, 5.0)
         self.assertEqual(self.order.order_line[0].qty_to_invoice, 0.0)
         self.assertEqual(self.order.order_line[0].qty_refunded_not_invoiceable, 5.0)
+        # Check after posting credit note
+        credit_note.action_post()
+        self.assertEqual(self.order.order_line[0].qty_invoiced_posted, 5.0)
 
     def test_refund_qty_to_reinvoice(self):
         """
@@ -67,6 +72,7 @@ class TestSaleLineRefundToInvoiceQty(TransactionCase):
         reinvoice in the sales order line, when the boolean is left unchecked.
         """
         self.assertEqual(self.order.order_line[0].qty_invoiced, 5.0)
+        self.assertEqual(self.order.order_line[0].qty_invoiced_posted, 5.0)
         reversal_wizard = self.move_reversal_wiz(self.invoice)
         credit_note = self.env["account.move"].browse(
             reversal_wizard.reverse_moves()["res_id"]
@@ -74,5 +80,9 @@ class TestSaleLineRefundToInvoiceQty(TransactionCase):
         for line in credit_note.line_ids:
             self.assertTrue(line.sale_qty_to_reinvoice)
         self.assertEqual(self.order.order_line[0].qty_invoiced, 0.0)
+        self.assertEqual(self.order.order_line[0].qty_invoiced_posted, 5.0)
         self.assertEqual(self.order.order_line[0].qty_to_invoice, 5.0)
         self.assertEqual(self.order.order_line[0].qty_refunded_not_invoiceable, 0.0)
+        # Check after posting credit note
+        credit_note.action_post()
+        self.assertEqual(self.order.order_line[0].qty_invoiced_posted, 0.0)


### PR DESCRIPTION
In v18, the core logic for computing the remaining amounts to invoice on SOs relies heavily on the `qty_invoiced_posted` field. It was introduced in https://github.com/odoo/odoo/commit/4bcfd5c4d212d2ed8a4c66e7fa6682ce41bcb2da.

Currently, the `sale_line_refund_to_invoice_qty` module only overrides the `_compute_qty_invoiced` method to revert the effect of refunds (with `sale_qty_to_reinvoice`). 

This PR applies the same logic and criteria to `_compute_qty_invoiced_posted`. By adding the refunded quantities back into `qty_invoiced_posted` field (when the reinvoice bool is false), we ensure the SO invoicing status calculation respects the module's original intention.