### PR TITLE
[18.0][REF] stock_picking_invoicing: Align 'To be Invoiced' in Kanban View

### DIFF
--- a/stock_picking_invoicing/views/stock_picking_type_views.xml
+++ b/stock_picking_invoicing/views/stock_picking_type_views.xml
@@ -22,14 +22,19 @@
             </field>
             <xpath expr="//div[hasclass('stock-overview-links')]" position="inside">
                 <div t-if="record.count_picking_2binvoiced.raw_value > 0" class="row">
-                    <div class="col-9">
-                        <a name="%(2binvoiced_action_picking_dashboard)d" type="action">
-                            To be Invoiced
-                        </a>
-                    </div>
-                    <div class="col-3">
-                        <field name="count_picking_2binvoiced" />
-                    </div>
+                    <a
+                        class="col-8 offset-4 pe-0 text-truncate"
+                        name="%(2binvoiced_action_picking_dashboard)d"
+                        type="action"
+                    >
+                        <div class="row">
+                            <span class="col-6">To be Invoiced</span>
+                            <field
+                                class="col-2 text-end"
+                                name="count_picking_2binvoiced"
+                            />
+                        </div>
+                    </a>
                 </div>
             </xpath>
         </field>


### PR DESCRIPTION
Simple PR, just align the information about **'To be Invoiced'** in the Kanban View:

**Today**
<img width="1274" height="439" alt="image" src="https://github.com/user-attachments/assets/5db5b213-0a88-4b71-992e-68ec4cfcac61" />

**With this PR**

<img width="1271" height="432" alt="image" src="https://github.com/user-attachments/assets/4d889719-a6b1-4b03-a895-9b321b571735" />

The change was based in the way the other informations are included at the view https://github.com/OCA/OCB/blob/18.0/addons/stock/views/stock_picking_type_views.xml#L279

Probably missing in the Migrations PRs:

* https://github.com/OCA/account-invoicing/pull/1794
* https://github.com/OCA/account-invoicing/pull/1942

cc @rvalyi @renatonlima 