### PR TITLE
[FIX] account_invoice_show_currency_rate: ignore COGS lines in rate

### DIFF
--- a/account_invoice_show_currency_rate/models/account_move.py
+++ b/account_invoice_show_currency_rate/models/account_move.py
@@ -20,7 +20,14 @@ class AccountMove(models.Model):
         # If move is posted, get rate based on line amount
         res = super()._compute_invoice_currency_rate()
         for move in self:
-            lines = move.line_ids.filtered(lambda x: abs(x.amount_currency) > 0)
+            # Exclude anglo-saxon COGS lines: they are kept in company currency
+            # (amount_currency == balance, see
+            # account.move.line._compute_currency_id), so taking them into account
+            # would distort the company -> document currency rate. The core ignores
+            # them as well (see AccountMove._get_lines_onchange_currency).
+            lines = move.line_ids.filtered(
+                lambda x: abs(x.amount_currency) > 0 and x.display_type != "cogs"
+            )
             if move.state != "posted" or not lines or not move.currency_id:
                 continue
             amount_currency_positive = sum(

--- a/account_invoice_show_currency_rate/tests/test_account_move.py
+++ b/account_invoice_show_currency_rate/tests/test_account_move.py
@@ -101,3 +101,39 @@ class TestAccountMove(common.TransactionCase):
         invoice = self.env["account.move"].new({"move_type": "entry"})
         # Simply check the method doesn't crash
         invoice._compute_invoice_currency_rate()
+
+    def test_04_currency_rate_ignores_cogs_lines(self):
+        """Anglo-Saxon COGS lines are kept in company currency (rate 1.0) and
+        must be ignored when computing the invoice currency rate. Otherwise they
+        distort the sum(amount_currency)/sum(balance) ratio, dragging the rate
+        towards 1.0. The core ignores them too (see
+        AccountMove._get_lines_onchange_currency)."""
+        self.partner.property_product_pricelist = self.pricelist_currency_extra
+        invoice = self._create_invoice(self.currency_extra)
+        self.assertAlmostEqual(invoice.invoice_currency_rate, 2.0, 2)
+        # Simulate the COGS lines added by stock_account on posting: they are
+        # kept in company currency (amount_currency == balance) and may be much
+        # larger than the invoice amounts.
+        company_currency = invoice.company_currency_id
+        self.env["account.move.line"].with_context(check_move_validity=False).create(
+            [
+                {
+                    "move_id": invoice.id,
+                    "display_type": "cogs",
+                    "account_id": self.other_account.id,
+                    "currency_id": company_currency.id,
+                    "balance": 1000.0,
+                    "amount_currency": 1000.0,
+                },
+                {
+                    "move_id": invoice.id,
+                    "display_type": "cogs",
+                    "account_id": self.other_account.id,
+                    "currency_id": company_currency.id,
+                    "balance": -1000.0,
+                    "amount_currency": -1000.0,
+                },
+            ]
+        )
+        # The rate must still reflect the real invoice lines, not the COGS ones.
+        self.assertAlmostEqual(invoice.invoice_currency_rate, 2.0, 2)


### PR DESCRIPTION
The invoice currency rate was computed as
sum(abs(amount_currency)) / sum(abs(balance)) over every move line with a non-zero amount_currency. Anglo-Saxon COGS lines are kept in company currency (amount_currency == balance, so their per-line rate is 1.0; see account.move.line._compute_currency_id), so including them dragged the company -> document currency rate towards 1.0.

On a foreign-currency customer invoice with automated inventory valuation this produced a wrong invoice_currency_rate. In Odoo 18 this field is used by the core tax totals to convert the untaxed base into company currency, so the printed subtotal in company currency came out wrong while the tax amount (taken from the posted line balance) stayed correct.

Exclude COGS lines from the computation, as the core itself does in AccountMove._get_lines_onchange_currency.