### PR TITLE
[19.0][FIX] account_invoice_pricelist: make secondary currency tests deterministic

### DIFF
--- a/account_invoice_pricelist/tests/test_account_move_pricelist.py
+++ b/account_invoice_pricelist/tests/test_account_move_pricelist.py
@@ -328,15 +328,13 @@ class TestAccountMovePricelist(common.TransactionCase):
                 ],
             }
         )
-        # Fix currency rate of EUR -> USD to 1.5289
-        usd_currency = cls.env["res.currency"].search([("name", "=", "USD")])
-        usd_rates = cls.env["res.currency.rate"].search(
-            [("currency_id", "=", usd_currency.id)]
-        )
-        usd_rates.unlink()
+        # Fix currency rate of EUR -> USD to 1.1913
+        cls.env["res.currency.rate"].search(
+            [("currency_id", "in", (cls.usd_currency.id, cls.euro_currency.id))]
+        ).unlink()
         cls.env["res.currency.rate"].create(
             {
-                "currency_id": usd_currency.id,
+                "currency_id": cls.usd_currency.id,
                 "rate": 1.1913,
                 "create_date": "2010-01-01",
                 "write_date": "2010-01-01",


### PR DESCRIPTION
cc @Tecnativa TT63195

The base data ships an EUR rate (1.2834) that skewed the USD -> EUR conversion in the pricelist tests. test_06 and test_07 assumed an EUR rate of 1.0, so the converted price unit no longer matched the expected values (100 / 1.1913 = 83.94 EUR), making the tests fail.

ping @pedrobaeza @victoralmau could you review please?