### PR TITLE
[ADD] account_invoice_payment_pdf_refresh: auto-delete cached invoice PDF on payment registration

### DIFF
--- a/account_invoice_payment_pdf_refresh/__init__.py
+++ b/account_invoice_payment_pdf_refresh/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2026 Bright Haven Electric LLC
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import wizards

--- a/account_invoice_payment_pdf_refresh/__manifest__.py
+++ b/account_invoice_payment_pdf_refresh/__manifest__.py
@@ -1,0 +1,20 @@
+# Copyright 2026 Bright Haven Electric LLC
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Invoice PDF Refresh on Payment",
+    "summary": "Automatically regenerate invoice PDF when a payment is registered",
+    "version": "17.0.1.0.0",
+    "development_status": "Beta",
+    "category": "Accounting & Finance",
+    "website": "https://github.com/OCA/account-invoicing",
+    "author": "Bright Haven Electric LLC, Odoo Community Association (OCA)",
+    "maintainers": ["bhelectric"],
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": [
+        "account",
+    ],
+    "data": [],
+}

--- a/account_invoice_payment_pdf_refresh/pyproject.toml
+++ b/account_invoice_payment_pdf_refresh/pyproject.toml
@@ -1,0 +1,3 @@
+[options]
+install_requires =
+    odoo>=17.0a,<17.1dev

--- a/account_invoice_payment_pdf_refresh/readme/CONFIGURE.md
+++ b/account_invoice_payment_pdf_refresh/readme/CONFIGURE.md
@@ -1,0 +1,1 @@
+No special configuration is required. Simply install the module.

--- a/account_invoice_payment_pdf_refresh/readme/CONTRIBUTORS.md
+++ b/account_invoice_payment_pdf_refresh/readme/CONTRIBUTORS.md
@@ -1,0 +1,3 @@
+* `Bright Haven Electric LLC <https://bhelectric.ltd>`__:
+
+  * Lava (initial development)

--- a/account_invoice_payment_pdf_refresh/readme/DESCRIPTION.md
+++ b/account_invoice_payment_pdf_refresh/readme/DESCRIPTION.md
@@ -1,0 +1,14 @@
+When an invoice PDF is generated via **Send & Print**, Odoo caches it as an
+``ir.attachment`` linked to the ``invoice_pdf_report_file`` field on the
+invoice. Any subsequent print or send operation will reuse that cached PDF
+instead of generating a new one.
+
+This becomes a problem when a payment is registered *after* the initial PDF
+was generated: the cached PDF still shows the old payment status (e.g.
+"Amount Due: $500") even though the payment has been fully reconciled in the
+system.
+
+This module automatically deletes the cached invoice PDF attachment whenever
+a payment is registered through the **Register Payment** wizard, so that the
+next time the invoice is printed or sent the PDF is regenerated with accurate,
+up-to-date payment information.

--- a/account_invoice_payment_pdf_refresh/readme/USAGE.md
+++ b/account_invoice_payment_pdf_refresh/readme/USAGE.md
@@ -1,0 +1,6 @@
+1. Create and confirm an invoice.
+2. Use **Send & Print** to generate and send the invoice PDF.
+3. Register a payment against the invoice via the **Register Payment** wizard.
+4. The previously cached PDF is automatically deleted.
+5. The next time you click **Send & Print** or **Print**, a fresh PDF is
+   generated reflecting the payment status.

--- a/account_invoice_payment_pdf_refresh/wizards/__init__.py
+++ b/account_invoice_payment_pdf_refresh/wizards/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2026 Bright Haven Electric LLC
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import account_payment_register

--- a/account_invoice_payment_pdf_refresh/wizards/account_payment_register.py
+++ b/account_invoice_payment_pdf_refresh/wizards/account_payment_register.py
@@ -1,0 +1,58 @@
+# Copyright 2026 Bright Haven Electric LLC
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import logging
+
+from odoo import models
+
+_logger = logging.getLogger(__name__)
+
+
+class AccountPaymentRegister(models.TransientModel):
+    _inherit = "account.payment.register"
+
+    def _invalidate_invoice_pdf_reports(self, moves):
+        """Delete cached invoice PDF attachments so they are regenerated
+        with the latest payment information on the next print or send action.
+
+        This ensures that when a payment is registered against an invoice,
+        the previously generated PDF (which may not reflect the payment)
+        is removed so Odoo will create a fresh one upon the next
+        Send & Print or Print action.
+        """
+        invoices = moves.filtered(
+            lambda m: m.is_invoice(include_receipts=True)
+            and m.invoice_pdf_report_id
+        )
+        if not invoices:
+            return
+
+        for invoice in invoices:
+            attachment = invoice.invoice_pdf_report_id
+            _logger.info(
+                "Removing cached PDF attachment %s (id=%s) for invoice %s "
+                "to allow regeneration after payment.",
+                attachment.name,
+                attachment.id,
+                invoice.name,
+            )
+            attachment.unlink()
+            invoice.invalidate_recordset(
+                fnames=["invoice_pdf_report_id", "invoice_pdf_report_file"]
+            )
+
+    def action_create_payments(self):
+        """Override to remove cached invoice PDFs before creating payments.
+
+        The invoice PDF is generated once and cached as an ir.attachment.
+        When a new payment is registered the cached PDF becomes stale
+        because it does not reflect the updated payment status.  By
+        unlinking the attachment here the next Send & Print (or Print)
+        action will regenerate the PDF with the correct payment data.
+        """
+        # Collect the invoices linked to the payment lines *before*
+        # creating the payments, since context / line_ids are still
+        # available at this point.
+        moves = self.line_ids.move_id
+        self._invalidate_invoice_pdf_reports(moves)
+        return super().action_create_payments()


### PR DESCRIPTION
When a payment is registered via the Register Payment wizard, any previously cached invoice PDF attachment is automatically deleted. This ensures the next Send & Print or Print action regenerates the PDF with accurate, up-to-date payment information.