### PR TITLE
[18.0][IMP] account_billing: remove showing invoices button only for billed state

### DIFF
--- a/account_billing/views/account_billing_views.xml
+++ b/account_billing/views/account_billing_views.xml
@@ -145,7 +145,6 @@
                             class="oe_stat_button"
                             name="invoice_relate_billing_tree_view"
                             type="object"
-                            invisible="state != 'billed'"
                             icon="fa-pencil-square-o"
                         >
                             <field


### PR DESCRIPTION
Related: https://github.com/OCA/account-invoicing/issues/2311
@qrtl QT6560