### PR TITLE
[19.0][FIX] stock_picking_return_refund_option: Recompute all PO lines to correctly handle returns with extra invoiceable lines

### DIFF
--- a/stock_picking_return_refund_option/models/stock_picking.py
+++ b/stock_picking_return_refund_option/models/stock_picking.py
@@ -74,4 +74,11 @@ class StockPicking(models.Model):
             po_lines = self.mapped("move_ids.purchase_line_id").filtered(
                 lambda x: x.product_id.invoice_policy in ("order", "delivery")
             )
+            # Check if exists is_delivery field in purchase.order.line that has
+            # been added by delivery module, this module has not dependency of this.
+            # Otherwise, the PO will have an inconsistent `invoice_status`.
+            if hasattr(self.env["purchase.order.line"], "is_delivery"):
+                po_lines |= self.mapped("purchase_id.order_line").filtered(
+                    lambda x: x.is_delivery
+                )
             po_lines._compute_qty_received()


### PR DESCRIPTION
Without these changes, using this module together with other modules, such as `delivery_purchase`, raises this error:

```
ERROR prod odoo.addons.stock_picking_return_refund_option.tests.test_stock_picking_return_refund_options: FAIL: TestSaleOrderLineInput.test_return_po_wo_to_refund
Traceback (most recent call last):
  File "/opt/odoo/auto/addons/stock_picking_return_refund_option/tests/test_stock_picking_return_refund_options.py", line 137, in test_return_po_wo_to_refund
    self.assertEqual(po_order.invoice_status, "no")
AssertionError: 'to invoice' != 'no'
- to invoice
+ no
```

This change is needed for real purchase returns with extra invoiceable lines, such as delivery costs.
When `to_refund` is changed on a return picking, the received quantity of the related purchase line is recomputed. But other lines on the same purchase order, for example delivery_purchase lines marked as is_delivery, may also depend on whether the normal product lines are still invoiceable.
So after recomputing `qty_received`, we also recompute `qty_to_invoice` for all lines of the purchase order.
Without this, a fully returned purchase can still remain "to invoice" because an auxiliary line keeps an outdated `qty_to_invoice`.

@pedrobaeza @victoralmau can you review please?

@Tecnativa