### PR TITLE
[18.0][FIX] account_invoice_pricelist: cls.env.ref() to get currency on test

### DIFF
--- a/account_invoice_pricelist/tests/test_account_move_pricelist.py
+++ b/account_invoice_pricelist/tests/test_account_move_pricelist.py
@@ -191,11 +191,9 @@ class TestAccountMovePricelist(BaseCommon):
                 ],
             }
         )
-        cls.euro_currency = cls.env["res.currency"].search(
-            [("active", "=", False), ("name", "=", "EUR")]
-        )
+        cls.euro_currency = cls.env.ref("base.EUR")
         cls.euro_currency.active = True
-        cls.usd_currency = cls.env["res.currency"].search([("name", "=", "USD")])
+        cls.usd_currency = cls.env.ref("base.USD")
         cls.sale_pricelist_with_discount_in_euros = cls.ProductPricelist.create(
             {
                 "name": "Test Sale pricelist - 4",


### PR DESCRIPTION
cc @Tecnativa TT63195
`currency_id` search may fail if other test already active the currency

ping @pedrobaeza @victoralmau 