### PR TITLE
[16.0][FIX] account_invoice_show_currency_rate: keep booked rate on reset to draft

### DIFF
--- a/account_invoice_show_currency_rate/models/account_move.py
+++ b/account_invoice_show_currency_rate/models/account_move.py
@@ -18,6 +18,7 @@ class AccountMove(models.Model):
 
     @api.depends(
         "state",
+        "posted_before",
         "date",
         "line_ids.amount_currency",
         "line_ids.balance",
@@ -34,7 +35,7 @@ class AccountMove(models.Model):
         self.currency_rate_amount = 1
         for item in self.filtered("show_currency_rate_amount"):
             lines = item.line_ids.filtered(lambda x: abs(x.amount_currency) > 0)
-            if item.state == "posted" and lines:
+            if (item.state == "posted" or item.posted_before) and lines:
                 amount_currency_positive = sum(
                     [abs(amc) for amc in lines.mapped("amount_currency")]
                 )
@@ -62,14 +63,20 @@ class AccountMoveLine(models.Model):
         "move_id.company_id",
         "move_id.date",
         "move_id.state",
+        "move_id.posted_before",
         "amount_currency",
         "balance",
     )
     def _compute_currency_rate(self):
-        # If move is posted, get rate based on line amount
+        # If the move is posted (or was posted before, e.g. when it is reset to
+        # draft to correct it), keep the real rate booked on the lines. Otherwise
+        # the rate would fall back to the table rate and re-derive the balance,
+        # introducing a rounding difference that wrongly breaks _check_balanced.
         res = super()._compute_currency_rate()
         for line in self:
-            if line.move_id.state != "posted" or not line.amount_currency:
+            if (
+                line.move_id.state != "posted" and not line.move_id.posted_before
+            ) or not line.amount_currency:
                 continue
             line.currency_rate = (
                 abs(line.amount_currency) / abs(line.balance) if line.balance else 0

--- a/account_invoice_show_currency_rate/tests/test_account_move.py
+++ b/account_invoice_show_currency_rate/tests/test_account_move.py
@@ -44,6 +44,11 @@ class TestAccountMove(common.TransactionCase):
         cls.journal = cls.env["account.journal"].create(
             {"name": "Test sale journal", "type": "sale", "code": "TEST-SALE"}
         )
+        # Purchase setup to reproduce the reset-to-draft rounding bug on a
+        # multi-line foreign-currency vendor bill.
+        cls.purchase_journal = cls.env["account.journal"].create(
+            {"name": "Test purchase journal", "type": "purchase", "code": "TPUR"}
+        )
         cls.pricelist_currency = cls.env["product.pricelist"].create(
             {"name": "Pricelist Currency", "currency_id": cls.currency.id}
         )
@@ -90,5 +95,94 @@ class TestAccountMove(common.TransactionCase):
         self.assertAlmostEqual(invoice.currency_rate_amount, 2.0, 2)
         self.assertAlmostEqual(invoice.line_ids[0].currency_rate, 2.0, 2)
         invoice.button_draft()
-        self.assertAlmostEqual(invoice.currency_rate_amount, 3.0, 2)
-        self.assertAlmostEqual(invoice.line_ids[0].currency_rate, 3.0, 2)
+        # The invoice was posted before, so the real booked rate (2.0) is kept
+        # instead of falling back to the table rate (3.0). This prevents the
+        # balance from being re-derived and wrongly unbalanced on reset to draft.
+        self.assertAlmostEqual(invoice.currency_rate_amount, 2.0, 2)
+        self.assertAlmostEqual(invoice.line_ids[0].currency_rate, 2.0, 2)
+
+    def _create_vendor_bill_multi(self, currency_id, amounts):
+        """Multi-line foreign-currency vendor bill, mirroring the production
+        case where per-line rounding of the re-derived balance breaks
+        _check_balanced on reset to draft."""
+        move_form = Form(
+            self.env["account.move"].with_context(
+                default_move_type="in_invoice",
+                default_journal_id=self.purchase_journal.id,
+            )
+        )
+        move_form.partner_id = self.partner
+        move_form.invoice_date = fields.Date.from_string("2000-01-01")
+        move_form.currency_id = currency_id
+        for amount in amounts:
+            with move_form.invoice_line_ids.new() as line_form:
+                line_form.product_id = self.product
+                line_form.price_unit = amount
+        invoice = move_form.save()
+        invoice.action_post()
+        return invoice
+
+    def test_03_reset_to_draft_no_balance_error(self):
+        """A multi-line foreign-currency vendor bill that was posted can be
+        reset to draft without raising a false 'unbalanced entry' error, and
+        keeping the booked balances (regression of the production case)."""
+        # Rate where per-line rounding of these amounts breaks the balance when
+        # the rate is re-applied uniformly on draft (reproduces the bug).
+        rate_custom = self.currency_extra.rate_ids.filtered(
+            lambda x: x.name == fields.Date.from_string("2000-01-01")
+        )
+        rate_custom.rate = 1.1777
+        amounts = [
+            21900,
+            9750,
+            20400,
+            500,
+            500,
+            360,
+            360,
+            450,
+            500,
+            280,
+            2625,
+            2475,
+            450,
+        ]
+        invoice = self._create_vendor_bill_multi(self.currency_extra, amounts)
+        balances_posted = invoice.line_ids.mapped("balance")
+        # Without the fix this raises UserError ("unbalanced entry"); with it,
+        # the booked rate is kept and the entry stays balanced.
+        invoice.button_draft()
+        self.assertEqual(invoice.state, "draft")
+        self.assertEqual(
+            self.env.company.currency_id.round(sum(invoice.line_ids.mapped("balance"))),
+            0.0,
+        )
+        self.assertEqual(invoice.line_ids.mapped("balance"), balances_posted)
+
+    def test_04_reset_to_draft_edit_and_repost(self):
+        """After reset to draft, the bill can be edited and posted again
+        without the false unbalanced error (V3)."""
+        rate_custom = self.currency_extra.rate_ids.filtered(
+            lambda x: x.name == fields.Date.from_string("2000-01-01")
+        )
+        rate_custom.rate = 1.1777
+        amounts = [
+            21900,
+            9750,
+            20400,
+            500,
+            500,
+            360,
+            360,
+            450,
+            500,
+            280,
+            2625,
+            2475,
+            450,
+        ]
+        invoice = self._create_vendor_bill_multi(self.currency_extra, amounts)
+        invoice.button_draft()
+        invoice.invoice_line_ids[0].price_unit = 22000
+        invoice.action_post()
+        self.assertEqual(invoice.state, "posted")


### PR DESCRIPTION
When a foreign-currency invoice that was already posted is reset to draft, _compute_currency_rate fell back to the table rate and re-derived the line balances, introducing a per-line rounding difference that wrongly raised an "unbalanced entry" error and blocked the reset.

Keep the real booked rate also for moves that were posted before (posted_before) in both _compute_currency_rate and _compute_currency_rate_amount, so the balance is preserved and the entry can be reset to draft and re-posted without error. Add tests covering a multi-line foreign-currency vendor bill reset to draft and re-posted.