### PR TITLE
[FIX] runboat: prevent installing incompatible modules together

### DIFF
--- a/.oca.yml
+++ b/.oca.yml
@@ -1,0 +1,13 @@
+﻿ignored_modules:
+  - account_invoice_fixed_discount
+  - account_invoice_triple_discount
+
+module_groups:
+  - modules:
+      - account_invoice_fixed_discount
+    excludes:
+      - account_invoice_triple_discount
+  - modules:
+      - account_invoice_triple_discount
+    excludes:
+      - account_invoice_fixed_discount


### PR DESCRIPTION
account_invoice_fixed_discount and account_invoice_triple_discount declare each other in the 'excludes' manifest key, making them incompatible. Runboat was attempting to install both modules together, causing a deployment failure.

Added .oca.yml to configure module groups so Runboat will not attempt to install both modules in the same test environment.

Fixes #2353