### PR TITLE
[16.0][IMP] account_billing: remove showing invoices button only for billed…

### DIFF
--- a/account_billing/views/account_billing_views.xml
+++ b/account_billing/views/account_billing_views.xml
@@ -145,7 +145,6 @@
                             class="oe_stat_button"
                             name="invoice_relate_billing_tree_view"
                             type="object"
-                            attrs="{'invisible':[('state', 'not in', ['billed'])]}"
                             icon="fa-pencil-square-o"
                         >
                             <field


### PR DESCRIPTION
Backport of [OCA/account-invoicing#2312](https://github.com/OCA/account-invoicing/pull/2312) to 16.0

@qrtl
QT6560