### PR TITLE
[18.0][REM] stock_picking_invoicing: Method '_prepare_extra_move_vals' removed in v17.3

### DIFF
--- a/stock_picking_invoicing/models/stock_move.py
+++ b/stock_picking_invoicing/models/stock_move.py
@@ -130,12 +130,6 @@ class StockMove(models.Model):
 
         return result
 
-    def _prepare_extra_move_vals(self, qty):
-        """Copy invoice state for a new extra stock move"""
-        values = super()._prepare_extra_move_vals(qty)
-        values["invoice_state"] = self.invoice_state
-        return values
-
     def _prepare_move_split_vals(self, uom_qty):
         """Copy invoice state for a new splitted stock move"""
         values = super()._prepare_move_split_vals(uom_qty)


### PR DESCRIPTION
There is no more **'_prepare_extra_move_vals'** method in stock.move, removed in v17.3:

* https://github.com/odoo/odoo/pull/162244

Probably missing in the v18.0 migration PR:

* https://github.com/OCA/account-invoicing/pull/1942

cc @rvalyi @renatonlima 