### PR TITLE
[FIX] sale_stock_picking_invoicing: exclude note/section lines from SO invoiceable lines under 'stock_picking' policy

### DIFF
--- a/sale_stock_picking_invoicing/models/sale_order.py
+++ b/sale_stock_picking_invoicing/models/sale_order.py
@@ -21,12 +21,12 @@ class SaleOrder(models.Model):
             so_invoiceable_lines = lines.filtered(
                 lambda ln: ln.product_id.type != "consu" and not ln.is_downpayment
             )
-            if so_invoiceable_lines:
+            if so_invoiceable_lines.filtered(lambda ln: not ln.display_type):
                 lines = so_invoiceable_lines
             else:
                 raise UserError(
                     self.env._(
-                        "When 'Sale Invoicing Policy' is defined as"
+                        "When 'Sale Invoicing Policy' is defined as "
                         "'Stock Picking' the Invoice can only be created"
                         " from the Stock Picking, if necessary you can change"
                         " in the Company or Sale Settings."

--- a/sale_stock_picking_invoicing/tests/test_sale_stock.py
+++ b/sale_stock_picking_invoicing/tests/test_sale_stock.py
@@ -464,3 +464,21 @@ class TestSaleStockPickingInvoicing(TestSaleStockPickingInvoicingCommon):
         )
         so_invoice.action_post()
         self.assertEqual(so_invoice.state, "posted")
+
+    def test_10_so_only_consu_with_notes_invoice_from_so_raises(self):
+        """
+        Under 'stock_picking', a SO whose only invoiceable content is
+        consu products (plus note/section lines) must raise the explicit
+        "invoice from the picking" error, instead of returning the
+        note/section lines and failing with Odoo's generic
+        "No items are available to invoice".
+        """
+        self.assertEqual(self.company.sale_invoicing_policy, "stock_picking")
+        # sale_order_3 = 2 consu products + 1 note + 1 section, no service
+        picking = self.run_sale_picking_process(self.sale_order_3)
+        self.assertEqual(picking.state, "done")
+        with self.assertRaises(exceptions.UserError) as e:
+            self.sale_order_3.with_context(active_model="sale.order")._create_invoices(
+                final=True
+            )
+        self.assertIn("Sale Invoicing Policy", e.exception.args[0])


### PR DESCRIPTION
Under 'stock_picking', a SO whose only invoiceable content is consu products (plus note/section lines) must raise the explicit "invoice from the picking" error, instead of returning the  note/section lines and failing with Odoo's generic "No items are available to invoice".

Example:
If  we have stock picking invoice policy:
<img width="653" height="223" alt="image" src="https://github.com/user-attachments/assets/3eb42dc1-b2a4-4604-89d9-3d3d95d3fe09" />

And we try to invoice a Sale Order with only consu products + notes/sections:
<img width="1653" height="1134" alt="image" src="https://github.com/user-attachments/assets/f0267209-e312-442e-905f-0fe228a4411c" />

Message should be:
<img width="1879" height="520" alt="image" src="https://github.com/user-attachments/assets/8ff664f8-fd5c-4400-b909-ad4861a25a66" />
