### PR TITLE
[18.0][IMP] account_billing: Add One2many inverse relationship for billing lines

### DIFF
--- a/account_billing/models/account_move.py
+++ b/account_billing/models/account_move.py
@@ -8,6 +8,12 @@ from odoo.exceptions import UserError
 class AccountMove(models.Model):
     _inherit = "account.move"
 
+    billing_line_ids = fields.One2many(
+        comodel_name="account.billing.line",
+        inverse_name="move_id",
+        string="Billing Lines",
+        help="Billing lines that reference this invoice",
+    )
     billing_ids = fields.Many2many(
         comodel_name="account.billing",
         string="Billings",
@@ -16,10 +22,8 @@ class AccountMove(models.Model):
     )
 
     def _compute_billing_ids(self):
-        bl_obj = self.env["account.billing.line"]
         for rec in self:
-            billing_lines = bl_obj.search([("move_id", "=", rec.id)])
-            rec.billing_ids = billing_lines.mapped("billing_id")
+            rec.billing_ids = rec.billing_line_ids.mapped("billing_id")
 
     def _get_billing_type(self):
         outbound_types = {"out_invoice", "out_refund", "out_receipt"}

--- a/account_billing/models/account_move.py
+++ b/account_billing/models/account_move.py
@@ -18,6 +18,7 @@ class AccountMove(models.Model):
         comodel_name="account.billing",
         string="Billings",
         compute="_compute_billing_ids",
+        groups="account.group_account_invoice",
         help="Relationship between invoice and billing",
     )
 


### PR DESCRIPTION
Add proper bidirectional relationship between account.move and account.billing.line:

- Add billing_line_ids One2many field as inverse of move_id Many2one
- Optimize _compute_billing_ids to use the relationship instead of search

This improvement will be useful when we want to add new field in `account.move` for the related billings and add in the search view because of `billing_ids` is non stored compute field and can't use in search view.

@qrtl QT6574