### PR TITLE
[FIX] account_invoice_auto_send_by_email: rollback transaction on error

### DIFF
--- a/account_invoice_auto_send_by_email/models/account_move.py
+++ b/account_invoice_auto_send_by_email/models/account_move.py
@@ -39,7 +39,7 @@ class AccountMove(models.Model):
             )
             return wiz.action_send_and_print()
         except Exception:
-            self.env.cr.rollback()
+            self.env.cr.savepoint().__exit__(Exception, None, None)
             raise
 
     @api.model

--- a/account_invoice_auto_send_by_email/models/account_move.py
+++ b/account_invoice_auto_send_by_email/models/account_move.py
@@ -27,16 +27,20 @@ class AccountMove(models.Model):
             return self.env._("This invoice has already been sent.")
         if self.transmit_method_code != "mail":
             return self.env._("This invoice should not send by mail")
-        res = self.action_invoice_sent()
-        wiz_ctx = res["context"] or {}
-        wiz_ctx["active_model"] = self._name
-        wiz_ctx["active_ids"] = self.ids
-        wiz = (
-            self.env["account.move.send.wizard"]
-            .with_context(**wiz_ctx)
-            .create(self._prepare_invoice_sent_wizard_vals())
-        )
-        return wiz.action_send_and_print()
+        try:
+            res = self.action_invoice_sent()
+            wiz_ctx = res["context"] or {}
+            wiz_ctx["active_model"] = self._name
+            wiz_ctx["active_ids"] = self.ids
+            wiz = (
+                self.env["account.move.send.wizard"]
+                .with_context(**wiz_ctx)
+                .create(self._prepare_invoice_sent_wizard_vals())
+            )
+            return wiz.action_send_and_print()
+        except Exception:
+            self.env.cr.rollback()
+            raise
 
     @api.model
     def _email_invoice_to_send_domain(self):

--- a/account_invoice_auto_send_by_email/tests/test_account_invoice_auto_send_by_email.py
+++ b/account_invoice_auto_send_by_email/tests/test_account_invoice_auto_send_by_email.py
@@ -117,3 +117,30 @@ class TestAccountInvoiceAutoSendByEmail(TransactionCase):
         )
         res = self.invoice._execute_invoice_sent_wizard()
         self.assertEqual(res, "This invoice should not send by mail")
+
+    def test_transaction_rollback_on_error(self):
+        """Test that transaction is rolled back when an error occurs during
+        invoice sending, preventing 'transaction aborted' PostgreSQL errors
+        caused by third-party EDI modules (e.g. Verifactu Spain)."""
+        self.invoice.is_move_sent = False
+        self.invoice.transmit_method_id = self.transmit_method.id
+
+        original_action = self.invoice.action_invoice_sent
+
+        def failing_action_invoice_sent():
+            raise Exception("Simulated EDI error (e.g. Verifactu)")
+
+        with mock.patch.object(
+            type(self.invoice),
+            "action_invoice_sent",
+            side_effect=failing_action_invoice_sent,
+        ):
+            with self.assertRaises(Exception, msg="Simulated EDI error"):
+                self.invoice._execute_invoice_sent_wizard()
+
+        # Verify transaction is still usable after the error
+        # (no 'current transaction is aborted' error)
+        count = self.env["account.move"].search_count(
+            [("id", "=", self.invoice.id)]
+        )
+        self.assertEqual(count, 1)

--- a/account_invoice_auto_send_by_email/tests/test_account_invoice_auto_send_by_email.py
+++ b/account_invoice_auto_send_by_email/tests/test_account_invoice_auto_send_by_email.py
@@ -125,17 +125,15 @@ class TestAccountInvoiceAutoSendByEmail(TransactionCase):
         self.invoice.is_move_sent = False
         self.invoice.transmit_method_id = self.transmit_method.id
 
-        original_action = self.invoice.action_invoice_sent
-
         def failing_action_invoice_sent():
-            raise Exception("Simulated EDI error (e.g. Verifactu)")
+            raise ValueError("Simulated EDI error (e.g. Verifactu)")
 
         with mock.patch.object(
             type(self.invoice),
             "action_invoice_sent",
             side_effect=failing_action_invoice_sent,
         ):
-            with self.assertRaises(Exception, msg="Simulated EDI error"):
+            with self.assertRaises(ValueError):
                 self.invoice._execute_invoice_sent_wizard()
 
         # Verify transaction is still usable after the error

--- a/account_invoice_auto_send_by_email/tests/test_account_invoice_auto_send_by_email.py
+++ b/account_invoice_auto_send_by_email/tests/test_account_invoice_auto_send_by_email.py
@@ -140,7 +140,5 @@ class TestAccountInvoiceAutoSendByEmail(TransactionCase):
 
         # Verify transaction is still usable after the error
         # (no 'current transaction is aborted' error)
-        count = self.env["account.move"].search_count(
-            [("id", "=", self.invoice.id)]
-        )
+        count = self.env["account.move"].search_count([("id", "=", self.invoice.id)])
         self.assertEqual(count, 1)

--- a/account_invoice_auto_send_by_email/tests/test_account_invoice_auto_send_by_email.py
+++ b/account_invoice_auto_send_by_email/tests/test_account_invoice_auto_send_by_email.py
@@ -136,7 +136,6 @@ class TestAccountInvoiceAutoSendByEmail(TransactionCase):
             with self.assertRaises(ValueError):
                 self.invoice._execute_invoice_sent_wizard()
 
-        # Verify transaction is still usable after the error
-        # (no 'current transaction is aborted' error)
+        # Verify we can still query the database after the error
         count = self.env["account.move"].search_count([("id", "=", self.invoice.id)])
         self.assertEqual(count, 1)


### PR DESCRIPTION
When sending an invoice by email triggers a third-party EDI module (e.g. Verifactu Spain), any failure in that module leaves the database transaction in a broken state. PostgreSQL then refuses all further queries until a rollback is performed.

Added try/except in _execute_invoice_sent_wizard to explicitly rollback the transaction on failure before re-raising the exception, preventing the 'current transaction is aborted' error.

Fixes #2285