### PR TITLE
[16.0][FIX] account_invoice_payment_retention: Refund of invoice with retention

### DIFF
--- a/account_invoice_payment_retention/__manifest__.py
+++ b/account_invoice_payment_retention/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Account Invoice Payment Retention",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.0.1",
     "category": "Accounting & Finance",
     "author": "Ecosoft, Odoo Community Association (OCA)",
     "license": "AGPL-3",

--- a/account_invoice_payment_retention/models/account_move.py
+++ b/account_invoice_payment_retention/models/account_move.py
@@ -184,7 +184,9 @@ class AccountMove(models.Model):
     @api.constrains("amount_retention", "retention_amount_currency")
     def _check_retention_amount_currency(self):
         for rec in self.filtered("payment_retention"):
-            if rec.retention_amount_currency > rec.amount_untaxed:
+            # abs(): during _reverse_moves, the refund is transiently seen with
+            # refund move_type but invoice-signed lines, making both values negative.
+            if abs(rec.retention_amount_currency) > abs(rec.amount_untaxed):
                 raise ValidationError(
                     _("Retention must not exceed the total untaxed amount")
                 )


### PR DESCRIPTION
  ## Description

  Creating a credit note from a posted invoice that carries a retention raises  
  `ValidationError: Retention must not exceed the total untaxed amount` and
  blocks the reversal wizard, for both **Partial Refund** and **Full Refund**.  
                                                                                
  ## Steps to reproduce                                                         
                                                                                
  1. Install `account_invoice_payment_retention` on a clean 16.0 database.      
  2. In Accounting → Configuration → Settings, set the Retention and Retention
     Receivable accounts; grant the user the "Payment Retention" group.         
  3. Create a customer invoice with one line (e.g. 500 untaxed). Set            
     `Payment Retention = Percent`, `Method = Untaxed`, `Retention = 10`.       
     Post it.                                                                   
  4. From the invoice, click **Add Credit Note** → choose **Partial Refund**    
     (same result with **Full Refund**) → **Reverse**.                          
                                                                                
  ## Result experienced                                                         
                                                                                
  ValidationError: Retention must not exceed the total untaxed amount           
    File ".../account_invoice_payment_retention/models/account_move.py",
      line 188, in _check_retention_amount_currency                             
      raise ValidationError(                                                    
          _("Retention must not exceed the total untaxed amount")               
      )                                                                         
                                                            
  The credit note is never created.
                                                                                
  ## Expected result
                                                                                
  A draft credit note is created (Partial Refund) or a posted credit note is    
  created (Full Refund), with no ValidationError.
                                                                                
  ## Root cause                                             

  In `account.move._reverse_moves`, the refund is created in two steps:         
  `copy()` first, then line `balance` / `amount_currency` inversion. Between
  the two, the new record already has the reversed `move_type` but its lines    
  still carry invoice-side signs. In that window, both `amount_untaxed` and     
  `retention_amount_currency` compute as negative, and the signed comparison    
  `retention_amount_currency > amount_untaxed` wrongly evaluates to `True`      
  (e.g. `-50 > -500`), tripping the constraint on an otherwise-valid refund.    
                                                                                
  ## Fix                                                                        
                                                                                
  Compare magnitudes with `abs()`. The check is conceptually about absolute     
  amounts and behaves identically in the normal positive-signed case. A user
  entering a retention larger than the untaxed amount still raises.             
