### PR TITLE
[FIX] partner_last_invoice_date: avoid error when partner is created directly from

### DIFF
--- a/partner_last_invoice_date/models/res_partner.py
+++ b/partner_last_invoice_date/models/res_partner.py
@@ -20,6 +20,8 @@ class ResPartner(models.Model):
 
     def _last_invoice_date_domain(self):
         self.ensure_one()
+        if isinstance(self.id, models.NewId):
+            return []
         all_child = self.with_context(active_test=False).search(
             [("id", "child_of", self.id)]
         )

--- a/partner_last_invoice_date/tests/test_partner_last_invoice_date.py
+++ b/partner_last_invoice_date/tests/test_partner_last_invoice_date.py
@@ -103,3 +103,9 @@ class TestPartnerLastInvoiceDate(AccountTestInvoicingCommon):
         self.assertEqual(self.partner.last_bill_date, datetime.date(2025, 1, 2))
         self.assertFalse(self.partner_child.last_invoice_date)
         self.assertFalse(self.partner_child.last_bill_date)
+
+    def test_partner_newid(self):
+        new = self.env["res.partner"].new({})
+        self.invoice.copy(default={"partner_id": new.id})
+        self.assertFalse(new.last_invoice_date)
+        self.assertFalse(new.last_bill_date)


### PR DESCRIPTION
… invoice

When a customer is created directly from invoice form, an error is raised because "TypeError: 'NewId' object is not iterable".

After this changes, user can create partners directly in invoice form.

ping @LauraCForgeFlow 