### PR TITLE
[18.0][IMP]  account_invoice_tax_required: Skip requirement with context

### DIFF
--- a/account_invoice_tax_required/models/account_move.py
+++ b/account_invoice_tax_required/models/account_move.py
@@ -80,6 +80,9 @@ class AccountMove(models.Model):
                 ),
                 # Avoid breaking unaware addons' tests by default
                 config["test_enable"],
+                # Allow skipping if some operation needs it EX questionable but legal
+                # external invoice importing
+                self.env.context.get("skip_tax_required"),
             )
         )
         if force_test or not skip_test:


### PR DESCRIPTION
Allow skipping if some operation needs it EX questionable but valid and legal external invoice importing
TT56336
@Tecnativa 