### PR TITLE
[15.0][FIX] account_invoice_payment_retention: not copy retention info when duplicate

### DIFF
--- a/account_invoice_payment_retention/models/account_move.py
+++ b/account_invoice_payment_retention/models/account_move.py
@@ -12,6 +12,7 @@ class AccountMove(models.Model):
         selection=[("percent", "Percent"), ("amount", "Amount")],
         readonly=True,
         states={"draft": [("readonly", False)]},
+        copy=False,
         help="Suggested retention amount to be withheld on payment.\n"
         "Note: as a suggestiong, during payment, user can ignore it.",
     )
@@ -20,6 +21,7 @@ class AccountMove(models.Model):
         default=lambda self: self.env.company.retention_method,
         readonly=True,
         states={"draft": [("readonly", False)]},
+        copy=False,
         help="Method for computing the retention\n"
         "- Untaxed Amount: The retention compute from the untaxed amount\n"
         "- Total: The retention compute from the total amount",
@@ -28,12 +30,14 @@ class AccountMove(models.Model):
         string="Retention",
         readonly=True,
         states={"draft": [("readonly", False)]},
+        copy=False,
         help="Retention in percent of this invoice, or by amount",
     )
     retention_amount_currency = fields.Monetary(
         string="Retention Amount",
         compute="_compute_retention_amount_currency",
         store=True,
+        copy=False,
         help="Based on retention type, this field show the amount to retain.",
     )
     retention_residual_currency = fields.Monetary(


### PR DESCRIPTION
PR Description: Fix Credit Note Copying Retention Fields

Root Cause

When creating a Credit Note via the Account Move Reversal wizard, the system calls move._reverse_moves() which internally uses move.copy_data(include_business_fields=True) to copy data from the source Invoice.

Four retention fields lacked copy=False, causing them to be copied to the Credit Note:

FIX
Add copy=False to all four retention fields in account_invoice_payment_retention/models/account_move.py

Steps to Reproduce
1.Create a Vendor Bill (in_invoice) or Customer Invoice (out_invoice)
2.Set Retention: payment_retention = "percent", amount_retention = 5 (5%)
3.Post the Invoice
4.Click Add Credit Note → select Full Refund
5.Check the created Credit Note: payment_retention, amount_retention, retention_amount_currency are incorrectly copied

