### PR TITLE
[19.0][FIX] account_invoice_pricelist: don't reset price_unit on vendor bills when quantity changes

### DIFF
--- a/account_invoice_pricelist/models/account_move.py
+++ b/account_invoice_pricelist/models/account_move.py
@@ -121,10 +121,37 @@ class AccountMoveLine(models.Model):
                     # to the customer
                     line.discount = discount
 
-    @api.depends("quantity")
     def _compute_price_unit(self):
+        # `quantity` is intentionally NOT in the depends: merging it
+        # would re-fire super() on vendor bills and overwrite their
+        # PO-supplied price with `standard_price`. Quantity-driven
+        # recomputes are scheduled for sale lines only in `modified()`.
         res = super()._compute_price_unit()
+        self._apply_pricelist_to_price_unit()
+        return res
+
+    def modified(self, fnames, create=False, before=False):
+        # Reschedule price_unit on sale lines when quantity changes
+        # post-create. We skip `create` so explicit `price_unit` in
+        # create vals isn't clobbered by the pricelist.
+        res = super().modified(fnames, create=create, before=before)
+        if "quantity" in fnames and not create:
+            sale_lines = self.filtered(
+                lambda line: line.move_id.move_type
+                in ("out_invoice", "out_refund", "out_receipt")
+            )
+            if sale_lines:
+                self.env.add_to_compute(self._fields["price_unit"], sale_lines)
+        return res
+
+    def _apply_pricelist_to_price_unit(self):
         for line in self:
+            if line.move_id.move_type not in (
+                "out_invoice",
+                "out_refund",
+                "out_receipt",
+            ):
+                continue
             line = line.with_company(line.company_id)
             if not line.move_id.pricelist_id:
                 continue
@@ -142,7 +169,6 @@ class AccountMoveLine(models.Model):
                 line.with_context(
                     check_move_validity=False
                 ).price_unit = line.currency_id.round(price_unit)
-        return res
 
     def _get_display_price(self):
         """Compute the displayed unit price for a given line.

--- a/account_invoice_pricelist/tests/test_account_move_pricelist.py
+++ b/account_invoice_pricelist/tests/test_account_move_pricelist.py
@@ -447,6 +447,34 @@ class TestAccountMovePricelist(common.TransactionCase):
         self.assertEqual(invoice_line.price_unit, 100.00)
         self.assertEqual(invoice_line.discount, 0.00)
 
+    def test_vendor_bill_pricelist_does_not_overwrite_price_unit(self):
+        """Vendor bills must never have a sale pricelist applied: even if a
+        pricelist_id is set on an in_invoice (e.g. by a third-party module
+        or by user error), the supplied price_unit must be preserved so the
+        price brought in from the PO autocomplete or supplierinfo isn't
+        replaced by the product's list_price / standard_price.
+        """
+        bill = self.AccountMove.create(
+            {
+                "partner_id": self.partner.id,
+                "move_type": "in_invoice",
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.product.product_variant_ids[:1].id,
+                            "name": "Vendor line",
+                            "quantity": 1.0,
+                            "price_unit": 42.00,
+                        },
+                    ),
+                ],
+            }
+        )
+        bill.pricelist_id = self.sale_pricelist.id
+        bill.invoice_line_ids[:1].quantity = 0.0
+        bill.invoice_line_ids[:1].quantity = 1.0
+        self.assertEqual(bill.invoice_line_ids[:1].price_unit, 42.00)
+
     def test_14_calculate_discount(self):
         self.env.user.write({"group_ids": [(4, self.group_discount.id)]})
         self.product.write({"list_price": 0.00})


### PR DESCRIPTION
### Problem

`account_invoice_pricelist` overrides `account.move.line._compute_price_unit` and adds `quantity` to the `@api.depends`:

```python
@api.depends("quantity")
def _compute_price_unit(self):
    res = super()._compute_price_unit()
    ...
```

`@api.depends` are merged across the inheritance chain, so the parent's depends become `('product_id', 'product_uom_id', 'quantity')` for **every** move type, not just sale documents.

The intent of the override is to re-evaluate **sale** pricelist rules (which can be volume-based) when `quantity` changes on a customer invoice. The side effect, however, is that `super()._compute_price_unit()` now also re-fires on **vendor bills** every time a line's quantity changes. The parent's `_compute_price_unit` does:

```python
line.price_unit = line.product_id._get_tax_included_unit_price(
    line.move_id.company_id, ..., 'purchase', ...
)
```

`_get_tax_included_unit_price` for purchase moves returns the product's `standard_price` (no PO context). The result is that the `price_unit` brought in by the PO autocomplete (or by `purchase.order.line._prepare_account_move_line`) is **silently overwritten** with the product's `standard_price` the moment the user touches the quantity on the bill.

### Reproducer

1. On a draft vendor bill, click *Auto-Complete* and pull lines from a PO whose `price_unit` differs from the product's `standard_price`.
2. Edit the quantity on any line.
3. Observe that `price_unit` now equals `product.standard_price` instead of the PO price.

### Fix

Drop `quantity` from the merged `_compute_price_unit` depends entirely, then re-introduce the quantity trigger only for sale lines via `modified()` and `env.add_to_compute`:

```python
def modified(self, fnames, create=False, before=False):
    res = super().modified(fnames, create=create, before=before)
    if "quantity" in fnames:
        sale_lines = self.filtered(
            lambda line: line.move_id.move_type in ("out_invoice", "out_refund")
        )
        if sale_lines:
            self.env.add_to_compute(self._fields["price_unit"], sale_lines)
    return res
```

`modified()` is the framework's universal "field changed" notifier — it is called from `write`, `_write`, `create`, `update`, `flush`, cache invalidations and direct setter assignments alike. Hooking here gives identical behaviour for UI, RPC, shell, and tests, with no risk of UI/shell asymmetry that an `@api.onchange` would introduce.

The recompute still flows through `_compute_price_unit` (super + pricelist) exactly as if `quantity` were a real dependency — but only for the records we explicitly select.

`_apply_pricelist_to_price_unit` is also defensively scoped to sale moves so `button_update_prices_from_pricelist` cannot apply a sale pricelist to a bill if one is somehow attached.

### Effect

| Trigger | Sale invoice / refund | Vendor bill / refund |
|---|---|---|
| `product_id` / `product_uom_id` change | super + pricelist applied | super (unchanged behaviour) |
| `quantity` change (any path) | pricelist re-applied via scheduled recompute | **untouched** — PO `price_unit` preserved |
| `button_update_prices_from_pricelist` | pricelist applied | no-op |

### Tests

Adds `test_vendor_bill_pricelist_does_not_overwrite_price_unit` asserting that an `in_invoice` line's `price_unit` survives quantity edits even when a `pricelist_id` is attached to the bill.

All existing tests continue to pass — the `quantity = 0; quantity = 1` pattern several tests use to force a recompute still works because backend writes go through `modified()`.