### PR TITLE
[FIX] account_invoice_supplierinfo_update: updating the right supplierinfo

### DIFF
--- a/account_invoice_supplierinfo_update/models/account_move_line.py
+++ b/account_invoice_supplierinfo_update/models/account_move_line.py
@@ -11,8 +11,9 @@ class AccountMoveLine(models.Model):
         """Given an invoice line, return the supplierinfo that matches
         with product and supplier, if exist"""
         self.ensure_one()
-        supplierinfos = self.product_id.seller_ids.filtered(
-            lambda seller: seller.name == self.move_id.supplier_partner_id
+        supplierinfos = self.product_id._select_seller(
+            partner_id=self.move_id.supplier_partner_id,
+            quantity=self.quantity,
         )
         return supplierinfos and supplierinfos[0] or False
 

--- a/account_invoice_supplierinfo_update/tests/test_account_invoice_supplierinfo_update.py
+++ b/account_invoice_supplierinfo_update/tests/test_account_invoice_supplierinfo_update.py
@@ -57,6 +57,109 @@ class Tests(TransactionCase):
             line_form.quantity = 1.0
             line_form.price_unit = 10.0
         self.invoice = invoice_form.save()
+        self.line1 = self.invoice.invoice_line_ids.filtered(
+            lambda x: x.product_id == self.product1
+        )
+
+    def test_get_the_right_variant_supplierinfo(self):
+        # Variant the product A and set a price on variation 1
+        tmpl_a = self.product1.product_tmpl_id
+        tmpl_a.write(
+            {
+                "attribute_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "attribute_id": self.env.ref(
+                                "product.product_attribute_2"
+                            ).id,
+                            "value_ids": [
+                                (
+                                    6,
+                                    0,
+                                    [
+                                        self.env.ref(
+                                            "product.product_attribute_value_3"
+                                        ).id,
+                                        self.env.ref(
+                                            "product.product_attribute_value_4"
+                                        ).id,
+                                    ],
+                                )
+                            ],
+                        },
+                    )
+                ]
+            }
+        )
+        product_a_1, product_a_2 = tmpl_a.product_variant_ids
+
+        supplier_product_a_1 = self.env["product.supplierinfo"].create(
+            [
+                {
+                    "name": self.invoice.supplier_partner_id.id,
+                    "product_tmpl_id": tmpl_a.id,
+                    "product_id": product_a_1.id,
+                    "price": 30,
+                }
+            ]
+        )
+
+        # Set the variation 2 on the invoice and run the wizard
+        self.line1.write({"product_id": product_a_2.id, "price_unit": 400})
+        vals_wizard = self.invoice.check_supplierinfo().get("context", {})
+        line_ids = vals_wizard.get("default_line_ids", {})
+
+        self.assertEqual(line_ids[0][2]["current_price"], False)
+        self.assertEqual(line_ids[0][2]["new_price"], 400.0)
+
+        wizard = self.wizard_obj.create(
+            {"line_ids": line_ids, "invoice_id": self.invoice.id}
+        )
+        wizard.update_supplierinfo()
+
+        # Supplier of product_a_1 should be not updated and a new supplierinfo
+        # have been created (to make it simple supplierinfo are always created
+        # on template)
+        self.assertEqual(supplier_product_a_1.price, 30)
+        self.assertEqual(len(tmpl_a.seller_ids), 2)
+        self.assertEqual(tmpl_a.seller_ids[1].price, 400)
+        self.assertFalse(tmpl_a.seller_ids[1].product_id)
+
+    def test_get_the_right_qty_supplierinfo(self):
+        tmpl_a = self.product1.product_tmpl_id
+        self.env["product.supplierinfo"].create(
+            [
+                {
+                    "name": self.invoice.supplier_partner_id.id,
+                    "product_tmpl_id": tmpl_a.id,
+                    "price": 500,
+                    "min_qty": 0,
+                },
+                {
+                    "name": self.invoice.supplier_partner_id.id,
+                    "product_tmpl_id": tmpl_a.id,
+                    "price": 300,
+                    "min_qty": 20,
+                },
+            ]
+        )
+
+        vals_wizard = self.invoice.check_supplierinfo().get("context", {})
+        line_ids = vals_wizard.get("default_line_ids", {})
+
+        self.assertEqual(line_ids[0][2]["current_price"], 500)
+        self.assertEqual(line_ids[0][2]["new_price"], 400.0)
+
+        wizard = self.wizard_obj.create(
+            {"line_ids": line_ids, "invoice_id": self.invoice.id}
+        )
+        wizard.update_supplierinfo()
+
+        self.assertEqual(len(tmpl_a.seller_ids), 2)
+        self.assertEqual(tmpl_a.seller_ids[0].price, 300)
+        self.assertEqual(tmpl_a.seller_ids[1].price, 400)
 
     def test_with_update_pricelist_supplierinfo_on_product_template(self):
         # supplier invoice with pricelist supplierinfo to update and


### PR DESCRIPTION
Backporting the fix from https://github.com/OCA/account-invoicing/pull/1697.
I adapted the changes as little as possible to keep the versions aligned.

@sebastienbeau I kept you as author, let me know what you think.