### PR TITLE
[17.0][FIX] sale_timesheet_invoice_description migration for default values

### DIFF
--- a/sale_timesheet_invoice_description/migrations/17.0.1.0.1/post-migrate.py
+++ b/sale_timesheet_invoice_description/migrations/17.0.1.0.1/post-migrate.py
@@ -1,0 +1,26 @@
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    res_config_obj = env["res.config.settings"]
+    default_values = res_config_obj.default_get(list(res_config_obj.fields_get()))
+    timesheet_invoice_description = default_values.get(
+        "default_timesheet_invoice_description"
+    )
+    if not timesheet_invoice_description:
+        default_values.update({"default_timesheet_invoice_description": "000"})
+        res_config_obj.create(default_values).execute()
+        timesheet_invoice_description = default_values.get(
+            "default_timesheet_invoice_description"
+        )
+    sale_orders = (
+        env["sale.order"]
+        .with_context(active_test=False)
+        .search(
+            [
+                ("timesheet_invoice_description", "=", False),
+            ]
+        )
+    )
+    sale_orders.write({"timesheet_invoice_description": timesheet_invoice_description})


### PR DESCRIPTION
Field `timesheet_invoice_description` is not filled in sale.order, nor field `default_timesheet_invoice_description` in `res.config.settings`, with default values, as the defaults until v. 16 were not set.

This PR fix this.