### PR TITLE
[18.0][FIX] product_customerinfo_invoice: move partner_show_customer_code to account.move to prevent invoice view error

### DIFF
--- a/product_customerinfo_invoice/models/__init__.py
+++ b/product_customerinfo_invoice/models/__init__.py
@@ -1,1 +1,2 @@
+from . import account_move
 from . import account_move_line

--- a/product_customerinfo_invoice/models/account_move.py
+++ b/product_customerinfo_invoice/models/account_move.py
@@ -1,0 +1,17 @@
+# Copyright 2026 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, fields, models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    partner_show_customer_code = fields.Boolean(
+        compute="_compute_partner_show_customer_code"
+    )
+
+    @api.depends("move_type")
+    def _compute_partner_show_customer_code(self):
+        for move in self:
+            move.partner_show_customer_code = move.is_sale_document()

--- a/product_customerinfo_invoice/models/account_move_line.py
+++ b/product_customerinfo_invoice/models/account_move_line.py
@@ -9,23 +9,18 @@ from odoo import api, fields, models
 class AccountInvoiceLine(models.Model):
     _inherit = "account.move.line"
 
-    @api.depends("product_id")
+    product_customer_code = fields.Char(
+        compute="_compute_product_customer_code",
+    )
+
+    @api.depends(
+        "product_id", "move_id.partner_id", "move_id.partner_show_customer_code"
+    )
     def _compute_product_customer_code(self):
         for line in self:
-            if line.product_id and line.partner_show_customer_code:
+            if line.product_id and line.move_id.partner_show_customer_code:
                 product = line.product_id
                 code_id = product._select_customerinfo(partner=line.move_id.partner_id)
                 line.product_customer_code = code_id.product_code or ""
             else:
                 line.product_customer_code = ""
-
-    product_customer_code = fields.Char(
-        compute="_compute_product_customer_code",
-    )
-    partner_show_customer_code = fields.Boolean(
-        compute="_compute_partner_show_customer_code"
-    )
-
-    def _compute_partner_show_customer_code(self):
-        for rec in self:
-            rec.partner_show_customer_code = rec.move_id.is_sale_document()

--- a/product_customerinfo_invoice/tests/test_product_customerinfo_invoice.py
+++ b/product_customerinfo_invoice/tests/test_product_customerinfo_invoice.py
@@ -33,14 +33,17 @@ class TestProductCustomerInfoInvoice(TransactionCase):
         )
 
     @classmethod
-    def _create_invoice(cls, customer):
+    def _create_invoice(cls, customer, move_type="out_invoice"):
+        journal_type = (
+            "sale" if move_type in ("out_invoice", "out_refund") else "purchase"
+        )
         return cls.move_model.create(
             {
                 "journal_id": cls.env["account.journal"]
-                .search([("type", "=", "sale")], limit=1)
+                .search([("type", "=", journal_type)], limit=1)
                 .id,
                 "partner_id": customer.id,
-                "move_type": "out_invoice",
+                "move_type": move_type,
                 "invoice_line_ids": [
                     Command.create(
                         {
@@ -77,3 +80,12 @@ class TestProductCustomerInfoInvoice(TransactionCase):
         )
         self.assertEqual(len(line_no_product), 1)
         self.assertFalse(line_no_product.product_customer_code)
+
+    def test_03_partner_show_customer_code(self):
+        invoice = self._create_invoice(self.customer_1)
+        self.assertTrue(invoice.partner_show_customer_code)
+        bill = self._create_invoice(self.customer_1, move_type="in_invoice")
+        self.assertFalse(bill.partner_show_customer_code)
+        bill_line = bill.invoice_line_ids.filtered(lambda il: il.product_id)
+        self.assertEqual(len(bill_line), 1)
+        self.assertFalse(bill_line.product_customer_code)

--- a/product_customerinfo_invoice/views/account_move_view.xml
+++ b/product_customerinfo_invoice/views/account_move_view.xml
@@ -13,14 +13,16 @@
         <field name="inherit_id" ref="account.view_move_form" />
         <field eval="16" name="priority" />
         <field name="arch" type="xml">
+            <xpath expr="//field[@name='invoice_line_ids']" position="before">
+                <field name="partner_show_customer_code" invisible="1" />
+            </xpath>
             <xpath
                 expr="//field[@name='invoice_line_ids']/list/field[@name='product_id']"
                 position="after"
             >
-                <field name="partner_show_customer_code" column_invisible="True" />
                 <field
                     name="product_customer_code"
-                    column_invisible="not partner_show_customer_code"
+                    column_invisible="not parent.partner_show_customer_code"
                 />
             </xpath>
         </field>


### PR DESCRIPTION
Error that is raised when opening invoice view:

OwlError: The following error occurred in onWillRender: "Can not evaluate python expression: (bool(not partner_show_customer_code)) Error: Name 'partner_show_customer_code' is not defined" Error
