### PR TITLE
[18.0][REF] stock_picking_invoicing, sale_stock_picking_invoicing: Run Tests without Demo Data

### DIFF
--- a/sale_stock_picking_invoicing/__manifest__.py
+++ b/sale_stock_picking_invoicing/__manifest__.py
@@ -5,7 +5,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {
-    "name": "Sales Stock Picking Invocing",
+    "name": "Sales Stock Picking Invoicing",
     "category": "Warehouse Management",
     "license": "AGPL-3",
     "author": "Akretion, Odoo Community Association (OCA)",

--- a/sale_stock_picking_invoicing/tests/__init__.py
+++ b/sale_stock_picking_invoicing/tests/__init__.py
@@ -1,1 +1,2 @@
+from . import common
 from . import test_sale_stock

--- a/sale_stock_picking_invoicing/tests/common.py
+++ b/sale_stock_picking_invoicing/tests/common.py
@@ -1,0 +1,217 @@
+# Copyright (C) 2023-Today - Akretion (<http://www.akretion.com>).
+# @author Magno Costa <magno.costa@akretion.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.fields import Command
+from odoo.tests import tagged
+
+from odoo.addons.stock_picking_invoicing.tests.common import (
+    TestStockPickingInvoicingCommon,
+)
+from odoo.addons.stock_picking_invoicing.tests.tools import (
+    create_with_form_product_product,
+)
+
+from .tools import (
+    create_with_form_product_combo,
+    create_with_form_res_partner,
+    create_with_form_sale_order,
+)
+
+
+@tagged("post_install", "-at_install")
+class TestSaleStockPickingInvoicingCommon(TestStockPickingInvoicingCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # In order to avoid errors in the tests CI environment when the tests
+        # Create of Invoice by Sale Order using sale.advance.payment.inv object
+        # is necessary let default policy as sale_order, just affect demo data.
+        # TODO: Is there other form to avoid this problem?
+        cls.company.sale_invoicing_policy = "stock_picking"
+
+        # Partner to test Delivery Address
+        cls.partner_a_delivery_address = create_with_form_res_partner(
+            cls.env,
+            {
+                "name": "Delivery Address - sale_stock_picking_invoicing",
+                "parent_id": cls.partner_a,
+                "type": "delivery",
+                "category_id": cls.env.ref("base.res_partner_category_14"),
+                "street": "77 Santa Barbara Rd",
+                "city": "Pleasant Hill",
+                "state_id": cls.env.ref("base.state_br_sp"),
+                "zip": "09843-010",
+                "country_id": cls.env.ref("base.br"),
+                "phone": "+55(11)4545-7777",
+                "website": "http://www.company.com",
+                "vat": "12345673",
+            },
+        )
+
+        # Service Product
+        cls.product_service = create_with_form_product_product(
+            cls.env, cls.common_product_values | {"name": "Service", "type": "service"}
+        )
+
+        # Common Sale Order Data
+        cls.pricelist = cls.env["product.pricelist"].search(
+            [("company_id", "=", cls.company.id)], limit=1
+        )
+        incoterm_fob = cls.env["account.incoterms"].search(
+            [("active", "=", True), ("name", "=", "FREE ON BOARD")]
+        )
+
+        cls.so_vals = {
+            "partner_id": cls.partner_a,
+            "partner_invoice_id": cls.partner_a,
+            "partner_shipping_id": cls.partner_a,
+            "pricelist_id": cls.pricelist,
+            "company_id": cls.company,
+            "client_order_ref": "Customer Ref Test",
+            "incoterm": incoterm_fob,
+            "note": "Test Note sale_stock_picking_invoicing",
+        }
+
+        cls.so_vals_delivery_partner = cls.so_vals | {
+            "partner_shipping_id": cls.partner_a_delivery_address,
+        }
+
+        cls.so_line_product_1 = [
+            {
+                "product_id": cls.product_storable_1,
+                "product_uom_qty": 1.0,
+            }
+        ]
+
+        cls.so_line_product_2 = [
+            {
+                "product_id": cls.product_storable_2,
+                "product_uom_qty": 2.0,
+            }
+        ]
+
+        cls.so_line_product_service = [
+            {
+                "product_id": cls.product_service,
+                "product_uom_qty": 2.0,
+            }
+        ]
+
+        cls.so_line_note = [
+            {
+                "name": "This is a Note",
+                "display_type": "line_note",
+            }
+        ]
+
+        cls.so_line_section = [
+            {
+                "name": "This is a Section",
+                "display_type": "line_section",
+            }
+        ]
+
+        # Sale Orders
+        cls.sale_order_0 = create_with_form_sale_order(
+            cls.env, cls.so_vals, cls.so_line_product_1
+        )
+
+        cls.sale_order_1 = create_with_form_sale_order(
+            cls.env,
+            cls.so_vals_delivery_partner,
+            cls.so_line_product_1
+            + cls.so_line_note
+            + cls.so_line_section
+            + cls.so_line_product_2,
+        )
+
+        cls.sale_order_2 = create_with_form_sale_order(
+            cls.env,
+            cls.so_vals_delivery_partner,
+            cls.so_line_product_1
+            + cls.so_line_note
+            + cls.so_line_section
+            + cls.so_line_product_service,
+        )
+
+        cls.sale_order_3 = create_with_form_sale_order(
+            cls.env,
+            cls.so_vals,
+            cls.so_line_product_1
+            + cls.so_line_note
+            + cls.so_line_section
+            + cls.so_line_product_2,
+        )
+
+        cls.sale_order_4 = create_with_form_sale_order(
+            cls.env,
+            cls.so_vals,
+            cls.so_line_product_1
+            + cls.so_line_note
+            + cls.so_line_section
+            + cls.so_line_product_2,
+        )
+
+        # Combo Case
+        cls.combo_service = create_with_form_product_combo(
+            cls.env,
+            {"name": "Service Choice"},
+            [{"product_id": cls.product_service}],
+        )
+
+        cls.combo_consu_1 = create_with_form_product_combo(
+            cls.env,
+            {"name": "Consu Choice 1"},
+            [{"product_id": cls.product_storable_1}],
+        )
+
+        cls.combo_consu_2 = create_with_form_product_combo(
+            cls.env,
+            {"name": "Consu Choice 2"},
+            [{"product_id": cls.product_storable_2}],
+        )
+
+        cls.product_combo = cls.env["product.product"].create(
+            {
+                "name": "Test Meal Combo",
+                "type": "combo",
+                "list_price": 75.0,
+                "combo_ids": [
+                    Command.link(cls.combo_service.id),
+                    Command.link(cls.combo_consu_1.id),
+                    Command.link(cls.combo_consu_2.id),
+                ],
+            }
+        )
+
+        cls.sale_order_5 = create_with_form_sale_order(
+            cls.env,
+            cls.so_vals_delivery_partner,
+            [
+                {"product_id": cls.product_combo, "product_uom_qty": 1.0},
+            ],
+        )
+        cls.sale_order_5.order_line = [
+            Command.create(
+                {
+                    "product_id": product.id,
+                    "product_uom_qty": 1.0,
+                    "price_unit": product.list_price,
+                    "combo_item_id": combo.combo_item_ids.id,
+                    "linked_line_id": cls.sale_order_5.order_line.id,
+                }
+            )
+            for product, combo in (
+                (cls.product_service, cls.combo_service),
+                (cls.product_storable_1, cls.combo_consu_1),
+                (cls.product_storable_2, cls.combo_consu_2),
+            )
+        ]
+
+    def run_sale_picking_process(self, sale_order):
+        sale_order.action_confirm()
+        picking = sale_order.picking_ids
+        self.picking_move_state(picking)
+        return picking

--- a/sale_stock_picking_invoicing/tests/common.py
+++ b/sale_stock_picking_invoicing/tests/common.py
@@ -173,6 +173,9 @@ class TestSaleStockPickingInvoicingCommon(TestStockPickingInvoicingCommon):
             [{"product_id": cls.product_storable_2}],
         )
 
+        # Combo product uses direct .create() instead of Form because
+        # combo products require linking combo_ids via Command.link which
+        # is not easily handled through the Form helper.
         cls.product_combo = cls.env["product.product"].create(
             {
                 "name": "Test Meal Combo",

--- a/sale_stock_picking_invoicing/tests/test_sale_stock.py
+++ b/sale_stock_picking_invoicing/tests/test_sale_stock.py
@@ -2,29 +2,25 @@
 # @author Magno Costa <magno.costa@akretion.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import Command, exceptions, models
+from odoo import exceptions, models
 from odoo.tests import Form
 
-from odoo.addons.stock_picking_invoicing.tests.common import TestPickingInvoicingCommon
+from odoo.addons.stock_picking_invoicing.tests.tools import (
+    create_with_form_inv_onshipping,
+    create_with_form_return_picking,
+)
+
+from .common import TestSaleStockPickingInvoicingCommon
+from .tools import (
+    create_with_form_account_payment,
+    create_with_form_sale_adv_pay_inv,
+)
 
 
-class TestSaleStock(TestPickingInvoicingCommon):
+class TestSaleStockPickingInvoicing(TestSaleStockPickingInvoicingCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.account_move_model = cls.env["account.move"]
-        cls.invoice_wizard = cls.env["stock.invoice.onshipping"]
-        cls.stock_return_picking = cls.env["stock.return.picking"]
-        cls.stock_picking = cls.env["stock.picking"]
-        # In order to avoid errors in the tests CI environment when the tests
-        # Create of Invoice by Sale Order using sale.advance.payment.inv object
-        # is necessary let default policy as sale_order, just affect demo data.
-        # TODO: Is there other form to avoid this problem?
-        cls.companies = cls.env["res.company"].search(
-            [("sale_invoicing_policy", "=", "sale_order")]
-        )
-        for company in cls.companies:
-            company.sale_invoicing_policy = "stock_picking"
 
     def test_01_sale_stock_return(self):
         """
@@ -32,60 +28,35 @@ class TestSaleStock(TestPickingInvoicingCommon):
         the SO, then do a return of the picking. Check that a refund
          invoice is well generated.
         """
-        # intial so
-        self.partner = self.env.ref(
-            "sale_stock_picking_invoicing.res_partner_2_address"
-        )
-        self.product = self.env.ref("product.product_delivery_01")
-        so_vals = {
-            "partner_id": self.partner.id,
-            "partner_invoice_id": self.partner.id,
-            "partner_shipping_id": self.partner.id,
-            "order_line": [
-                (
-                    0,
-                    0,
-                    {
-                        "name": self.product.name,
-                        "product_id": self.product.id,
-                        "product_uom_qty": 3.0,
-                        "product_uom": self.product.uom_id.id,
-                        "price_unit": self.product.list_price,
-                    },
-                )
-            ],
-            "pricelist_id": self.env.ref(
-                "sale_stock_picking_invoicing.demo_pricelist"
-            ).id,
-        }
-        self.so = self.env["sale.order"].create(so_vals)
+        sale_order = self.sale_order_0
 
         # confirm our standard so, check the picking
-        self.so.action_confirm()
+        sale_order.action_confirm()
         self.assertTrue(
-            self.so.picking_ids,
+            sale_order.picking_ids,
             'Sale Stock: no picking created for "invoice on '
             'delivery" storable products',
         )
 
         # set stock.picking to be invoiced
         self.assertTrue(
-            len(self.so.picking_ids) == 1,
-            "More than one stock " "picking for sale.order",
+            len(sale_order.picking_ids) == 1,
+            "More than one stock picking for sale.order",
         )
 
         # Check Sale Invoicing Policy Warning to force create Invoice from Picking
         with self.assertRaises(exceptions.UserError):
-            self.so._create_invoices(final=True)
+            sale_order.with_context(active_model="sale.order")._create_invoices(
+                final=True
+            )
 
-        self.so.picking_ids.set_to_be_invoiced()
+        sale_order.picking_ids.set_to_be_invoiced()
 
         # validate stock.picking
-        stock_picking = self.so.picking_ids
-
+        stock_picking = sale_order.picking_ids
         # compare sale.order.line with stock.move
         stock_move = stock_picking.move_ids
-        sale_order_line = self.so.order_line
+        sale_order_line = sale_order.order_line
 
         sm_fields = [key for key in self.env["stock.move"]._fields.keys()]
         sol_fields = [key for key in self.env["sale.order.line"]._fields.keys()]
@@ -114,22 +85,14 @@ class TestSaleStock(TestPickingInvoicingCommon):
                 "to stock.move",
             )
 
-    def test_picking_sale_order_product_and_service(self):
+    def test_02_picking_sale_order_product_and_service(self):
         """
         Test Sale Order with product and service
         """
-
         # Ensure the company's sale_invoicing_policy is set to "stock_picking"
-        company = self.env.ref("base.main_company")
-        company.sale_invoicing_policy = "stock_picking"
-        sale_order_form = sale_order_form = Form(
-            self.env.ref("sale_stock_picking_invoicing.main_company-sale_order_2")
-        )
-        # Necessary to get the currency
-        sale_order_form.pricelist_id = self.env.ref(
-            "sale_stock_picking_invoicing.demo_pricelist"
-        )
-        sale_order_2 = sale_order_form.save()
+        self.assertEqual(self.company.sale_invoicing_policy, "stock_picking")
+
+        sale_order_2 = self.sale_order_2
         sale_order_2.action_confirm()
         # Method to create invoice in sale order should work only
         # for lines where products are of TYPE Service
@@ -171,7 +134,7 @@ class TestSaleStock(TestPickingInvoicingCommon):
         with self.assertRaises(exceptions.UserError):
             payment.with_context(**context).create_invoices()
 
-        invoice = self.create_invoice_wizard(picking)
+        invoice = create_with_form_inv_onshipping(self.env, picking)
         self.assertEqual(picking.invoice_state, "invoiced")
         self.assertIn(invoice, picking.invoice_ids)
         self.assertIn(picking, invoice.picking_ids)
@@ -198,7 +161,7 @@ class TestSaleStock(TestPickingInvoicingCommon):
 
         # Check Invoiced QTY
         for line in sale_order_2.order_line.filtered(
-            lambda ln: ln.product_id.type == "product"
+            lambda ln: ln.product_id.is_storable
         ):
             self.assertEqual(line.product_uom_qty, line.qty_invoiced)
             # Test the qty_to_invoice
@@ -255,7 +218,7 @@ class TestSaleStock(TestPickingInvoicingCommon):
             )
 
         # Return Picking
-        picking_devolution = self.return_picking_wizard(picking)
+        picking_devolution = create_with_form_return_picking(self.env, picking)
 
         self.assertEqual(picking_devolution.invoice_state, "2binvoiced")
         for line in picking_devolution.move_ids:
@@ -264,7 +227,9 @@ class TestSaleStock(TestPickingInvoicingCommon):
         self.picking_move_state(picking_devolution)
         self.assertEqual(picking_devolution.state, "done", "Change state fail.")
 
-        invoice_devolution = self.create_invoice_wizard(picking_devolution)
+        invoice_devolution = create_with_form_inv_onshipping(
+            self.env, picking_devolution
+        )
         # Confirm Invoice
         invoice_devolution.action_post()
         self.assertEqual(
@@ -282,31 +247,22 @@ class TestSaleStock(TestPickingInvoicingCommon):
         #    if line.product_id.type == "product":
         #        # self.assertEqual(0.0, line.qty_invoiced)
 
-    def test_picking_invoicing_partner_shipping_invoiced(self):
+    def test_03_picking_invoicing_partner_shipping_invoiced(self):
         """
         Test the invoice generation grouped by partner/product with 2
         picking and 2 moves per picking, but Partner to Shipping is
         different from Partner to Invoice.
         """
-        sale_order_1 = self.env.ref(
-            "sale_stock_picking_invoicing.main_company-sale_order_1"
-        )
-        sale_order_1.action_confirm()
-        picking = sale_order_1.picking_ids
-        self.picking_move_state(picking)
-        sale_order_2 = self.env.ref(
-            "sale_stock_picking_invoicing.main_company-sale_order_2"
-        )
+        picking = self.run_sale_picking_process(self.sale_order_1)
+        sale_order_2 = self.sale_order_2
         sale_order_2.note = False
-        sale_order_2.action_confirm()
-        picking2 = sale_order_2.picking_ids
-        self.picking_move_state(picking2)
+        picking2 = self.run_sale_picking_process(sale_order_2)
         pickings = picking | picking2
-        invoice = self.create_invoice_wizard(pickings)
+        invoice = create_with_form_inv_onshipping(self.env, pickings)
         # Groupping Invoice
         self.assertEqual(len(invoice), 1)
         # Invoice should be create with the partner_invoice_id
-        self.assertEqual(invoice.partner_id, sale_order_1.partner_invoice_id)
+        self.assertEqual(invoice.partner_id, self.sale_order_1.partner_invoice_id)
         # Invoice partner shipping should be the same of picking
         self.assertEqual(invoice.partner_shipping_id, picking.partner_id)
         self.assertIn(invoice, picking.invoice_ids)
@@ -323,36 +279,18 @@ class TestSaleStock(TestPickingInvoicingCommon):
         # Post the Invoice to validate the fields
         invoice.action_post()
 
-    def test_ungrouping_pickings_partner_shipping_different(self):
+    def test_04_ungrouping_pickings_partner_shipping_different(self):
         """
         Test the invoice generation grouped by partner/product with 3
         picking and 2 moves per picking, the 3 has the same Partner to
         Invoice but one has Partner to Shipping so shouldn't be grouping.
         """
-
-        sale_order_1 = self.env.ref(
-            "sale_stock_picking_invoicing.main_company-sale_order_1"
-        )
-        sale_order_1.action_confirm()
-        picking = sale_order_1.picking_ids
-        self.picking_move_state(picking)
-
-        sale_order_3 = self.env.ref(
-            "sale_stock_picking_invoicing.main_company-sale_order_3"
-        )
-        sale_order_3.action_confirm()
-        picking3 = sale_order_3.picking_ids
-        self.picking_move_state(picking3)
-
-        sale_order_4 = self.env.ref(
-            "sale_stock_picking_invoicing.main_company-sale_order_4"
-        )
-        sale_order_4.action_confirm()
-        picking4 = sale_order_4.picking_ids
-        self.picking_move_state(picking4)
+        picking = self.run_sale_picking_process(self.sale_order_1)
+        picking3 = self.run_sale_picking_process(self.sale_order_3)
+        picking4 = self.run_sale_picking_process(self.sale_order_4)
 
         pickings = picking | picking3 | picking4
-        invoices = self.create_invoice_wizard(pickings)
+        invoices = create_with_form_inv_onshipping(self.env, pickings)
         # Even with same Partner Invoice if the Partner Shipping
         # are different should not be Groupping
         self.assertEqual(len(invoices), 2)
@@ -363,7 +301,9 @@ class TestSaleStock(TestPickingInvoicingCommon):
             lambda t: t.partner_id != t.partner_shipping_id
         )
         # Invoice should be create with partner_invoice_id
-        self.assertEqual(invoice_pick_1.partner_id, sale_order_1.partner_invoice_id)
+        self.assertEqual(
+            invoice_pick_1.partner_id, self.sale_order_1.partner_invoice_id
+        )
         # Invoice create with Partner Shipping used in Picking
         self.assertEqual(invoice_pick_1.partner_shipping_id, picking.partner_id)
 
@@ -374,39 +314,21 @@ class TestSaleStock(TestPickingInvoicingCommon):
         self.assertIn(invoice_pick_3_4, picking3.invoice_ids)
         self.assertIn(invoice_pick_3_4, picking4.invoice_ids)
 
-    def test_down_payment(self):
+    def test_05_down_payment(self):
         """Test the case with Down Payment"""
-        sale_order_1 = self.env.ref(
-            "sale_stock_picking_invoicing.main_company-sale_order_1"
-        )
+        sale_order_1 = self.sale_order_1
         sale_order_1.action_confirm()
-        # Create Invoice Sale
-        context = {
-            "active_model": "sale.order",
-            "active_id": sale_order_1.id,
-            "active_ids": sale_order_1.ids,
-        }
-        # DownPayment
-        payment_wizard = (
-            self.env["sale.advance.payment.inv"]
-            .with_context(**context)
-            .create(
-                {
-                    "advance_payment_method": "percentage",
-                    "amount": 50,
-                }
-            )
-        )
-        payment_wizard.create_invoices()
 
-        invoice_down_payment = sale_order_1.invoice_ids[0]
-        invoice_down_payment.action_post()
-        payment_register = Form(
-            self.env["account.payment.register"].with_context(
-                active_model="account.move",
-                active_ids=invoice_down_payment.ids,
-            )
+        invoice_down_payment = create_with_form_sale_adv_pay_inv(
+            self.env,
+            sale_order_1,
+            {
+                "advance_payment_method": "percentage",
+                "amount": 50,
+            },
         )
+        invoice_down_payment.action_post()
+
         journal_cash = self.env["account.journal"].search(
             [
                 ("type", "=", "cash"),
@@ -414,13 +336,16 @@ class TestSaleStock(TestPickingInvoicingCommon):
             ],
             limit=1,
         )
-        payment_register.journal_id = journal_cash
-        payment_register.amount = invoice_down_payment.amount_total
-        payment_register.save()._create_payments()
+        payment = create_with_form_account_payment(
+            self.env,
+            invoice_down_payment,
+            {"journal_id": journal_cash, "amount": invoice_down_payment.amount_total},
+        )
+        self.assertTrue(payment, "Payment not created by Down Payment test.")
 
         picking = sale_order_1.picking_ids
         self.picking_move_state(picking)
-        invoice = self.create_invoice_wizard(picking)
+        invoice = create_with_form_inv_onshipping(self.env, picking)
         # 2 Products, 2 Down Payment, 1 Note and 1 Section
         self.assertEqual(len(invoice.invoice_line_ids), 6)
         line_section = invoice.invoice_line_ids.filtered(
@@ -432,7 +357,7 @@ class TestSaleStock(TestPickingInvoicingCommon):
         )
         assert down_payment_line, "Invoice without Down Payment line."
 
-    def test_default_value_sale_invoicing_policy(self):
+    def test_06_default_value_sale_invoicing_policy(self):
         """Test default value for sale_invoicing_policy"""
         company = self.env["res.company"].create(
             {
@@ -441,182 +366,39 @@ class TestSaleStock(TestPickingInvoicingCommon):
         )
         self.assertEqual(company.sale_invoicing_policy, "sale_order")
 
-    def test_consumable_product_invoicing_from_picking(self):
-        """
-        Test that consumable (non-storable) products generate a picking
-        and must be invoiced from it, not from the sale order.
-        """
-        product_consumable = self.env["product.product"].create(
-            {
-                "name": "Test Consumable",
-                "type": "consu",
-                "is_storable": False,
-                "list_price": 50.0,
-                "invoice_policy": "delivery",
-            }
-        )
-
-        partner = self.env.ref("sale_stock_picking_invoicing.res_partner_2_address")
-        so = self.env["sale.order"].create(
-            {
-                "partner_id": partner.id,
-                "partner_invoice_id": partner.id,
-                "partner_shipping_id": partner.id,
-                "order_line": [
-                    (
-                        0,
-                        0,
-                        {
-                            "name": product_consumable.name,
-                            "product_id": product_consumable.id,
-                            "product_uom_qty": 2.0,
-                            "product_uom": product_consumable.uom_id.id,
-                            "price_unit": product_consumable.list_price,
-                        },
-                    )
-                ],
-                "pricelist_id": self.env.ref(
-                    "sale_stock_picking_invoicing.demo_pricelist"
-                ).id,
-            }
-        )
-        so.action_confirm()
-        self.assertTrue(so.picking_ids, "Consumable product should generate a picking")
-
-        # Invoicing from SO must raise error — consumable is not a service
-        with self.assertRaises(exceptions.UserError):
-            so._create_invoices(final=True)
-
-        # Validate picking and invoice from it
-        picking = so.picking_ids
+    def test_07_picking_invocing_without_sale_order(self):
+        """Test Picking Invoicing without Sale Order"""
+        picking = self.picking_out_1
         picking.set_to_be_invoiced()
         self.picking_move_state(picking)
-
-        invoice = self.create_invoice_wizard(picking)
+        invoice = create_with_form_inv_onshipping(self.env, picking)
         self.assertEqual(len(invoice), 1)
-        invoice.action_post()
-        self.assertEqual(invoice.state, "posted")
 
-    def test_combo_product_invoicing(self):
+    def test_08_combo_product_invoicing(self):
         """
         Combo product with stock_picking policy: the combo header line and
         any service child must be invoiceable from the Sale Order; consu
         children must be invoiced from the related Stock Picking.
         """
-        partner = self.env.ref("sale_stock_picking_invoicing.res_partner_2_address")
-        pricelist = self.env.ref("sale_stock_picking_invoicing.demo_pricelist")
-
-        product_service = self.env["product.product"].create(
-            {
-                "name": "Combo Service Item",
-                "type": "service",
-                "list_price": 30.0,
-                "invoice_policy": "order",
-            }
-        )
-        product_consu_1 = self.env["product.product"].create(
-            {
-                "name": "Combo Consu Item 1",
-                "type": "consu",
-                "is_storable": False,
-                "list_price": 20.0,
-                "invoice_policy": "delivery",
-            }
-        )
-        product_consu_2 = self.env["product.product"].create(
-            {
-                "name": "Combo Consu Item 2",
-                "type": "consu",
-                "is_storable": False,
-                "list_price": 25.0,
-                "invoice_policy": "delivery",
-            }
-        )
-
-        combo_service = self.env["product.combo"].create(
-            {
-                "name": "Service Choice",
-                "combo_item_ids": [Command.create({"product_id": product_service.id})],
-            }
-        )
-        combo_consu_1 = self.env["product.combo"].create(
-            {
-                "name": "Consu Choice 1",
-                "combo_item_ids": [Command.create({"product_id": product_consu_1.id})],
-            }
-        )
-        combo_consu_2 = self.env["product.combo"].create(
-            {
-                "name": "Consu Choice 2",
-                "combo_item_ids": [Command.create({"product_id": product_consu_2.id})],
-            }
-        )
-        product_combo = self.env["product.product"].create(
-            {
-                "name": "Test Meal Combo",
-                "type": "combo",
-                "list_price": 75.0,
-                "combo_ids": [
-                    Command.link(combo_service.id),
-                    Command.link(combo_consu_1.id),
-                    Command.link(combo_consu_2.id),
-                ],
-            }
-        )
-
-        so = self.env["sale.order"].create(
-            {
-                "partner_id": partner.id,
-                "partner_invoice_id": partner.id,
-                "partner_shipping_id": partner.id,
-                "pricelist_id": pricelist.id,
-                "order_line": [
-                    Command.create(
-                        {
-                            "name": product_combo.name,
-                            "product_id": product_combo.id,
-                            "product_uom_qty": 1.0,
-                            "price_unit": 0,
-                        }
-                    ),
-                ],
-            }
-        )
-        so.order_line = [
-            Command.create(
-                {
-                    "product_id": product.id,
-                    "product_uom_qty": 1.0,
-                    "price_unit": product.list_price,
-                    "combo_item_id": combo.combo_item_ids.id,
-                    "linked_line_id": so.order_line.id,
-                }
-            )
-            for product, combo in (
-                (product_service, combo_service),
-                (product_consu_1, combo_consu_1),
-                (product_consu_2, combo_consu_2),
-            )
-        ]
-
+        so = self.sale_order_5
         so.action_confirm()
 
         # Only consu children generate stock moves
         self.assertTrue(so.picking_ids, "Combo with consu items should create picking")
         picking = so.picking_ids
         picking_products = picking.move_ids.mapped("product_id")
-        self.assertIn(product_consu_1, picking_products)
-        self.assertIn(product_consu_2, picking_products)
-        self.assertNotIn(product_service, picking_products)
-        self.assertNotIn(product_combo, picking_products)
+        self.assertIn(self.product_storable_1, picking_products)
+        self.assertIn(self.product_storable_2, picking_products)
+        self.assertNotIn(self.product_service, picking_products)
+        self.assertNotIn(self.product_combo, picking_products)
 
         # Invoicing from SO: combo header + service child, no consu
         so_invoice = so._create_invoices()
         self.assertEqual(len(so_invoice), 1)
         so_invoice_products = so_invoice.invoice_line_ids.mapped("product_id")
-        self.assertIn(product_service, so_invoice_products)
-        self.assertNotIn(product_consu_1, so_invoice_products)
-        self.assertNotIn(product_consu_2, so_invoice_products)
+        self.assertIn(self.product_service, so_invoice_products)
+        self.assertNotIn(self.product_storable_1, so_invoice_products)
+        self.assertNotIn(self.product_storable_2, so_invoice_products)
         self.assertTrue(
             so_invoice.invoice_line_ids.filtered(
                 lambda ln: ln.display_type == "line_section"
@@ -629,116 +411,36 @@ class TestSaleStock(TestPickingInvoicingCommon):
         # Invoicing from picking: only consu children
         picking.set_to_be_invoiced()
         self.picking_move_state(picking)
-        picking_invoice = self.create_invoice_wizard(picking)
+        picking_invoice = create_with_form_inv_onshipping(self.env, picking)
         self.assertEqual(len(picking_invoice), 1)
         picking_invoice_products = picking_invoice.invoice_line_ids.mapped("product_id")
-        self.assertIn(product_consu_1, picking_invoice_products)
-        self.assertIn(product_consu_2, picking_invoice_products)
-        self.assertNotIn(product_service, picking_invoice_products)
+        self.assertIn(self.product_storable_1, picking_invoice_products)
+        self.assertIn(self.product_storable_2, picking_invoice_products)
+        self.assertNotIn(self.product_service, picking_invoice_products)
         self.assertTrue(
             picking_invoice.invoice_line_ids.filtered(
                 lambda ln: ln.display_type == "line_section"
-                and ln.name == product_combo.name
+                and ln.name == self.product_combo.name
             ),
             "Combo header should appear as a section on the picking invoice",
         )
         picking_invoice.action_post()
         self.assertEqual(picking_invoice.state, "posted")
 
-    def test_combo_product_invoicing_picking_first(self):
+    def test_09_combo_product_invoicing_picking_first(self):
         """
         Reverse flow: invoice the picking before the Sale Order. The combo
         header must still appear on the later SO invoice.
         """
-        partner = self.env.ref("sale_stock_picking_invoicing.res_partner_2_address")
-        pricelist = self.env.ref("sale_stock_picking_invoicing.demo_pricelist")
-
-        product_service = self.env["product.product"].create(
-            {
-                "name": "Combo Service Item",
-                "type": "service",
-                "list_price": 30.0,
-                "invoice_policy": "order",
-            }
-        )
-        product_consu = self.env["product.product"].create(
-            {
-                "name": "Combo Consu Item",
-                "type": "consu",
-                "is_storable": False,
-                "list_price": 20.0,
-                "invoice_policy": "delivery",
-            }
-        )
-        combo_service = self.env["product.combo"].create(
-            {
-                "name": "Service Choice",
-                "combo_item_ids": [Command.create({"product_id": product_service.id})],
-            }
-        )
-        combo_consu = self.env["product.combo"].create(
-            {
-                "name": "Consu Choice",
-                "combo_item_ids": [Command.create({"product_id": product_consu.id})],
-            }
-        )
-        product_combo = self.env["product.product"].create(
-            {
-                "name": "Test Meal Combo",
-                "type": "combo",
-                "list_price": 50.0,
-                "combo_ids": [
-                    Command.link(combo_service.id),
-                    Command.link(combo_consu.id),
-                ],
-            }
-        )
-
-        so = self.env["sale.order"].create(
-            {
-                "partner_id": partner.id,
-                "partner_invoice_id": partner.id,
-                "partner_shipping_id": partner.id,
-                "pricelist_id": pricelist.id,
-                "order_line": [
-                    Command.create(
-                        {
-                            "name": product_combo.name,
-                            "product_id": product_combo.id,
-                            "product_uom_qty": 1.0,
-                            "price_unit": 0,
-                        }
-                    ),
-                ],
-            }
-        )
-        so.order_line = [
-            Command.create(
-                {
-                    "product_id": product.id,
-                    "product_uom_qty": 1.0,
-                    "price_unit": product.list_price,
-                    "combo_item_id": combo.combo_item_ids.id,
-                    "linked_line_id": so.order_line.id,
-                }
-            )
-            for product, combo in (
-                (product_service, combo_service),
-                (product_consu, combo_consu),
-            )
-        ]
-
-        so.action_confirm()
-        picking = so.picking_ids
-        picking.set_to_be_invoiced()
-        self.picking_move_state(picking)
+        so = self.sale_order_5
+        picking = self.run_sale_picking_process(so)
 
         # Invoice the picking first
-        picking_invoice = self.create_invoice_wizard(picking)
+        picking_invoice = create_with_form_inv_onshipping(self.env, picking)
         self.assertTrue(
             picking_invoice.invoice_line_ids.filtered(
                 lambda ln: ln.display_type == "line_section"
-                and ln.name == product_combo.name
+                and ln.name == self.product_combo.name
             ),
             "Combo header should appear as a section on the picking invoice",
         )
@@ -747,7 +449,9 @@ class TestSaleStock(TestPickingInvoicingCommon):
         # Then invoice the SO: combo header must still show up
         so_invoice = so._create_invoices()
         self.assertEqual(len(so_invoice), 1)
-        self.assertIn(product_service, so_invoice.invoice_line_ids.mapped("product_id"))
+        self.assertIn(
+            self.product_service, so_invoice.invoice_line_ids.mapped("product_id")
+        )
         self.assertTrue(
             so_invoice.invoice_line_ids.filtered(
                 lambda ln: ln.display_type == "line_section"
@@ -757,10 +461,3 @@ class TestSaleStock(TestPickingInvoicingCommon):
         )
         so_invoice.action_post()
         self.assertEqual(so_invoice.state, "posted")
-
-    def test_picking_invocing_without_sale_order(self):
-        """Test Picking Invoicing without Sale Order"""
-        picking = self.env.ref("stock_picking_invoicing.stock_picking_invoicing_1")
-        self.picking_move_state(picking)
-        invoice = self.create_invoice_wizard(picking)
-        self.assertEqual(len(invoice), 1)

--- a/sale_stock_picking_invoicing/tests/test_sale_stock.py
+++ b/sale_stock_picking_invoicing/tests/test_sale_stock.py
@@ -81,8 +81,7 @@ class TestSaleStockPickingInvoicing(TestSaleStockPickingInvoicingCommon):
             self.assertEqual(
                 stock_move[field],
                 sale_order_line[field],
-                f"Field {field} failed to transfer from sale.order.line "
-                "to stock.move",
+                f"Field {field} failed to transfer from sale.order.line to stock.move",
             )
 
     def test_02_picking_sale_order_product_and_service(self):
@@ -351,11 +350,11 @@ class TestSaleStockPickingInvoicing(TestSaleStockPickingInvoicingCommon):
         line_section = invoice.invoice_line_ids.filtered(
             lambda line: line.display_type == "line_section"
         )
-        assert line_section, "Invoice without Line Section for Down Payment."
+        self.assertTrue(line_section, "Invoice without Line Section for Down Payment.")
         down_payment_line = invoice.invoice_line_ids.filtered(
             lambda line: line.sale_line_ids.is_downpayment
         )
-        assert down_payment_line, "Invoice without Down Payment line."
+        self.assertTrue(down_payment_line, "Invoice without Down Payment line.")
 
     def test_06_default_value_sale_invoicing_policy(self):
         """Test default value for sale_invoicing_policy"""
@@ -419,8 +418,10 @@ class TestSaleStockPickingInvoicing(TestSaleStockPickingInvoicingCommon):
         self.assertNotIn(self.product_service, picking_invoice_products)
         self.assertTrue(
             picking_invoice.invoice_line_ids.filtered(
-                lambda ln: ln.display_type == "line_section"
-                and ln.name == self.product_combo.name
+                lambda ln: (
+                    ln.display_type == "line_section"
+                    and ln.name == self.product_combo.name
+                )
             ),
             "Combo header should appear as a section on the picking invoice",
         )
@@ -439,8 +440,10 @@ class TestSaleStockPickingInvoicing(TestSaleStockPickingInvoicingCommon):
         picking_invoice = create_with_form_inv_onshipping(self.env, picking)
         self.assertTrue(
             picking_invoice.invoice_line_ids.filtered(
-                lambda ln: ln.display_type == "line_section"
-                and ln.name == self.product_combo.name
+                lambda ln: (
+                    ln.display_type == "line_section"
+                    and ln.name == self.product_combo.name
+                )
             ),
             "Combo header should appear as a section on the picking invoice",
         )

--- a/sale_stock_picking_invoicing/tests/tools.py
+++ b/sale_stock_picking_invoicing/tests/tools.py
@@ -1,0 +1,93 @@
+# Copyright (C) 2026-Today - Akretion (<http://www.akretion.com>).
+# @author Magno Costa <magno.costa@akretion.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import Form
+
+
+def create_with_form_res_partner(env, values):
+    with Form(env["res.partner"]) as partner:
+        partner.name = values.get("name")
+        partner.category_id = values.get("category_id")
+        partner.street = values.get("street")
+        partner.city = values.get("city")
+        partner.country_id = values.get("country_id")
+        partner.state_id = values.get("state_id")
+        partner.zip = values.get("zip")
+        partner.email = values.get("email")
+        partner.phone = values.get("phone")
+        partner.website = values.get("website")
+        partner.vat = values.get("vat")
+        if values.get("type"):
+            partner.type = values.get("type")
+        if values.get("parent_id"):
+            partner.parent_id = values.get("parent_id")
+    return partner.save()
+
+
+def create_with_form_product_combo(env, values, line_values):
+    with Form(env["product.combo"]) as combo:
+        combo.name = values.get("name")
+        for ln_value in line_values:
+            with combo.combo_item_ids.new() as combo_line:
+                combo_line.product_id = ln_value.get("product_id")
+
+    return combo.save()
+
+
+def create_with_form_sale_order(env, values, line_values=False):
+    with Form(
+        env["sale.order"]
+        .with_company(values.get("company_id"))
+        .with_context(
+            mail_notrack=True,
+            mail_create_nolog=True,
+        )
+    ) as sale:
+        sale.partner_id = values.get("partner_id")
+        sale.partner_invoice_id = values.get("partner_invoice_id")
+        sale.partner_shipping_id = values.get("partner_shipping_id")
+        sale.pricelist_id = values.get("pricelist_id")
+        sale.client_order_ref = values.get("client_order_ref")
+        sale.incoterm = values.get("incoterm")
+        sale.note = values.get("note")
+        sale.company_id = values.get("company_id")
+        for value in line_values:
+            with sale.order_line.new() as line:
+                if value.get("display_type"):
+                    line.name = value.get("name")
+                    line.display_type = value.get("display_type")
+                else:
+                    line.product_id = value.get("product_id")
+                    line.product_uom_qty = value.get("product_uom_qty")
+
+    return sale.save()
+
+
+def create_with_form_sale_adv_pay_inv(env, sale_order, values):
+    with Form(
+        env["sale.advance.payment.inv"].with_context(
+            active_model="sale.order",
+            active_id=sale_order.id,
+            active_ids=sale_order.ids,
+        )
+    ) as wzd:
+        wzd.advance_payment_method = values.get("advance_payment_method")
+        wzd.amount = values.get("amount")
+        result_wzd = wzd.save()
+        result_wzd.create_invoices()
+
+    return sale_order.mapped("invoice_ids")
+
+
+def create_with_form_account_payment(env, invoice, values):
+    with Form(
+        env["account.payment.register"].with_context(
+            active_model="account.move",
+            active_ids=invoice.ids,
+        )
+    ) as wzd:
+        wzd.journal_id = values.get("journal_id")
+        wzd.amount = values.get("amount")
+
+    return wzd.save()._create_payments()

--- a/stock_picking_invoicing/tests/__init__.py
+++ b/stock_picking_invoicing/tests/__init__.py
@@ -1,6 +1,3 @@
-# Copyright (C) 2019-Today: Odoo Community Association (OCA)
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-
 from . import common
 from . import test_picking_invoicing
 from . import test_stock_rule

--- a/stock_picking_invoicing/tests/common.py
+++ b/stock_picking_invoicing/tests/common.py
@@ -59,7 +59,7 @@ class TestStockPickingInvoicingCommon(TestAccountMoveStockCommon):
         # Fiscal Position
         fiscal_position = cls.env["account.fiscal.position"].create(
             {
-                "name": "Test - Stock Picking Invocing",
+                "name": "Test - Stock Picking Invoicing",
                 "company_id": cls.company.id,
                 "auto_apply": 1,
             }

--- a/stock_picking_invoicing/tests/common.py
+++ b/stock_picking_invoicing/tests/common.py
@@ -145,7 +145,9 @@ class TestStockPickingInvoicingCommon(TestAccountMoveStockCommon):
             for invoice in invoices:
                 if picking.picking_type_id != self.picking_type_in:
                     # TODO: Invoice created by Picking Type In don't get user, why?
-                    assert invoice.invoice_user_id, "Error to map User in Invoice."
+                    self.assertTrue(
+                        invoice.invoice_user_id, "Error to map User in Invoice."
+                    )
 
                 self.assertIn(invoice.partner_id, pickings.mapped("partner_id"))
                 self.assertIn(invoice, pickings.mapped("invoice_ids"))
@@ -163,7 +165,7 @@ class TestStockPickingInvoicingCommon(TestAccountMoveStockCommon):
                 )
 
                 for inv_line in invoice.invoice_line_ids:
-                    assert inv_line.price_unit, "Error to get Price Unit"
+                    self.assertTrue(inv_line.price_unit, "Error to get Price Unit")
 
                     self.assertTrue(
                         inv_line.product_uom_id,

--- a/stock_picking_invoicing/tests/common.py
+++ b/stock_picking_invoicing/tests/common.py
@@ -2,73 +2,185 @@
 # @author Magno Costa <magno.costa@akretion.com.br>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo.tests import Form
-from odoo.tests.common import TransactionCase
+from odoo.tests import Form, tagged
+
+from odoo.addons.stock_account.tests.test_account_move import TestAccountMoveStockCommon
+
+from .tools import (
+    create_with_form_product_product,
+    create_with_form_stock_picking,
+)
 
 
-class TestPickingInvoicingCommon(TransactionCase):
+@tagged("post_install", "-at_install")
+class TestStockPickingInvoicingCommon(TestAccountMoveStockCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
 
-    def _run_picking_onchanges(self, record):
-        record._onchange_invoice_state()
+        # Products Common Data
+        cls.tax_model = cls.env["account.tax"]
+        cls.tax_sale_1 = cls.tax_model.create(
+            {"name": "Sale tax 20", "type_tax_use": "sale", "amount": "20.00"}
+        )
+        cls.tax_sale_2 = cls.tax_model.create(
+            {"name": "Sale tax 10", "type_tax_use": "sale", "amount": "10.00"}
+        )
+        cls.tax_purchase_1 = cls.tax_model.create(
+            {"name": "Purchase tax 10", "type_tax_use": "purchase", "amount": "10.00"}
+        )
+        cls.tax_purchase_2 = cls.tax_model.create(
+            {"name": "Purchase tax 20", "type_tax_use": "purchase", "amount": "20.00"}
+        )
 
-    def _run_line_onchanges(self, record):
-        record._onchange_product_id()
+        cls.account_revenue = cls.env["account.account"].search(
+            [("account_type", "=", "expense_direct_cost")], limit=1
+        )
+
+        cls.common_product_values = {
+            "lst_price": "15000",
+            "taxes_id": cls.tax_sale_1 + cls.tax_sale_2,
+            "supplier_taxes_id": cls.tax_purchase_1 + cls.tax_purchase_2,
+            "property_account_income_id": cls.account_revenue,
+            "standard_price": "500",
+            "is_storable": True,
+            "invoice_policy": "order",
+        }
+
+        # Products Storable
+        cls.product_storable_1 = create_with_form_product_product(
+            cls.env, cls.common_product_values | {"name": "Test 1", "type": "consu"}
+        )
+        cls.product_storable_2 = create_with_form_product_product(
+            cls.env, cls.common_product_values | {"name": "Test 2", "type": "consu"}
+        )
+
+        # Fiscal Position
+        fiscal_position = cls.env["account.fiscal.position"].create(
+            {
+                "name": "Test - Stock Picking Invocing",
+                "company_id": cls.company.id,
+                "auto_apply": 1,
+            }
+        )
+        cls.partner_a.property_account_position_id = fiscal_position
+
+        # Common Picking Data
+        cls.picking_type_out = cls.env["stock.picking.type"].search(
+            [
+                ("company_id", "=", cls.company.id),
+                ("name", "=", "Delivery Orders"),
+            ],
+            limit=1,
+        )
+
+        picking_out_vals = {
+            "partner_id": cls.partner_a,
+            "picking_type_id": cls.picking_type_out,
+        }
+
+        cls.picking_type_in = cls.env["stock.picking.type"].search(
+            [
+                ("company_id", "=", cls.company.id),
+                ("name", "=", "Receipts"),
+            ],
+            limit=1,
+        )
+
+        picking_in_vals = {
+            "partner_id": cls.partner_a,
+            "picking_type_id": cls.picking_type_in,
+        }
+
+        move_vals_1 = [
+            {
+                "product_id": cls.product_storable_1,
+                "product_uom_qty": 1,
+            }
+        ]
+        move_vals_2 = move_vals_1 + [
+            {
+                "product_id": cls.product_storable_2,
+                "product_uom_qty": 1,
+            }
+        ]
+        move_vals_3 = move_vals_1 + move_vals_2
+
+        # Picking Out
+        cls.picking_out_1 = create_with_form_stock_picking(
+            cls.env, picking_out_vals, move_vals_1
+        )
+        cls.picking_out_2 = create_with_form_stock_picking(
+            cls.env, picking_out_vals, move_vals_2
+        )
+        cls.picking_out_3 = create_with_form_stock_picking(
+            cls.env, picking_out_vals, move_vals_3
+        )
+
+        # Picking In
+        cls.picking_in_1 = create_with_form_stock_picking(
+            cls.env, picking_in_vals, move_vals_1
+        )
 
     def picking_move_state(self, picking):
-        self._run_picking_onchanges(picking)
         picking.action_confirm()
         # Check product availability
         picking.action_assign()
         # Force product availability
-        for move in picking.move_ids_without_package:
-            self._run_line_onchanges(move)
-            move.quantity = move.product_uom_qty
+        with Form(picking) as picking_form:
+            i = 0
+            while i != len(picking.move_ids_without_package):
+                with picking_form.move_ids_without_package.edit(i) as line:
+                    line.quantity = line.product_uom_qty
+                i += 1
+
+            picking_form.save()
         picking.button_validate()
+        self.assertEqual(picking.state, "done")
 
-    def create_invoice_wizard(self, pickings):
-        wizard_obj = self.env["stock.invoice.onshipping"].with_context(
-            active_ids=pickings.ids,
-            active_model=pickings._name,
-        )
-        fields_list = wizard_obj.fields_get().keys()
-        wizard_values = wizard_obj.default_get(fields_list)
-        wizard_values.update({"group": "partner_product"})
-        wizard = wizard_obj.create(wizard_values)
-        wizard.onchange_group()
-        wizard.action_generate()
-        domain = [("picking_ids", "in", pickings.ids)]
-        invoice = self.env["account.move"].search(domain)
-        return invoice
+    def check_invoice_created(self, pickings, invoices):
+        for picking in pickings:
+            self.assertEqual(picking.invoice_state, "invoiced")
+            for invoice in invoices:
+                if picking.picking_type_id != self.picking_type_in:
+                    # TODO: Invoice created by Picking Type In don't get user, why?
+                    assert invoice.invoice_user_id, "Error to map User in Invoice."
 
-    def return_picking_wizard(self, picking):
-        # Return Picking
-        return_wizard_form = Form(
-            self.env["stock.return.picking"].with_context(
-                **dict(active_id=picking.id, active_model="stock.picking")
-            )
-        )
-        return_wizard_form.invoice_state = "2binvoiced"
-        self.return_wizard = return_wizard_form.save()
-        self.return_wizard.product_return_moves[0].quantity = 1
-        result_wizard = self.return_wizard.action_create_returns()
-        self.assertTrue(result_wizard, "Create returns wizard fail.")
-        picking_devolution = self.env["stock.picking"].browse(
-            result_wizard.get("res_id")
-        )
-        return picking_devolution
+                self.assertIn(invoice.partner_id, pickings.mapped("partner_id"))
+                self.assertIn(invoice, pickings.mapped("invoice_ids"))
+                self.assertTrue(
+                    invoice.invoice_payment_term_id,
+                    "Error to map Payment Term in Invoice.",
+                )
+                self.assertTrue(
+                    invoice.fiscal_position_id,
+                    "Error to map Fiscal Position in Invoice.",
+                )
+                self.assertTrue(invoice.company_id, "Error to map Company in Invoice.")
+                self.assertTrue(
+                    invoice.invoice_line_ids, "Error to create invoice line."
+                )
 
-    def create_backorder_wizard(self, picking):
-        res_dict_for_back_order = picking.button_validate()
-        backorder_wizard = Form(
-            self.env[res_dict_for_back_order["res_model"]].with_context(
-                **res_dict_for_back_order["context"]
-            )
-        ).save()
-        backorder_wizard.process()
-        backorder = self.env["stock.picking"].search(
-            [("backorder_id", "=", picking.id)]
-        )
-        return backorder
+                for inv_line in invoice.invoice_line_ids:
+                    assert inv_line.price_unit, "Error to get Price Unit"
+
+                    self.assertTrue(
+                        inv_line.product_uom_id,
+                        "Error to map Product UOM in Invoice Line.",
+                    )
+                    self.assertIn(
+                        inv_line.product_id,
+                        [self.product_storable_1, self.product_storable_2],
+                    )
+                    self.assertTrue(
+                        inv_line.tax_ids, "Error to map Tax in invoice.line."
+                    )
+                    for inv_mv_line in inv_line.move_line_ids:
+                        link_pck_line = self.env["stock.move"].search(
+                            [("id", "=", inv_mv_line.id)]
+                        )
+                        self.assertTrue(
+                            link_pck_line,
+                            "Error to link Invoice Line with Stock Move.",
+                        )

--- a/stock_picking_invoicing/tests/test_picking_invoicing.py
+++ b/stock_picking_invoicing/tests/test_picking_invoicing.py
@@ -1,194 +1,46 @@
 # Copyright (C) 2019-Today: Odoo Community Association (OCA)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import exceptions
+from odoo import Command, exceptions
 
-from .common import TestPickingInvoicingCommon
+from .common import TestStockPickingInvoicingCommon
+from .tools import (
+    create_with_form_inv_onshipping,
+    create_with_form_pck_backorder,
+    create_with_form_return_picking,
+)
 
 
-class TestPickingInvoicing(TestPickingInvoicingCommon):
+class TestStockPickingInvoicing(TestStockPickingInvoicingCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.picking_model = cls.env["stock.picking"]
-        cls.move_model = cls.env["stock.move"]
-        cls.invoice_model = cls.env["account.move"]
-        cls.partner_model = cls.env["res.partner"]
-        cls.partner = cls.env.ref("base.res_partner_2")
-        cls.partner2 = cls.env.ref("base.res_partner_address_4")
-        cls.partner3 = cls.env.ref("base.res_partner_18")
-        cls.supplier = cls.env.ref("base.res_partner_12")
-        cls.pick_type_in = cls.env.ref("stock.picking_type_in")
-        cls.pick_type_out = cls.env.ref("stock.picking_type_out")
-        cls.stock_location = cls.env.ref("stock.stock_location_stock")
-        cls.customers_location = cls.env.ref("stock.stock_location_customers")
-        cls.suppliers_location = cls.env.ref("stock.stock_location_suppliers")
-        cls.journal = cls.env["account.journal"].create(
-            {
-                "name": "A super journal name",
-                "code": "ABC",
-                "type": "sale",
-                "refund_sequence": True,
-            }
-        )
 
-        cls.product_model = cls.env["product.product"]
-        cls.fiscal_position_model = cls.env["account.fiscal.position"]
-        cls.fiscal_position_tax_model = cls.env["account.fiscal.position.tax"]
-        cls.fiscal_position_account_model = cls.env["account.fiscal.position.account"]
-        cls.tax_model = cls.env["account.tax"]
-        cls.product_tmpl_model = cls.env["product.template"]
-        cls.account_receivable = cls.env["account.account"].search(
-            [
-                (
-                    "account_type",
-                    "=",
-                    "asset_receivable",
-                )
-            ],
-            limit=1,
-        )
-        cls.account_revenue = cls.env["account.account"].search(
-            [("account_type", "=", "expense_direct_cost")], limit=1
-        )
-
-        cls.tax_sale_1 = cls.tax_model.create(
-            {"name": "Sale tax 20", "type_tax_use": "sale", "amount": "20.00"}
-        )
-        cls.tax_sale_2 = cls.tax_model.create(
-            {"name": "Sale tax 10", "type_tax_use": "sale", "amount": "10.00"}
-        )
-        cls.tax_purchase_1 = cls.tax_model.create(
-            {"name": "Purchase tax 10", "type_tax_use": "purchase", "amount": "10.00"}
-        )
-        cls.tax_purchase_2 = cls.tax_model.create(
-            {"name": "Purchase tax 20", "type_tax_use": "purchase", "amount": "20.00"}
-        )
-
-        cls.product_test_1 = cls.product_model.create(
-            {
-                "name": "Test 1",
-                "lst_price": "15000",
-                "taxes_id": [(6, 0, [cls.tax_sale_1.id, cls.tax_sale_2.id])],
-                "supplier_taxes_id": [
-                    (6, 0, [cls.tax_purchase_1.id, cls.tax_purchase_2.id])
-                ],
-                "property_account_income_id": cls.account_revenue.id,
-                "standard_price": "500",
-            }
-        )
-        cls.product_test_2 = cls.product_model.create(
-            {
-                "name": "Test 2",
-                "lst_price": "15000",
-                "taxes_id": [(6, 0, [cls.tax_sale_1.id, cls.tax_sale_2.id])],
-                "supplier_taxes_id": [
-                    (6, 0, [cls.tax_purchase_1.id, cls.tax_purchase_2.id])
-                ],
-                "property_account_income_id": cls.account_revenue.id,
-                "standard_price": "500",
-            }
-        )
-
-        # Test PriceList and Sellers Price
-        product_price_test = cls.env.ref("product.product_product_6")
-        cls.price_list = cls.env["product.pricelist"].create({"name": "Test pricelist"})
-        cls.price_list.item_ids.create(
-            {
-                "compute_price": "fixed",
-                "fixed_price": 1234.0,
-                "applied_on": "0_product_variant",
-                "product_id": product_price_test.id,
-                "pricelist_id": cls.price_list.id,
-            }
-        )
-        # Data has duplicate line with 2 Prices for same Partner,
-        # just remove one for the test.
-        seller_to_delete = product_price_test.seller_ids.filtered(
-            lambda line: line.price == 785.0
-            and line.partner_id == cls.env.ref("base.res_partner_4")
-        )
-        seller_to_delete.unlink()
-
-    def test_0_picking_out_invoicing(self):
-        # setting Agrolait type to default, because it's 'contact' in demo data
-        nb_invoice_before = self.invoice_model.search_count([])
+    def test_01_picking_out_invoicing(self):
+        nb_invoice_before = self.env["account.move"].search_count([])
         # Test case to Get Price Unit to Invoice when Partner don't has Pricelist
-        self.partner.write({"type": "invoice", "property_product_pricelist": False})
-        picking = self.picking_model.create(
-            {
-                "partner_id": self.partner2.id,
-                "picking_type_id": self.pick_type_out.id,
-                "location_id": self.stock_location.id,
-                "location_dest_id": self.customers_location.id,
-            }
-        )
-        move_vals = {
-            "product_id": self.product_test_1.id,
-            "picking_id": picking.id,
-            "location_dest_id": self.customers_location.id,
-            "location_id": self.stock_location.id,
-            "name": self.product_test_1.name,
-            "product_uom_qty": 2,
-            "product_uom": self.product_test_1.uom_id.id,
-        }
-        new_move = self.move_model.create(move_vals)
+        self.partner_a.write({"type": "invoice", "property_product_pricelist": False})
+        picking = self.picking_out_1
         picking.set_to_be_invoiced()
         self.picking_move_state(picking)
-        self.assertEqual(picking.state, "done")
-        invoice = self.create_invoice_wizard(picking)
-        self.assertEqual(picking.invoice_state, "invoiced")
-        self.assertEqual(invoice.partner_id, self.partner)
-        self.assertIn(invoice, picking.invoice_ids)
-        self.assertIn(picking, invoice.picking_ids)
-        nb_invoice_after = self.invoice_model.search_count([])
-        self.assertEqual(nb_invoice_before, nb_invoice_after - len(invoice))
-        assert invoice.invoice_user_id, "Error to map User in Invoice."
-        assert invoice.invoice_payment_term_id, "Error to map Payment Term in Invoice."
-        assert invoice.fiscal_position_id, "Error to map Fiscal Position in Invoice."
-        assert invoice.company_id, "Error to map Company in Invoice."
-        assert invoice.invoice_line_ids, "Error to create invoice line."
-        for inv_line in invoice.invoice_line_ids:
-            assert inv_line.account_id, "Error to map Account in Invoice Line."
-            assert inv_line.tax_ids, "Error to map Sale Tax in Invoice Line."
-            assert inv_line.product_uom_id, "Error to map Product UOM in Invoice Line."
-            assert inv_line.price_unit, "Error in Price Unit"
-            assert (
-                inv_line.move_line_ids
-            ), "Error, there no relation between Invoice Line and Stock Move Line."
-            for mv_line in inv_line.move_line_ids:
-                self.assertEqual(
-                    mv_line.id,
-                    new_move.id,
-                    "Error to link stock.move with invoice.line.",
-                )
-
-    def test_1_picking_out_invoicing(self):
-        nb_invoice_before = self.invoice_model.search_count([])
-        self.partner.write({"type": "invoice"})
-        picking = self.picking_model.create(
-            {
-                "partner_id": self.partner2.id,
-                "picking_type_id": self.pick_type_out.id,
-                "location_id": self.stock_location.id,
-                "location_dest_id": self.customers_location.id,
-            }
+        invoice = create_with_form_inv_onshipping(
+            self.env,
+            picking,
         )
-        move_vals = {
-            "product_id": self.product_test_1.id,
-            "picking_id": picking.id,
-            "location_dest_id": self.customers_location.id,
-            "location_id": self.stock_location.id,
-            "name": self.product_test_1.name,
-            "product_uom_qty": 2,
-            "product_uom": self.product_test_1.uom_id.id,
-        }
-        self.move_model.create(move_vals)
+        self.check_invoice_created(picking, invoice)
+        nb_invoice_after = self.env["account.move"].search_count([])
+        self.assertEqual(nb_invoice_before, nb_invoice_after - len(invoice))
+
+    def test_02_picking_out_invoicing(self):
+        nb_invoice_before = self.env["account.move"].search_count([])
+        picking = self.picking_out_2
         self.picking_move_state(picking)
-        self.assertEqual(picking.state, "done")
 
         # Test Wizard Error
-        # self.create_invoice_wizard(picking)
+        # invoice = create_with_form_inv_onshipping(
+        #     self.env, picking,
+        # )
+
         wizard_obj = self.env["stock.invoice.onshipping"].with_context(
             active_ids=picking.ids,
             active_model=picking._name,
@@ -202,30 +54,12 @@ class TestPickingInvoicing(TestPickingInvoicingCommon):
             wizard.with_context(lang="en_US").action_generate()
         msg = "No invoice created!"
         self.assertIn(msg, e.exception.args[0])
-        nb_invoice_after = self.invoice_model.search_count([])
+        nb_invoice_after = self.env["account.move"].search_count([])
         self.assertEqual(nb_invoice_before, nb_invoice_after)
 
-    def test_2_picking_out_invoicing(self):
-        nb_invoice_before = self.invoice_model.search_count([])
-        self.partner.write({"type": "invoice"})
-        picking = self.picking_model.create(
-            {
-                "partner_id": self.partner2.id,
-                "picking_type_id": self.pick_type_out.id,
-                "location_id": self.stock_location.id,
-                "location_dest_id": self.customers_location.id,
-            }
-        )
-        move_vals = {
-            "product_id": self.product_test_1.id,
-            "picking_id": picking.id,
-            "location_dest_id": self.customers_location.id,
-            "location_id": self.stock_location.id,
-            "name": self.product_test_1.name,
-            "product_uom_qty": 2,
-            "product_uom": self.product_test_1.uom_id.id,
-        }
-        new_move = self.move_model.create(move_vals)
+    def test_03_picking_out_invoicing(self):
+        nb_invoice_before = self.env["account.move"].search_count([])
+        picking = self.picking_out_1
         picking.set_to_be_invoiced()
 
         # Test Set Not Invoice
@@ -237,97 +71,36 @@ class TestPickingInvoicing(TestPickingInvoicingCommon):
 
         picking.set_to_be_invoiced()
         self.picking_move_state(picking)
-        self.assertEqual(picking.state, "done")
-        invoice = self.create_invoice_wizard(picking)
-        self.assertEqual(picking.invoice_state, "invoiced")
-        self.assertEqual(invoice.partner_id, self.partner)
-        self.assertIn(invoice, picking.invoice_ids)
-        self.assertIn(picking, invoice.picking_ids)
-        nb_invoice_after = self.invoice_model.search_count([])
+        invoice = create_with_form_inv_onshipping(self.env, picking)
+        self.check_invoice_created(picking, invoice)
+        nb_invoice_after = self.env["account.move"].search_count([])
         self.assertEqual(nb_invoice_before, nb_invoice_after - len(invoice))
-        assert invoice.invoice_line_ids, "Error to create invoice line."
-        for inv_line in invoice.invoice_line_ids:
-            for mv_line in inv_line.move_line_ids:
-                self.assertEqual(
-                    mv_line.id,
-                    new_move.id,
-                    "Error to link stock.move with invoice.line.",
-                )
-            self.assertTrue(inv_line.tax_ids, "Error to map Sale Tax in invoice.line.")
 
-    def test_3_picking_out_invoicing(self):
+    def test_04_picking_out_invoicing(self):
         """
         Test invoicing picking in to check if get the taxes
         from supplier_taxes_id.
         """
-        nb_invoice_before = self.invoice_model.search_count([])
-        picking = self.picking_model.create(
-            {
-                "partner_id": self.supplier.id,
-                "picking_type_id": self.pick_type_in.id,
-                "location_id": self.suppliers_location.id,
-                "location_dest_id": self.stock_location.id,
-            }
-        )
-        move_vals = {
-            "product_id": self.product_test_1.id,
-            "picking_id": picking.id,
-            "location_dest_id": self.stock_location.id,
-            "location_id": self.suppliers_location.id,
-            "name": self.product_test_1.name,
-            "product_uom_qty": 2,
-            "product_uom": self.product_test_1.uom_id.id,
-        }
-        new_move = self.move_model.create(move_vals)
+        nb_invoice_before = self.env["account.move"].search_count([])
+        picking = self.picking_in_1
         picking.set_to_be_invoiced()
         self.picking_move_state(picking)
-        self.assertEqual(picking.state, "done")
-        invoice = self.create_invoice_wizard(picking)
-        self.assertEqual(picking.invoice_state, "invoiced")
-        self.assertEqual(invoice.partner_id, self.supplier)
-        self.assertIn(invoice, picking.invoice_ids)
-        self.assertIn(picking, invoice.picking_ids)
-        nb_invoice_after = self.invoice_model.search_count([])
+        invoice = create_with_form_inv_onshipping(
+            self.env,
+            picking,
+        )
+        self.check_invoice_created(picking, invoice)
+        nb_invoice_after = self.env["account.move"].search_count([])
         self.assertEqual(nb_invoice_before, nb_invoice_after - len(invoice))
-        assert invoice.invoice_line_ids, "Error to create invoice line."
-        for inv_line in invoice.invoice_line_ids:
-            for mv_line in inv_line.move_line_ids:
-                self.assertEqual(
-                    mv_line.id,
-                    new_move.id,
-                    "Error to link stock.move with invoice.line.",
-                )
-            self.assertTrue(
-                inv_line.tax_ids,
-                "Error to map Purchase Tax in invoice.line.",
-            )
 
-    def test_4_picking_out_invoicing_backorder(self):
+    def test_05_picking_out_invoicing_backorder(self):
         """
         Test invoicing picking out to check if backorder is create
         with same invoice state.
         """
-        nb_invoice_before = self.invoice_model.search_count([])
-        self.partner.write({"type": "invoice"})
-        picking = self.picking_model.create(
-            {
-                "partner_id": self.partner2.id,
-                "picking_type_id": self.pick_type_out.id,
-                "location_id": self.stock_location.id,
-                "location_dest_id": self.customers_location.id,
-            }
-        )
-        move_vals = {
-            "product_id": self.product_test_1.id,
-            "picking_id": picking.id,
-            "location_dest_id": self.customers_location.id,
-            "location_id": self.stock_location.id,
-            "name": self.product_test_1.name,
-            "product_uom_qty": 4,
-            "product_uom": self.product_test_1.uom_id.id,
-        }
-        new_move = self.move_model.create(move_vals)
-        new_move._onchange_product_id()
+        nb_invoice_before = self.env["account.move"].search_count([])
+        self.partner_a.write({"type": "invoice"})
+        picking = self.picking_out_1
         picking.set_to_be_invoiced()
         # Test BackOrder need to open Wizard
         # self.picking_move_state(picking)
@@ -340,165 +113,77 @@ class TestPickingInvoicing(TestPickingInvoicingCommon):
             # Test Price Unit informed by User
             move.price_unit = 345.0
 
-        backorder = self.create_backorder_wizard(picking)
+        backorder = create_with_form_pck_backorder(self.env, picking)
         backorder.action_assign()
         self.assertEqual(backorder.invoice_state, "2binvoiced")
-
         self.assertEqual(picking.state, "done")
-        invoice = self.create_invoice_wizard(picking)
-        self.assertEqual(picking.invoice_state, "invoiced")
-        self.assertEqual(invoice.partner_id, self.partner)
-        self.assertIn(invoice, picking.invoice_ids)
-        self.assertIn(picking, invoice.picking_ids)
-        nb_invoice_after = self.invoice_model.search_count([])
+
+        invoice = create_with_form_inv_onshipping(self.env, picking)
+        self.check_invoice_created(picking, invoice)
+        nb_invoice_after = self.env["account.move"].search_count([])
         self.assertEqual(nb_invoice_before, nb_invoice_after - len(invoice))
         assert invoice.invoice_line_ids, "Error to create invoice line."
         for inv_line in invoice.invoice_line_ids:
-            for mv_line in inv_line.move_line_ids:
-                self.assertEqual(
-                    mv_line.id,
-                    new_move.id,
-                    "Error to link stock.move with invoice.line.",
-                )
-            self.assertTrue(inv_line.tax_ids, "Error to map Sale Tax in invoice.line.")
             # Test Price Unit informed by user
             self.assertEqual(
                 inv_line.price_unit, 345.0, "Error in Price Unit informed by User."
             )
 
-    def test_picking_cancel(self):
+    def test_06_picking_cancel(self):
         """
         Ensure that the invoice_state of the picking is correctly
         updated when an invoice is cancelled
         :return:
         """
-        nb_invoice_before = self.invoice_model.search_count([])
-        self.partner.write({"type": "invoice"})
-        picking = self.picking_model.create(
-            {
-                "partner_id": self.partner2.id,
-                "picking_type_id": self.pick_type_out.id,
-                "location_id": self.stock_location.id,
-                "location_dest_id": self.customers_location.id,
-            }
-        )
-        move_vals = {
-            "product_id": self.product_test_1.id,
-            "picking_id": picking.id,
-            "location_dest_id": self.customers_location.id,
-            "location_id": self.stock_location.id,
-            "name": self.product_test_1.name,
-            "product_uom_qty": 2,
-            "product_uom": self.product_test_1.uom_id.id,
-        }
-        self.move_model.create(move_vals)
+        nb_invoice_before = self.env["account.move"].search_count([])
+        picking = self.picking_out_1
         picking.set_to_be_invoiced()
         self.picking_move_state(picking)
-        self.assertEqual(picking.state, "done")
-        invoice = self.create_invoice_wizard(picking)
-        self.assertEqual(picking.invoice_state, "invoiced")
-        self.assertEqual(invoice.partner_id, self.partner)
+        invoice = create_with_form_inv_onshipping(self.env, picking)
+        self.check_invoice_created(picking, invoice)
         invoice.button_cancel()
         self.assertEqual(picking.invoice_state, "2binvoiced")
         invoice.button_draft()
         self.assertEqual(picking.invoice_state, "invoiced")
-        self.assertIn(invoice, picking.invoice_ids)
-        self.assertIn(picking, invoice.picking_ids)
-        nb_invoice_after = self.invoice_model.search_count([])
+        self.check_invoice_created(picking, invoice)
+        nb_invoice_after = self.env["account.move"].search_count([])
         self.assertEqual(nb_invoice_before, nb_invoice_after - len(invoice))
 
-    def test_picking_invoice_refund(self):
+    def test_07_picking_invoice_refund(self):
         """
         Ensure that a refund keep the link to the picking
         :return:
         """
-        nb_invoice_before = self.invoice_model.search_count([])
-        self.partner.write({"type": "invoice"})
-        picking = self.picking_model.create(
-            {
-                "partner_id": self.partner2.id,
-                "picking_type_id": self.pick_type_out.id,
-                "location_id": self.stock_location.id,
-                "location_dest_id": self.customers_location.id,
-            }
-        )
-        move_vals = {
-            "product_id": self.product_test_1.id,
-            "picking_id": picking.id,
-            "location_dest_id": self.customers_location.id,
-            "location_id": self.stock_location.id,
-            "name": self.product_test_1.name,
-            "product_uom_qty": 2,
-            "product_uom": self.product_test_1.uom_id.id,
-        }
-        self.move_model.create(move_vals)
+        nb_invoice_before = self.env["account.move"].search_count([])
+        picking = self.picking_out_1
         picking.set_to_be_invoiced()
         self.picking_move_state(picking)
-        self.assertEqual(picking.state, "done")
-        invoice = self.create_invoice_wizard(picking)
-        self.assertEqual(picking.invoice_state, "invoiced")
-        self.assertEqual(invoice.partner_id, self.partner)
-        self.assertIn(invoice, picking.invoice_ids)
-        self.assertIn(picking, invoice.picking_ids)
+        invoice = create_with_form_inv_onshipping(self.env, picking)
+        self.check_invoice_created(picking, invoice)
         invoice.action_post()
         refund = invoice._reverse_moves(cancel=True)
         self.assertEqual(picking.invoice_state, "invoiced")
         self.assertIn(picking, refund.picking_ids)
-        nb_invoice_after = self.invoice_model.search_count([])
+        nb_invoice_after = self.env["account.move"].search_count([])
         self.assertEqual(nb_invoice_before, nb_invoice_after - len(invoice | refund))
 
-    def test_picking_invoicing_by_product1(self):
+    def test_08_picking_invoicing_by_product1(self):
         """
         Test the invoice generation grouped by partner/product with 1
         picking and 2 moves.
         :return:
         """
-        nb_invoice_before = self.invoice_model.search_count([])
+        nb_invoice_before = self.env["account.move"].search_count([])
         self.partner.write({"type": "invoice"})
-        picking = self.picking_model.create(
-            {
-                "partner_id": self.partner.id,
-                "picking_type_id": self.pick_type_out.id,
-                "location_id": self.stock_location.id,
-                "location_dest_id": self.customers_location.id,
-            }
-        )
-        move_vals = {
-            "product_id": self.product_test_1.id,
-            "picking_id": picking.id,
-            "location_dest_id": self.customers_location.id,
-            "location_id": self.stock_location.id,
-            "name": self.product_test_1.name,
-            "product_uom_qty": 1,
-            "product_uom": self.product_test_1.uom_id.id,
-        }
-        self.move_model.create(move_vals)
-        move_vals2 = {
-            "product_id": self.product_test_2.id,
-            "picking_id": picking.id,
-            "location_dest_id": self.customers_location.id,
-            "location_id": self.stock_location.id,
-            "name": self.product_test_2.name,
-            "product_uom_qty": 1,
-            "product_uom": self.product_test_2.uom_id.id,
-        }
-        self.move_model.create(move_vals2)
+        picking = self.picking_out_2
         picking.set_to_be_invoiced()
         self.picking_move_state(picking)
-        self.assertEqual(picking.state, "done")
-        invoice = self.create_invoice_wizard(picking)
-        self.assertEqual(picking.invoice_state, "invoiced")
-        self.assertEqual(invoice.partner_id, self.partner)
-        self.assertIn(invoice, picking.invoice_ids)
-        self.assertIn(picking, invoice.picking_ids)
-        products = invoice.invoice_line_ids.mapped("product_id")
-        self.assertEqual(len(invoice.invoice_line_ids), 2)
-        self.assertIn(self.product_test_1, products)
-        self.assertIn(self.product_test_2, products)
-        nb_invoice_after = self.invoice_model.search_count([])
+        invoice = create_with_form_inv_onshipping(self.env, picking)
+        self.check_invoice_created(picking, invoice)
+        nb_invoice_after = self.env["account.move"].search_count([])
         self.assertEqual(nb_invoice_before, nb_invoice_after - len(invoice))
 
-    def test_picking_invoicing_by_product2(self):
+    def test_09_picking_invoicing_by_product2(self):
         """
         Test the invoice generation grouped by partner/product with 2
         picking and 2 moves per picking.
@@ -506,68 +191,27 @@ class TestPickingInvoicing(TestPickingInvoicingCommon):
         lines (and qty 2)
         :return:
         """
-        nb_invoice_before = self.invoice_model.search_count([])
-        self.partner.write({"type": "invoice"})
-        picking = self.picking_model.create(
-            {
-                "partner_id": self.partner.id,
-                "picking_type_id": self.pick_type_out.id,
-                "location_id": self.stock_location.id,
-                "location_dest_id": self.customers_location.id,
-            }
-        )
-        move_vals = {
-            "product_id": self.product_test_1.id,
-            "picking_id": picking.id,
-            "location_dest_id": self.customers_location.id,
-            "location_id": self.stock_location.id,
-            "name": self.product_test_1.name,
-            "product_uom_qty": 1,
-            "product_uom": self.product_test_1.uom_id.id,
-        }
-        self.move_model.create(move_vals)
+        nb_invoice_before = self.env["account.move"].search_count([])
+        picking = self.picking_out_2
         picking2 = picking.copy()
-        move_vals2 = {
-            "product_id": self.product_test_1.id,
-            "picking_id": picking2.id,
-            "location_dest_id": self.customers_location.id,
-            "location_id": self.stock_location.id,
-            "name": self.product_test_1.name,
-            "product_uom_qty": 1,
-            "product_uom": self.product_test_1.uom_id.id,
-        }
-        self.move_model.create(move_vals2)
         picking.set_to_be_invoiced()
         self.picking_move_state(picking)
         picking2.set_to_be_invoiced()
         self.picking_move_state(picking2)
-        self.assertEqual(picking.state, "done")
-        self.assertEqual(picking2.state, "done")
         pickings = picking | picking2
-        invoice = self.create_invoice_wizard(pickings)
-        self.assertEqual(len(invoice), 1)
-        self.assertEqual(picking.invoice_state, "invoiced")
-        self.assertEqual(picking2.invoice_state, "invoiced")
-        self.assertEqual(invoice.partner_id, self.partner)
-        self.assertIn(invoice, picking.invoice_ids)
-        self.assertIn(invoice, picking2.invoice_ids)
-        self.assertIn(picking, invoice.picking_ids)
-        self.assertIn(picking2, invoice.picking_ids)
-        products = invoice.invoice_line_ids.mapped("product_id")
-        self.assertIn(self.product_test_1, products)
+        invoice = create_with_form_inv_onshipping(self.env, pickings)
+        self.check_invoice_created(pickings, invoice)
         for inv_line in invoice.invoice_line_ids:
-            # qty = 3 because 1 move + duplicate one + 1 new
-            self.assertAlmostEqual(inv_line.quantity, 3)
-            self.assertTrue(inv_line.tax_ids, "Error to map Sale Tax in invoice.line.")
+            self.assertAlmostEqual(inv_line.quantity, 2)
         # Now test behaviour if the invoice is delete
         invoice.unlink()
         for picking in pickings:
             self.assertEqual(picking.invoice_state, "2binvoiced")
-        nb_invoice_after = self.invoice_model.search_count([])
+        nb_invoice_after = self.env["account.move"].search_count([])
         # Should be equals because we delete the invoice
         self.assertEqual(nb_invoice_before, nb_invoice_after)
 
-    def test_picking_invoicing_by_product3(self):
+    def test_10_picking_invoicing_by_product3(self):
         """
         Test the invoice generation grouped by partner/product with 2
         picking and 2 moves per picking.
@@ -575,83 +219,44 @@ class TestPickingInvoicing(TestPickingInvoicingCommon):
         with 2 lines (and qty 1)
         :return:
         """
-        nb_invoice_before = self.invoice_model.search_count([])
-        self.partner.write({"type": "invoice"})
-        picking = self.picking_model.create(
-            {
-                "partner_id": self.partner.id,
-                "picking_type_id": self.pick_type_out.id,
-                "location_id": self.stock_location.id,
-                "location_dest_id": self.customers_location.id,
-            }
-        )
-        move_vals = {
-            "product_id": self.product_test_1.id,
-            "picking_id": picking.id,
-            "location_dest_id": self.customers_location.id,
-            "location_id": self.stock_location.id,
-            "name": self.product_test_1.name,
-            "product_uom_qty": 1,
-            "product_uom": self.product_test_1.uom_id.id,
-        }
-        self.move_model.create(move_vals)
-        picking2 = picking.copy({"partner_id": self.partner3.id})
-        move_vals2 = {
-            "product_id": self.product_test_2.id,
-            "picking_id": picking2.id,
-            "location_dest_id": self.customers_location.id,
-            "location_id": self.stock_location.id,
-            "name": self.product_test_2.name,
-            "product_uom_qty": 1,
-            "product_uom": self.product_test_2.uom_id.id,
-        }
-        self.move_model.create(move_vals2)
+        # Check the case without PriceList
+        self.env["product.pricelist"].search([]).unlink()
+
+        nb_invoice_before = self.env["account.move"].search_count([])
+        picking = self.picking_out_2
+        picking2 = picking.copy({"partner_id": self.partner_b.id})
         picking.set_to_be_invoiced()
         self.picking_move_state(picking)
-
         picking2.set_to_be_invoiced()
         self.picking_move_state(picking2)
-        self.assertEqual(picking.state, "done")
-        self.assertEqual(picking2.state, "done")
         pickings = picking | picking2
-        invoices = self.create_invoice_wizard(pickings)
-
+        invoices = create_with_form_inv_onshipping(self.env, pickings)
         self.assertEqual(len(invoices), 2)
-        self.assertEqual(picking.invoice_state, "invoiced")
-        self.assertEqual(picking2.invoice_state, "invoiced")
-        self.assertIn(self.partner, invoices.mapped("partner_id"))
-        self.assertIn(self.partner3, invoices.mapped("partner_id"))
+        self.check_invoice_created(pickings, invoices)
         for invoice in invoices:
             self.assertEqual(len(invoice.picking_ids), 1)
             picking = invoice.picking_ids
-            self.assertIn(invoice, picking.invoice_ids)
-            for inv_line in invoice.invoice_line_ids:
-                self.assertAlmostEqual(inv_line.quantity, 1)
-                self.assertTrue(
-                    inv_line.tax_ids,
-                    "Error to map Sale Tax in invoice.line.",
-                )
             # Test the behaviour when the invoice is cancelled
             # The picking invoice_status should be updated
             invoice.button_cancel()
             self.assertEqual(picking.invoice_state, "2binvoiced")
-        nb_invoice_after = self.invoice_model.search_count([])
+        nb_invoice_after = self.env["account.move"].search_count([])
         self.assertEqual(nb_invoice_before, nb_invoice_after - len(invoices))
 
-    def test_0_counting_2binvoiced(self):
+    def test_11_counting_2binvoiced(self):
         """
         Check method counting 2binvoice used in kanban view
         """
-        self.assertEqual(1, self.pick_type_in.count_picking_2binvoiced)
+        self.assertEqual(0, self.picking_type_in.count_picking_2binvoiced)
 
-    def test_return_customer_picking(self):
+    def test_12_return_customer_picking(self):
         """
         Test Return Customer Picking and Invoice created.
         """
-        picking = self.env.ref("stock_picking_invoicing.stock_picking_invoicing_2")
+        picking = self.picking_out_1
+        picking.set_to_be_invoiced()
         self.picking_move_state(picking)
-        self.assertEqual(picking.state, "done")
-        invoice = self.create_invoice_wizard(picking)
+        invoice = create_with_form_inv_onshipping(self.env, picking)
         # Confirm Invoice
         invoice.action_post()
         self.assertEqual(invoice.state, "posted", "Invoice should be in state Posted")
@@ -661,15 +266,17 @@ class TestPickingInvoicing(TestPickingInvoicingCommon):
         )
 
         # Return Picking
-        picking_devolution = self.return_picking_wizard(picking)
+        picking_devolution = create_with_form_return_picking(self.env, picking)
 
         self.assertEqual(picking_devolution.invoice_state, "2binvoiced")
         for line in picking_devolution.move_ids:
             self.assertEqual(line.invoice_state, "2binvoiced")
 
         self.picking_move_state(picking_devolution)
-        self.assertEqual(picking_devolution.state, "done", "Change state fail.")
-        invoice_devolution = self.create_invoice_wizard(picking_devolution)
+        invoice_devolution = create_with_form_inv_onshipping(
+            self.env, picking_devolution
+        )
+        self.check_invoice_created(picking_devolution, invoice_devolution)
         # Confirm Return Invoice
         invoice_devolution.action_post()
         self.assertEqual(
@@ -682,14 +289,29 @@ class TestPickingInvoicing(TestPickingInvoicingCommon):
             "Invoice Type should be Out Refund",
         )
 
-    def test_return_supplier_picking(self):
+    def test_13_return_supplier_picking(self):
         """
         Test Return Supplier Picking and Invoice created.
         """
-        picking = self.env.ref("stock_picking_invoicing.stock_picking_invoicing_7")
+        picking = self.picking_in_1
+        picking.set_to_be_invoiced()
         self.picking_move_state(picking)
-        self.assertEqual(picking.state, "done")
-        invoice = self.create_invoice_wizard(picking)
+
+        self.product_storable_1.write(
+            {
+                "seller_ids": [
+                    Command.create(
+                        {
+                            "partner_id": self.partner_a,
+                            "min_qty": 1,
+                            "price": 150,
+                        }
+                    )
+                ]
+            }
+        )
+
+        invoice = create_with_form_inv_onshipping(self.env, picking)
         for line in invoice.invoice_line_ids:
             for seller in line.product_id.seller_ids:
                 if seller.partner_id == invoice.partner_id:
@@ -708,16 +330,16 @@ class TestPickingInvoicing(TestPickingInvoicingCommon):
         )
 
         # Return Picking
-        picking_devolution = self.return_picking_wizard(picking)
+        picking_devolution = create_with_form_return_picking(self.env, picking)
 
         self.assertEqual(picking_devolution.invoice_state, "2binvoiced")
         for line in picking_devolution.move_ids:
             self.assertEqual(line.invoice_state, "2binvoiced")
 
         self.picking_move_state(picking_devolution)
-        self.assertEqual(picking_devolution.state, "done", "Change state fail.")
-
-        invoice_devolution = self.create_invoice_wizard(picking_devolution)
+        invoice_devolution = create_with_form_inv_onshipping(
+            self.env, picking_devolution
+        )
         # Confirm Return Invoice
         invoice_devolution.action_post()
         self.assertEqual(
@@ -730,31 +352,43 @@ class TestPickingInvoicing(TestPickingInvoicingCommon):
             "Invoice Type should be In Refund",
         )
 
-    def test_get_price_from_pricelist(self):
+    def test_14_get_price_from_pricelist(self):
         """Test get Price from PriceList."""
-        picking = self.env.ref("stock_picking_invoicing.stock_picking_invoicing_1")
-        picking.partner_id.property_product_pricelist = self.price_list
+
+        price_list = self.env["product.pricelist"].create({"name": "Test pricelist"})
+        price_list.item_ids.create(
+            {
+                "compute_price": "fixed",
+                "fixed_price": 1234.0,
+                "applied_on": "0_product_variant",
+                "product_id": self.product_storable_1.id,  # product_price_test.id,
+                "pricelist_id": price_list.id,
+            }
+        )
+
+        picking = self.picking_out_1
+        picking.partner_id.property_product_pricelist = price_list
+        picking.set_to_be_invoiced()
         self.picking_move_state(picking)
-        self.assertEqual(picking.state, "done")
-        invoice = self.create_invoice_wizard(picking)
+        invoice = create_with_form_inv_onshipping(self.env, picking)
+        self.check_invoice_created(picking, invoice)
         self.assertEqual(picking.invoice_state, "invoiced")
         for inv_line in invoice.invoice_line_ids:
-            if inv_line.product_id == self.env.ref("product.product_product_6"):
+            if inv_line.product_id == self.product_storable_1:
                 self.assertEqual(
                     inv_line.price_unit,
                     1234.0,
                     "Error to get sale Price from Price List.",
                 )
 
-    def test_picking_extra_vals(self):
+    def test_15_picking_extra_vals(self):
         """Test Picking Extra Vals"""
-        picking = self.env.ref("stock_picking_invoicing.stock_picking_invoicing_1")
-
-        self._run_picking_onchanges(picking)
+        picking = self.picking_out_1
 
         for line in picking.move_ids_without_package:
-            self._run_line_onchanges(line)
             # Force Split
             line.quantity = 10
 
         picking.button_validate()
+        with self.assertRaises(exceptions.UserError):
+            create_with_form_inv_onshipping(self.env, self.env["stock.picking"])

--- a/stock_picking_invoicing/tests/test_picking_invoicing.py
+++ b/stock_picking_invoicing/tests/test_picking_invoicing.py
@@ -122,7 +122,7 @@ class TestStockPickingInvoicing(TestStockPickingInvoicingCommon):
         self.check_invoice_created(picking, invoice)
         nb_invoice_after = self.env["account.move"].search_count([])
         self.assertEqual(nb_invoice_before, nb_invoice_after - len(invoice))
-        assert invoice.invoice_line_ids, "Error to create invoice line."
+        self.assertTrue(invoice.invoice_line_ids, "Error to create invoice line.")
         for inv_line in invoice.invoice_line_ids:
             # Test Price Unit informed by user
             self.assertEqual(

--- a/stock_picking_invoicing/tests/tools.py
+++ b/stock_picking_invoicing/tests/tools.py
@@ -1,0 +1,75 @@
+# Copyright (C) 2026-Today - Akretion (<http://www.akretion.com>).
+# @author Magno Costa <magno.costa@akretion.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import Form
+
+
+def create_with_form_product_product(env, values):
+    with Form(env["product.product"]) as product:
+        product.name = values.get("name")
+        product.lst_price = values.get("lst_price")
+        product.taxes_id = values.get("taxes_id")
+        product.supplier_taxes_id = values.get("supplier_taxes_id")
+        product.property_account_income_id = values.get("property_account_income_id")
+        product.standard_price = values.get("standard_price")
+        product.type = values.get("type")
+        if values.get("type") == "consu":
+            product.is_storable = values.get("is_storable")
+            product.invoice_policy = values.get("invoice_policy")
+        product.sale_ok = True
+        product.purchase_ok = True
+
+    return product.save()
+
+
+def create_with_form_stock_picking(env, values, line_values=False):
+    with Form(env["stock.picking"]) as picking:
+        picking.partner_id = values.get("partner_id")
+        picking.picking_type_id = values.get("picking_type_id")
+        for value in line_values:
+            with picking.move_ids_without_package.new() as line:
+                line.product_id = value.get("product_id")
+                line.product_uom_qty = value.get("product_uom_qty")
+
+    return picking.save()
+
+
+def create_with_form_inv_onshipping(env, pickings):
+    with Form(
+        env["stock.invoice.onshipping"].with_context(
+            active_ids=pickings.ids,
+            active_model=pickings._name,
+        )
+    ) as wzd_inv:
+        wzd_inv.group = "partner_product"
+        result = wzd_inv.save()
+
+    result.action_generate()
+
+    return pickings.mapped("invoice_ids")
+
+
+def create_with_form_return_picking(env, picking):
+    return_wizard_form = Form(
+        env["stock.return.picking"].with_context(
+            active_id=picking.id, active_model="stock.picking"
+        )
+    )
+    return_wizard_form.invoice_state = "2binvoiced"
+    return_wizard = return_wizard_form.save()
+    return_wizard.product_return_moves[0].quantity = 1
+    result_wizard = return_wizard.action_create_returns()
+    return env["stock.picking"].browse(result_wizard.get("res_id"))
+
+
+def create_with_form_pck_backorder(env, picking):
+    res_dict_for_back_order = picking.button_validate()
+    backorder_wizard = Form(
+        env[res_dict_for_back_order["res_model"]].with_context(
+            **res_dict_for_back_order["context"]
+        )
+    ).save()
+    backorder_wizard.process()
+
+    return env["stock.picking"].search([("backorder_id", "=", picking.id)])


### PR DESCRIPTION
Changed the Tests of **stock_picking_invoicing and sale_stock_picking_invoicing** to not use Demo Data, both modules need to be in the same PR to avoid error, the tests of sale_stock_picking_invoicing are using methods from stock_picking_invoicing.

This change is recommended by:

https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst

<img width="1019" height="145" alt="image" src="https://github.com/user-attachments/assets/8fd56865-2682-446b-8500-75913016a57c" />

And in **v19** this change becomes necessary:

https://github.com/OCA/maintainer-tools/wiki/Migration-to-version-19.0

<img width="892" height="58" alt="image" src="https://github.com/user-attachments/assets/80647ef6-9af5-4044-8733-09d4dd771ee7" />

I'm used the "Common Data" created in https://github.com/OCA/OCB/blob/18.0/addons/stock_account/tests/test_account_move.py#L10 and **Form** to create the other objects, by simulate the screen behaivor some defaults fields are be filled.


cc @rvalyi @renatonlima 