### PR TITLE
[18.0][IMP] account billing: improve billing line ordering

### DIFF
--- a/account_billing/models/account_billing.py
+++ b/account_billing/models/account_billing.py
@@ -1,6 +1,8 @@
 # Copyright 2019 Ecosoft Co., Ltd (https://ecosoft.co.th/)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
 
+from datetime import date
+
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
 
@@ -91,7 +93,7 @@ class AccountBilling(models.Model):
         selection=[("invoice_date_due", "Due Date"), ("invoice_date", "Invoice Date")],
         required=True,
         readonly=True,
-        default="invoice_date_due",
+        default=lambda self: self._get_default_threshold_date_type(),
         help="All invoices with date (threshold date type) before and equal to "
         "threshold date will be listed in billing lines",
     )
@@ -99,6 +101,10 @@ class AccountBilling(models.Model):
         compute="_compute_payment_paid_all",
         store=True,
     )
+
+    @api.model
+    def _get_default_threshold_date_type(self):
+        return "invoice_date_due"
 
     @api.depends("billing_line_ids.payment_state")
     def _compute_payment_paid_all(self):
@@ -126,6 +132,20 @@ class AccountBilling(models.Model):
 
     def _compute_invoice_related_count(self):
         self.invoice_related_count = len(self.billing_line_ids)
+
+    @api.onchange("threshold_date_type")
+    def _onchange_threshold_date_type(self):
+        self._sort_billing_lines()
+
+    def _sort_billing_lines(self):
+        if not self.billing_line_ids:
+            return
+        sorted_lines = self.billing_line_ids.sorted(
+            key=lambda x: (x.invoice_date or date.min, x.name or "", x.id)
+        )
+        for idx, line in enumerate(sorted_lines, start=1):
+            line.sequence = idx * 10
+        self.invalidate_recordset(["billing_line_ids"])
 
     def name_get(self):
         result = [(billing.id, (billing.name or "Draft")) for billing in self]
@@ -215,12 +235,15 @@ class AccountBilling(models.Model):
         moves = self._get_moves(self.threshold_date_type, types)
         billing_line_dict = self._get_billing_line_dict(moves)
         self.billing_line_ids.create(billing_line_dict)
+        self._sort_billing_lines()
 
 
 class AccountBillingLine(models.Model):
     _name = "account.billing.line"
     _description = "Billing Line"
+    _order = "sequence, id"
 
+    sequence = fields.Integer(default=10)
     billing_id = fields.Many2one(comodel_name="account.billing")
     move_id = fields.Many2one(
         comodel_name="account.move",
@@ -242,6 +265,11 @@ class AccountBillingLine(models.Model):
     state = fields.Selection(related="move_id.state")
     payment_state = fields.Selection(related="move_id.payment_state")
 
+    @api.depends(
+        "billing_id.threshold_date_type",
+        "move_id.invoice_date",
+        "move_id.invoice_date_due",
+    )
     def _compute_invoice_date(self):
         for line in self:
             if line.billing_id.threshold_date_type == "invoice_date_due":

--- a/account_billing/models/account_move.py
+++ b/account_billing/models/account_move.py
@@ -46,6 +46,7 @@ class AccountMove(models.Model):
                 ],
             }
         )
+        billing._sort_billing_lines()
         return billing
 
     def action_create_billing(self):

--- a/account_billing/tests/test_account_billing.py
+++ b/account_billing/tests/test_account_billing.py
@@ -90,16 +90,22 @@ class TestAccountBilling(TransactionCase):
         currency_id=None,
         partner=None,
         account_id=None,
+        invoice_date=None,
+        invoice_date_due=None,
     ):
         """Returns an open invoice"""
+        inv_date = invoice_date or fields.Date.context_today(self.env.user)
         invoice = self.invoice_model.create(
             {
                 "partner_id": partner or self.partner_agrolait.id,
                 "currency_id": currency_id or self.currency_eur_id,
                 "move_type": invoice_type,
-                "invoice_date": fields.Date.context_today(self.env.user),
-                "date": fields.Date.context_today(self.env.user),
-                "invoice_payment_term_id": self.payment_term.id,
+                "invoice_date": inv_date,
+                "date": inv_date,
+                "invoice_date_due": invoice_date_due,
+                "invoice_payment_term_id": (
+                    False if invoice_date_due else self.payment_term.id
+                ),
                 "invoice_line_ids": [
                     Command.create(
                         {
@@ -285,3 +291,40 @@ class TestAccountBilling(TransactionCase):
         action = invoices.action_create_billing()
         customer_billing = self.billing_model.browse(action["res_id"])
         self.assertEqual(customer_billing.currency_id.id, self.currency_eur_id)
+
+    def test_sort_billing_lines(self):
+        inv_a = self.create_invoice(
+            amount=100,
+            invoice_date=fields.Date.from_string("2024-04-03"),
+            invoice_date_due=fields.Date.from_string("2024-05-04"),
+        )
+        inv_b = self.create_invoice(
+            amount=200,
+            invoice_date=fields.Date.from_string("2024-04-01"),
+            invoice_date_due=fields.Date.from_string("2024-05-02"),
+        )
+        inv_c = self.create_invoice(
+            amount=300,
+            invoice_date=fields.Date.from_string("2024-04-02"),
+            invoice_date_due=fields.Date.from_string("2024-05-01"),
+        )
+        inv_d = self.create_invoice(
+            amount=400,
+            invoice_date=fields.Date.from_string("2024-04-02"),
+            invoice_date_due=fields.Date.from_string("2024-05-01"),
+        )
+        invoices = inv_a + inv_b + inv_c + inv_d
+        action = invoices.action_create_billing()
+        billing = self.billing_model.browse(action["res_id"])
+        self.assertEqual(
+            billing.billing_line_ids.mapped("move_id").ids,
+            (inv_c + inv_d + inv_b + inv_a).ids,
+        )
+
+        # Onchange triggers re-sort
+        billing.threshold_date_type = "invoice_date"
+        billing._onchange_threshold_date_type()
+        self.assertEqual(
+            billing.billing_line_ids.mapped("move_id").ids,
+            (inv_b + inv_c + inv_d + inv_a).ids,
+        )

--- a/account_billing/views/account_billing_views.xml
+++ b/account_billing/views/account_billing_views.xml
@@ -197,6 +197,7 @@
                             />
                             <field name="billing_line_ids" readonly="state != 'draft'">
                                 <list name="billing" create="0" editable="bottom">
+                                    <field name="sequence" widget="handle" />
                                     <field name="move_id" column_invisible="1" />
                                     <field name="name" />
                                     <field name="invoice_date" />


### PR DESCRIPTION
1. Add a sequence field to account_billing_line to reorder lines.
2. Sort billing lines created via the Create Billing button in the same order as compute_lines

@qrtl QT6581