### PR TITLE
[FIX] account_invoice_supplier_ref_unique: conservar ref de proveedor…

### DIFF
--- a/account_invoice_supplier_ref_unique/models/account_move.py
+++ b/account_invoice_supplier_ref_unique/models/account_move.py
@@ -59,12 +59,22 @@ class AccountMove(models.Model):
 
     def _reverse_moves(self, default_values_list=None, cancel=False):
         # OVERRIDE
+        # Blank the copied "ref" on purchase document reversals, except when it
+        # matches a supplier invoice number provided in the context. Blanking
+        # protects no invariant here: the uniqueness constraint is on
+        # supplier_invoice_number (copy=False), not on ref. A caller may set the
+        # ref on purpose through that context key (e.g. the SII refund wizard in
+        # l10n_es_aeat_sii_oca, which requires it on the credit note); wiping it
+        # would break the reversal. The check is per move so an unrelated move
+        # in the same batch is still blanked as before.
+        context_ref = self.env.context.get("supplier_invoice_number")
         if default_values_list:
             for move, default_values in zip(self, default_values_list):
                 if (
                     move
                     and move.is_purchase_document(include_receipts=True)
                     and default_values.get("ref")
+                    and default_values.get("ref") != context_ref
                 ):
                     default_values.update({"ref": ""})
         return super()._reverse_moves(
@@ -73,8 +83,11 @@ class AccountMove(models.Model):
 
     def copy(self, default=None):
         """
-        The unique vendor invoice number is not copied in vendor bills
+        The unique vendor invoice number is not copied in vendor bills,
+        unless a supplier invoice number was deliberately provided in context.
         """
-        if self.is_purchase_document(include_receipts=True):
+        if self.is_purchase_document(
+            include_receipts=True
+        ) and not self.env.context.get("supplier_invoice_number"):
             default = dict(default or {}, ref="")
         return super().copy(default)

--- a/account_invoice_supplier_ref_unique/tests/test_account_invoice_supplier_ref_unique.py
+++ b/account_invoice_supplier_ref_unique/tests/test_account_invoice_supplier_ref_unique.py
@@ -113,3 +113,43 @@ class TestAccountInvoiceSupplierRefUnique(AccountTestInvoicingCommon):
     def test_reverse_moves_robustness(self):
         res = self.invoice._reverse_moves()
         self.assertTrue(res.is_purchase_document(include_receipts=True))
+
+    def test_reverse_moves_keeps_context_supplier_ref(self):
+        """Simulate the SII refund flow: l10n_es_aeat_sii_oca reads the
+        supplier invoice number from context and sets it in ``default_values``
+        before calling super(). That deliberately-set ``ref`` must survive
+        instead of being blanked on the vendor credit note. Reproduced here
+        without depending on l10n_es_aeat_sii_oca by injecting both the context
+        key and the ref, exactly as that module does."""
+        refund = self.invoice.with_context(
+            supplier_invoice_number="REF-REFUND-001"
+        )._reverse_moves([{"ref": "REF-REFUND-001"}])
+        self.assertEqual(refund.ref, "REF-REFUND-001")
+
+    def test_copy_keeps_context_supplier_ref(self):
+        """copy() must keep a ref deliberately provided in context."""
+        invoice2 = self.invoice.with_context(
+            supplier_invoice_number="REF-COPY-001"
+        ).copy({"ref": "REF-COPY-001"})
+        self.assertEqual(invoice2.ref, "REF-COPY-001")
+
+    def test_reverse_moves_batch_only_matching_move_keeps_ref(self):
+        """The guard is per move: in a mixed batch only the move whose ref
+        matches the context-provided supplier invoice number keeps it; an
+        unrelated move reverted in the same batch is still blanked."""
+        invoice2 = self.account_move.create(
+            {
+                "partner_id": self.partner.id,
+                "invoice_date": fields.Date.today(),
+                "move_type": "in_invoice",
+                "supplier_invoice_number": "DEF456",
+                "invoice_line_ids": [(0, 0, {"partner_id": self.partner.id})],
+            }
+        )
+        moves = self.invoice + invoice2
+        refunds = moves.with_context(
+            supplier_invoice_number="REF-REFUND-001"
+        )._reverse_moves([{"ref": "REF-REFUND-001"}, {"ref": "Reversal of: BILL"}])
+        by_source = {r.reversed_entry_id.id: r for r in refunds}
+        self.assertEqual(by_source[self.invoice.id].ref, "REF-REFUND-001")
+        self.assertEqual(by_source[invoice2.id].ref, "")


### PR DESCRIPTION
… fijado a propósito

Los overrides de `_reverse_moves` y `copy` vacían `ref` de forma incondicional en rectificativas/copias de documentos de compra. Ese borrado no protege la restricción de unicidad (que opera sobre `supplier_invoice_number`, `copy=False`) y destruye el nº de factura de proveedor que un llamador fija deliberadamente por contexto — p. ej. el asistente de rectificativa de `l10n_es_aeat_sii_oca`, que lo recoge por adelantado y lo exige al validar (rompía toda rectificativa de proveedor con SII tras instalarse ambos módulos juntos).

Se añade un guard: no vaciar `ref` cuando el contexto trae `supplier_invoice_number`. Fuera de ese flujo el comportamiento es idéntico (las rectificativas/copias sin esa clave siguen naciendo con `ref` vacío).