### PR TITLE
[FIX] account_invoice_fixed_discount: recalculate discount_fixed on percentage change (19.0)

### DIFF
--- a/account_invoice_fixed_discount/models/account_move_line.py
+++ b/account_invoice_fixed_discount/models/account_move_line.py
@@ -74,7 +74,8 @@ class AccountMoveLine(models.Model):
         if self.env.context.get("ignore_discount_onchange"):
             return
         self = self.with_context(ignore_discount_onchange=True)
-        self.discount_fixed = 0.0
+        # Convert the percentage discount into equivalent fixed amount
+        self.discount_fixed = self.price_unit * (self.discount / 100.0)
 
     def _get_discount_from_fixed_discount(self):
         """Calculate the discount percentage from the fixed discount amount."""

--- a/account_invoice_fixed_discount/tests/test_account_fixed_discount.py
+++ b/account_invoice_fixed_discount/tests/test_account_fixed_discount.py
@@ -101,19 +101,32 @@ class TestInvoiceFixedDiscount(BaseCommon):
         self.assertEqual(self.invoice.invoice_line_ids.price_unit, 200.00)
         self.assertEqual(self.invoice.invoice_line_ids.price_subtotal, 143.00)
 
-        # Reset to regular discount at 20.00%
+        # Switch to regular discount at 20.00%
         with Form(self.invoice) as invoice_form:
             with invoice_form.invoice_line_ids.edit(0) as line:
-                # Force the fixed discount as the onchange does not
-                # handle the context properly
-                line.discount_fixed = 0.0
                 line.discount = 20.0
 
-        self.assertEqual(self.invoice.invoice_line_ids.discount_fixed, 0.0)
+        # discount_fixed is recalculated to its equivalent fixed amount
+        # (200 * 0.20 = 40.0)
+        self.assertEqual(self.invoice.invoice_line_ids.discount_fixed, 40.0)
         self.assertEqual(self.invoice.invoice_line_ids.discount, 20.0)
         self.assertEqual(self.invoice.amount_total, 176.0)
         self.assertEqual(self.invoice.invoice_line_ids.price_unit, 200.00)
         self.assertEqual(self.invoice.invoice_line_ids.price_subtotal, 160.00)
+
+    def test_01b_discount_fixed_not_reset_to_zero(self):
+        """Changing the percentage discount should recalculate the fixed
+        discount instead of resetting it to zero.
+        Regression test for OCA/account-invoicing#2317.
+        """
+        with Form(self.invoice) as invoice_form:
+            with invoice_form.invoice_line_ids.edit(0) as line:
+                line.discount_fixed = 50.0
+                line.discount = 20.0
+
+        # Fixed discount should be recalculated (200 * 20 / 100 = 40)
+        self.assertEqual(self.invoice.invoice_line_ids.discount_fixed, 40.0)
+        self.assertEqual(self.invoice.invoice_line_ids.discount, 20.0)
 
     def test_02_discounts_fixed_multiple_units(self):
         """Tests multiple discounts in line with taxes."""


### PR DESCRIPTION
[FIX] account_invoice_fixed_discount: recalculate discount_fixed on percentage change

When users set a fixed discount and then edit the percentage
discount field, the onchange unconditionally reset discount_fixed
to 0.0, silently destroying the user input.

Instead of zeroing out discount_fixed, recalculate it to its
equivalent fixed amount based on the percentage:
    discount_fixed = price_unit * (discount / 100.0)

This keeps both discount fields consistent at all times.

A new regression test is added to prevent future regression.

Fixes OCA/account-invoicing#2317