### PR TITLE
[FIX] account_invoice_discount_date: Sync discount_dates between move and move lines

### DIFF
--- a/account_invoice_discount_date/models/account_move.py
+++ b/account_invoice_discount_date/models/account_move.py
@@ -33,8 +33,10 @@ class AccountMove(models.Model):
 
     def _inverse_discount_date(self):
         """When set Discount date, update all move lines with Date maturity"""
+        discount_date_field = self._fields["discount_date"]
         for record in self:
             for line in record.line_ids.filtered_domain(
                 [("display_type", "=", "payment_term")]
             ):
                 line.discount_date = record.discount_date
+                self.env.add_to_compute(discount_date_field, record)

--- a/account_invoice_discount_date/readme/USAGE.md
+++ b/account_invoice_discount_date/readme/USAGE.md
@@ -1,8 +1,10 @@
 To use this module, you need to:
 
 1. Go to Accounting > Suppliers > Bills (or Customers > Invoices) and set the Discount Date on a desired bill.
-2. All Move Lines with maturity date set, will update its Discount Date with the Discount Date of the invoice.
-3. You can group invoices to know which Invoice should be paid to ensure the discount benefit.
-4. You can change the Discount Date on any move line. The lower one will be set on the bill.
+1. All Move Lines with maturity date set, will update its Discount Date with the Discount Date of the invoice.
+1. If you set Payment Terms with Early Payment before changing discount date, Early Payment date of Payment Terms will be preserved.
+1. Change again the discount date (if your case is the previous step).
+1. You can group invoices to know which Invoice should be paid to ensure the discount benefit.
+1. You can change the Discount Date on any move line. The lower one will be set on the bill.
   - When the Discount Date of the bill is changed, the recomputation of the Discount Date on the lines will happen.
   - Make sure you only increment the discount date if you have multiple maturity dates or the lower Discount Date will be propagated on all maturity lines.


### PR DESCRIPTION
Discount Date preserves on the first write the date given by the Early Payment Terms. Future modifications will be synced with the lines.

**Before:**
When you set a payment terms with early payments and select a new discount date before saving, discount date on the move and discount date on the lines are not synced.

**Now:**
If the Early Payment Term is set and you choose another discount date before saving the move, the Discount Date used will be the Early Payment Term Discount Date. No matter what you choose until move is saved.
Then, you can modify freely the discount date and sync like before.

https://www.loom.com/share/7edab76ed3e245debab2d8a0b9aa11d8

MT-14470 MT-14349 @moduon @rafaelbn @fcvalgar @Gelojr @EmilioPascual @chienandalu please review if you want 😄 