### PR TITLE
Refactor price unit computation for lines with pricelist

### DIFF
--- a/account_invoice_pricelist/models/account_move.py
+++ b/account_invoice_pricelist/models/account_move.py
@@ -71,9 +71,11 @@ class AccountMoveLine(models.Model):
 
     @api.depends("quantity")
     def _compute_price_unit(self):
-        lines_without_pricelist = self.filtered(lambda line: not line.move_id.pricelist_id)
+        lines_without_pricelist = self.filtered(
+            lambda line: not line.move_id.pricelist_id)
         lines_with_pricelist = self - lines_without_pricelist
-        res = super(AccountMoveLine, lines_with_pricelist)._compute_price_unit()
+        res = super(AccountMoveLine, lines_with_pricelist
+                   )._compute_price_unit()
         for line in lines_with_pricelist:
             line.with_context(
                 check_move_validity=False

--- a/account_invoice_pricelist/models/account_move.py
+++ b/account_invoice_pricelist/models/account_move.py
@@ -71,15 +71,14 @@ class AccountMoveLine(models.Model):
 
     @api.depends("quantity")
     def _compute_price_unit(self):
-        res = super()._compute_price_unit()
-        for line in self:
-            if not line.move_id.pricelist_id:
-                continue
+        lines_without_pricelist = self.filtered(lambda l: not l.move_id.pricelist_id)
+        lines_with_pricelist = self - lines_without_pricelist
+        res = super(AccountMoveLine, lines_with_pricelist)._compute_price_unit()
+        for line in lines_with_pricelist:
             line.with_context(
                 check_move_validity=False
             ).price_unit = line._get_price_with_pricelist()
         return res
-
     def _calculate_discount(self, base_price, final_price):
         discount = 0.0
         if base_price > 0.0:

--- a/account_invoice_pricelist/models/account_move.py
+++ b/account_invoice_pricelist/models/account_move.py
@@ -81,6 +81,7 @@ class AccountMoveLine(models.Model):
                 check_move_validity=False
             ).price_unit = line._get_price_with_pricelist()
         return res
+
     def _calculate_discount(self, base_price, final_price):
         discount = 0.0
         if base_price > 0.0:

--- a/account_invoice_pricelist/models/account_move.py
+++ b/account_invoice_pricelist/models/account_move.py
@@ -71,7 +71,7 @@ class AccountMoveLine(models.Model):
 
     @api.depends("quantity")
     def _compute_price_unit(self):
-        lines_without_pricelist = self.filtered(lambda l: not l.move_id.pricelist_id)
+        lines_without_pricelist = self.filtered(lambda line: not line.move_id.pricelist_id)
         lines_with_pricelist = self - lines_without_pricelist
         res = super(AccountMoveLine, lines_with_pricelist)._compute_price_unit()
         for line in lines_with_pricelist:


### PR DESCRIPTION
Super is called too early and put 0 in price when there's no pricelist (i.e. negative purchase invoicing)