### PR TITLE
[FIX] account_invoice_pricelist: apply discount when adding products via catalog

### DIFF
--- a/account_invoice_pricelist/models/account_move.py
+++ b/account_invoice_pricelist/models/account_move.py
@@ -219,3 +219,10 @@ class AccountMoveLine(models.Model):
             date=self._get_move_date(),
             currency=self.currency_id,
         )
+
+    def _get_product_catalog_lines_data(self, **kwargs):
+        """Override to apply pricelist discount when adding products via catalog."""
+        res = super()._get_product_catalog_lines_data(**kwargs)
+        if self and self[0].move_id.pricelist_id:
+            self._calculate_discount()
+        return res


### PR DESCRIPTION

<img width="960" height="510" alt="Annotation 2026-06-29 113513" src="https://github.com/user-attachments/assets/038c3b3b-31c3-48af-9ed5-7c0525be6f3a" />
When adding a product to a customer invoice using the product catalog,
the pricelist discount was not being applied to the invoice line.

The root cause is that the product catalog uses
`_get_product_catalog_lines_data()` to create/update invoice lines,
which does not trigger `_compute_price_unit()` where `_calculate_discount()`
is normally called. As a result, the discount field remains 0.0.

The fix overrides `_get_product_catalog_lines_data()` in `AccountMoveLine`
to explicitly call `_calculate_discount()` after the catalog creates the
line, ensuring the pricelist discount is applied correctly.

Fixes #2382