### PR TITLE
[18.0][FIX+REF] sale_stock_picking_invoicing: Grouping Pickings with and without Sale Orders related and change to use Command

### DIFF
--- a/sale_stock_picking_invoicing/tests/test_sale_stock.py
+++ b/sale_stock_picking_invoicing/tests/test_sale_stock.py
@@ -655,3 +655,24 @@ class TestSaleStockPickingInvoicing(TestSaleStockPickingInvoicingCommon):
         self.assertEqual(picking.invoice_state, "invoiced")
         for move in picking.move_ids:
             self.assertEqual(move.invoice_state, "invoiced")
+
+    def test_16_grouping_pickings_with_and_without_sale_order(self):
+        """
+        Test the case of Grouping Pickings by Partner/Product
+        with and without Sale Orders.
+        """
+        picking_1 = self.picking_out_1
+        picking_1.set_to_be_invoiced()
+        self.picking_move_state(picking_1)
+        picking_2 = self.picking_out_2
+        picking_2.set_to_be_invoiced()
+        self.picking_move_state(self.picking_out_2)
+
+        picking_3 = self.run_sale_picking_process(self.sale_order_3)
+        picking_4 = self.run_sale_picking_process(self.sale_order_4)
+
+        invoices = create_with_form_inv_onshipping(
+            self.env,
+            picking_1 | picking_2 | picking_3 | picking_4,
+        )
+        self.assertEqual(len(invoices), 1)

--- a/sale_stock_picking_invoicing/wizards/stock_invoice_onshipping.py
+++ b/sale_stock_picking_invoicing/wizards/stock_invoice_onshipping.py
@@ -4,6 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
+from odoo.fields import Command
 
 
 class StockInvoiceOnshipping(models.TransientModel):
@@ -209,7 +210,7 @@ class StockInvoiceOnshipping(models.TransientModel):
             # Same make above, get fields informed in Sale Line dict
             sale_line_values = move.sale_line_id._prepare_invoice_line()
             # Vals informed in any case
-            values["sale_line_ids"] = [(6, 0, moves.sale_line_id.ids)]
+            values["sale_line_ids"] = [Command.set(moves.sale_line_id.ids)]
             values["analytic_distribution"] = sale_line_values.get(
                 "analytic_distribution"
             )
@@ -262,9 +263,9 @@ class StockInvoiceOnshipping(models.TransientModel):
             # Set qty to 0 to keep combo header visible on SO invoice
             sale_line_vals["quantity"] = 0
             sale_line_vals["sale_line_ids"] = [
-                (6, 0, [sale_line_vals.get("sale_line_ids")[0][1]])
+                Command.set([sale_line_vals.get("sale_line_ids")[0][1]])
             ]
-            combo_section_vals.append((0, 0, sale_line_vals))
+            combo_section_vals.append(Command.create(sale_line_vals))
         return combo_section_vals
 
     def _create_invoice(self, invoice_values):
@@ -310,9 +311,9 @@ class StockInvoiceOnshipping(models.TransientModel):
                 # Change [(4, 59)] for [(6, 0, [59])] to avoid error
                 # in method to Resequencing
                 sale_line_vals["sale_line_ids"] = [
-                    (6, 0, [sale_line_vals.get("sale_line_ids")[0][1]])
+                    Command.set([sale_line_vals.get("sale_line_ids")[0][1]])
                 ]
-                section_note_vals.append((0, 0, sale_line_vals))
+                section_note_vals.append(Command.create(sale_line_vals))
 
             invoice_values["invoice_line_ids"] += section_note_vals
 
@@ -344,9 +345,7 @@ class StockInvoiceOnshipping(models.TransientModel):
                     # Create a dedicated section for the down payments
                     # (put at the end of the invoiceable_lines)
                     down_payment_vals.append(
-                        (
-                            0,
-                            0,
+                        Command.create(
                             line.order_id._prepare_down_payment_section_line(
                                 sequence=invoice_item_sequence,
                             ),
@@ -357,9 +356,7 @@ class StockInvoiceOnshipping(models.TransientModel):
 
                 if line.is_downpayment:
                     down_payment_vals.append(
-                        (
-                            0,
-                            0,
+                        Command.create(
                             line._prepare_invoice_line(
                                 sequence=invoice_item_sequence,
                             ),

--- a/sale_stock_picking_invoicing/wizards/stock_invoice_onshipping.py
+++ b/sale_stock_picking_invoicing/wizards/stock_invoice_onshipping.py
@@ -330,8 +330,8 @@ class StockInvoiceOnshipping(models.TransientModel):
             # [(6, 0, {})]
             if line[2]:
                 sale_line = line[2].get("sale_line_ids")
-                if sale_line:
-                    # [(6, 0, [58])]
+                # [(<Command.SET: 6>, 0, [])]
+                if sale_line[0][2]:
                     line[2]["sequence"] = invoice_item_seq_dict.get(sale_line[0][2][0])
 
         # Down Payments


### PR DESCRIPTION
Simple PR with two changes:

* **[FIX]** - If the User try to create a Grouping Pickings by Partner/Product with and without Sale Orders related, the variable **sale_line** can be **[(<Command.SET: 6>, 0, [])]**, in this case will occur the error:

```bash
2026-06-12 21:06:03,548 14 ERROR db odoo.http: Exception during request handling. 
Traceback (most recent call last):
  File "/opt/venv/lib/python3.12/site-packages/odoo/http.py", line 2577, in __call__
    response = request._serve_db()
               ^^^^^^^^^^^^^^^^^^^

...

  File "/home/odoo/app/external-src/account-invoicing/sale_stock_picking_invoicing/wizards/stock_invoice_onshipping.py", line 318, in _create_invoice
    line[2]["sequence"] = invoice_item_seq_dict.get(sale_line[0][2][0])
                                                    ~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```

It's possible reproduce the error with Demo Data, configure to Create Invoice from Stock Picking, Confirm the Sale Orders and Pickings, select all Pickings go to Actions and Create Draft Invoices

<img width="1085" height="389" alt="image" src="https://github.com/user-attachments/assets/6fee8ae7-423f-4e86-8cef-26ca7a2179fd" />

Define Group as Partner/Product

<img width="1133" height="472" alt="image" src="https://github.com/user-attachments/assets/67e5f41f-5da3-4ffe-b249-6d63efa504e6" />

<img width="1204" height="427" alt="image" src="https://github.com/user-attachments/assets/98b36fa3-561f-4e92-9cb2-1cbdf6c1668c" />

Test was included to check this case.

* **[REF]** - The second change is just to use Command, instead of use (0, 0, {}) and (6, 0, []) to use Command.create and Command.set

CC @rvalyi @renatonlima 