### PR TITLE
[IMP] stock_account_move_reset_to_draft: Allow advanced users to reset the vendor bill

### DIFF
--- a/stock_account_move_reset_to_draft/README.rst
+++ b/stock_account_move_reset_to_draft/README.rst
@@ -37,6 +37,10 @@ when an SVL (Stock Valuation Layer) record is created due to a price difference 
 when inventory from the receipt has yet to be consumed.
 When a vendor bill is reset to draft, as applicable, a new SVL record is generated to offset the valuation difference that was generated upon the bill's confirmation.
 
+This module allows advanced accounting users to reset the vendor bill to draft
+even if the products have been consumed as they often need it to correct other information
+than prices or quantities.
+
 **Table of contents**
 
 .. contents::
@@ -57,6 +61,12 @@ an SVL record is generated, locking the vendor bill. If a user then realizes a
 mistake, such as processing the bill for the incorrect purchase order, they are
 unable to cancel it.
 
+Configuration
+=============
+
+- Add advanced accounting users to the `Allowed to Force Account Moves to Draft (without stock valuations updates)`
+  user group in order to force the vendor bills with modified stock valuations.
+
 Usage
 =====
 
@@ -71,6 +81,12 @@ Usage
 When attempting to reset an invoice to draft for a product that has been partially or fully consumed, 
 the system will display the following error message: "The inventory has already been (partially) consumed."
 In that case, consider using landed costs to adjust the valuation of the product as necessary.
+
+When advanced user in the `Allowed to Force Account Moves to Draft (without stock valuations updates)`
+user group try to reset the vendro bill to draft that has already modified stock valuations,
+it will display a popup with the concerned moves in order to pay attention to them and
+to be sure they want to do it. With that flow, no revert stock valuations are generated at
+reset to draft nor during the revalidation.
 
 Bug Tracker
 ===========
@@ -102,6 +118,10 @@ Contributors
 
   * Yoshi Tashiro
   * Aung Ko Ko Lin
+
+* `Acsone <https://acsone.eu>`_:
+
+  * Denis Roussel <denis.roussel@acsone.eu>
 
 Maintainers
 ~~~~~~~~~~~

--- a/stock_account_move_reset_to_draft/__init__.py
+++ b/stock_account_move_reset_to_draft/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from . import wizards

--- a/stock_account_move_reset_to_draft/__manifest__.py
+++ b/stock_account_move_reset_to_draft/__manifest__.py
@@ -11,4 +11,9 @@
     "category": "Warehouse Management",
     "installable": True,
     "maintainers": ["victoralmau"],
+    "data": [
+        "security/security.xml",
+        "views/account_move.xml",
+        "wizards/stock_account_move_reset_to_draft.xml",
+    ],
 }

--- a/stock_account_move_reset_to_draft/models/__init__.py
+++ b/stock_account_move_reset_to_draft/models/__init__.py
@@ -1,3 +1,4 @@
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import account_move
+from . import account_move_line

--- a/stock_account_move_reset_to_draft/models/account_move.py
+++ b/stock_account_move_reset_to_draft/models/account_move.py
@@ -1,63 +1,120 @@
 # Copyright 2024 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-
-from odoo import _, models
-from odoo.exceptions import UserError
-from odoo.tools.float_utils import float_is_zero
+from odoo import _, api, fields, models
+from odoo.exceptions import AccessError, ValidationError
+from odoo.fields import Command
+from odoo.tools.safe_eval import safe_eval
 
 
 class AccountMove(models.Model):
     _inherit = "account.move"
 
+    dont_regenerate_valuation = fields.Boolean(
+        help="This is a technical field that will be set when resetting the account "
+        "move to draft in order to not regenerate stock valuations at revalidation."
+    )
+
+    def _get_reset_to_draft_wizard(
+        self, move_line_consumed_soft_ids=False, move_line_intertwined_soft_ids=False
+    ):
+        """
+        Returns the wizard to reset account move to draft by showing the lines
+        that have been consumed or intertwined.
+        """
+        if not move_line_consumed_soft_ids:
+            move_line_consumed_soft_ids = self.line_ids.browse()
+        if not move_line_intertwined_soft_ids:
+            move_line_intertwined_soft_ids = self.line_ids.browse()
+        action = self.env["ir.actions.actions"]._for_xml_id(
+            "stock_account_move_reset_to_draft.stock_account_move_reset_to_draft_act_window"
+        )
+        context = action.get("context", "{}")
+        context = safe_eval(context)
+        context.update(
+            {
+                "default_consumed_move_line_ids": [
+                    Command.set(move_line_consumed_soft_ids.ids)
+                ],
+                "default_intertwined_move_line_ids": [
+                    Command.set(move_line_intertwined_soft_ids.ids)
+                ],
+            }
+        )
+        action["context"] = context
+        return action
+
+    def _force_reset_to_draft(self):
+        """
+        This will force the reset to draft (called by the wizard).
+
+        Check if user has rights to do it.
+
+        Set the flag to not regenerate the valuations at revalidation.
+        """
+        if not self._has_right_to_reset_to_draft():
+            raise AccessError(_("You don't have rights to reset move to draft."))
+        if any(move.state != "posted" for move in self):
+            raise ValidationError(
+                _("You cannot force account move to Draft if it is not Posted")
+            )
+        self.write({"dont_regenerate_valuation": True})
+        return super().button_draft()
+
+    @api.model
+    def _has_right_to_reset_to_draft(self) -> bool:
+        return self.env.user.has_group(
+            "stock_account_move_reset_to_draft.group_stock_move_force_reset_to_draft"
+        )
+
     def button_draft(self):
         """If it is a purchase invoice, we will create a new SVL for each line with
         the sum of the value in opposite sign.
         """
-        for item in self.sudo().filtered(
+        moves_to_check = self.sudo().filtered(
             lambda x: x.is_inbound
             and any(line.stock_valuation_layer_ids for line in x.line_ids)
-        ):
-            for line in item.line_ids.filtered("stock_valuation_layer_ids"):
-                origin_svls = line.stock_valuation_layer_ids.stock_valuation_layer_id
-                if (
-                    len(
-                        origin_svls.stock_valuation_layer_ids.account_move_line_id.filtered(
-                            lambda x: x.parent_state == "posted"
-                        )
-                    )
-                    > 1
-                ):
-                    raise UserError(
-                        _(
-                            "Inventory valuation records are intertwined for %(line_name)s.",
-                            line_name=line.display_name,
-                        )
-                    )
-                for origin_svl in origin_svls:
-                    if origin_svl.quantity != origin_svl.remaining_qty:
-                        raise UserError(
-                            _(
-                                "The inventory has already been (partially) consumed "
-                                "for %(line_name)s.",
-                                line_name=line.display_name,
-                            )
-                        )
-                    svls = origin_svl.stock_valuation_layer_ids.filtered(
-                        "account_move_line_id"
-                    )
-                    value = sum(svls.mapped("value"))
-                    if not float_is_zero(
-                        value, precision_rounding=line.currency_id.rounding
-                    ):
-                        origin_svl.remaining_value -= value
-                        revert_svl = svls[0].copy({"value": -value})
-                        revert_svl._validate_accounting_entries()
-                product = line.product_id.with_company(item.company_id.id)
-                if product.cost_method == "average":
-                    product.sudo().with_context(disable_auto_svl=True).write(
-                        {"standard_price": product.value_svl / product.quantity_svl}
-                    )
+        )
+        if not moves_to_check:
+            return super().button_draft()
+        line_model = self.env["account.move.line"].browse()
+        soft = self._has_right_to_reset_to_draft()
+        move_line_intertwined_ids = move_line_consumed_ids = line_model
+
+        # Look for problems in stack valuation
+        # If no problem, do the valuation revert in order to be revalidated after
+        # If the user has no rights to force the reset, raise errors.
+        # If the user has rights to force the reset, warn through a wizard and let
+        # the user decides if he reset or not.
+        for item in moves_to_check:
+            lines_with_valuation = item.line_ids.filtered("stock_valuation_layer_ids")
+            move_line_intertwined_ids = (
+                lines_with_valuation._check_intertwined_valuation_at_draft(soft)
+            )
+            move_line_consumed_ids = (
+                lines_with_valuation._check_consumed_valuation_at_draft(soft)
+            )
+            if not move_line_consumed_ids and not move_line_intertwined_ids:
+                lines_with_valuation._revert_stock_valuation_at_draft()
+        if soft and (move_line_consumed_ids or move_line_intertwined_ids):
+            return self._get_reset_to_draft_wizard(
+                move_line_consumed_ids, move_line_intertwined_ids
+            )
         return super().button_draft()
+
+    def _post(self, soft=True):
+        """
+        Validate account move without regenerating stock valuations.
+        """
+        moves_without_valuation = self.filtered(
+            "dont_regenerate_valuation"
+        ).with_context(move_reverse_cancel=True)
+        if moves_without_valuation:
+            moves = super(AccountMove, moves_without_valuation)._post(soft=soft)
+            moves_without_valuation.dont_regenerate_valuation = False
+            return moves | super(AccountMove, (self - moves_without_valuation))._post(
+                soft=soft
+            )
+        return super()._post(soft=soft)
 
     def _compute_show_reset_to_draft_button(self):
         """Overwrite the value only if it is already posted and with SVLs.

--- a/stock_account_move_reset_to_draft/models/account_move.py
+++ b/stock_account_move_reset_to_draft/models/account_move.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Tecnativa - Víctor Martínez
+# Copyright 2026 ACSONE SA/NV (https://acsone.eu)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import _, api, fields, models
 from odoo.exceptions import AccessError, ValidationError

--- a/stock_account_move_reset_to_draft/models/account_move_line.py
+++ b/stock_account_move_reset_to_draft/models/account_move_line.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Tecnativa - Víctor Martínez
+# Copyright 2026 ACSONE SA/NV (https://acsone.eu)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import _, models
 from odoo.exceptions import UserError
@@ -17,25 +18,27 @@ class AccountMoveLine(models.Model):
         Raise an error if the user has no rights to force the reset to draft,
         else, returns the concerned line.
         """
-        self.ensure_one()
-        origin_svls = self.stock_valuation_layer_ids.stock_valuation_layer_id
-        if (
-            len(
-                origin_svls.stock_valuation_layer_ids.account_move_line_id.filtered(
-                    lambda x: x.parent_state == "posted"
+        intertwined_lines = self.browse()
+        for line in self:
+            origin_svls = line.stock_valuation_layer_ids.stock_valuation_layer_id
+            if (
+                len(
+                    origin_svls.stock_valuation_layer_ids.account_move_line_id.filtered(
+                        lambda x: x.parent_state == "posted"
+                    )
                 )
-            )
-            > 1
-        ):
-            if soft:
-                return self
-            raise UserError(
-                _(
-                    "Inventory valuation records are intertwined for %(line_name)s.",
-                    line_name=self.display_name,
-                )
-            )
-        return self.browse()
+                > 1
+            ):
+                if soft:
+                    intertwined_lines |= line
+                else:
+                    raise UserError(
+                        _(
+                            "Inventory valuation records are intertwined for %(line_name)s.",
+                            line_name=self.display_name,
+                        )
+                    )
+        return intertwined_lines
 
     def _check_consumed_valuation_at_draft(self, soft=False) -> MoveLine:
         """

--- a/stock_account_move_reset_to_draft/models/account_move_line.py
+++ b/stock_account_move_reset_to_draft/models/account_move_line.py
@@ -1,0 +1,89 @@
+# Copyright 2024 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import _, models
+from odoo.exceptions import UserError
+from odoo.tools.float_utils import float_is_zero
+
+from odoo.addons.account.models.account_move_line import AccountMoveLine as MoveLine
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    def _check_intertwined_valuation_at_draft(self, soft=False) -> MoveLine:
+        """
+        This will check if stock valuations are not intertwined.
+
+        Raise an error if the user has no rights to force the reset to draft,
+        else, returns the concerned line.
+        """
+        self.ensure_one()
+        origin_svls = self.stock_valuation_layer_ids.stock_valuation_layer_id
+        if (
+            len(
+                origin_svls.stock_valuation_layer_ids.account_move_line_id.filtered(
+                    lambda x: x.parent_state == "posted"
+                )
+            )
+            > 1
+        ):
+            if soft:
+                return self
+            raise UserError(
+                _(
+                    "Inventory valuation records are intertwined for %(line_name)s.",
+                    line_name=self.display_name,
+                )
+            )
+        return self.browse()
+
+    def _check_consumed_valuation_at_draft(self, soft=False) -> MoveLine:
+        """
+        Check if the incoming valuations haven't been consumed already.
+
+        If the user has no rights to force the reset to draft, raises an error,
+        else, return the concerned lines.
+        """
+        lines_with_consumed_values = self.browse()
+        for line in self:
+            origin_svls = line.stock_valuation_layer_ids.stock_valuation_layer_id
+            for origin_svl in origin_svls:
+                if origin_svl.quantity != origin_svl.remaining_qty:
+                    if soft:
+                        lines_with_consumed_values |= line
+                        continue
+                    raise UserError(
+                        _(
+                            "The inventory has already been (partially) consumed "
+                            "for %(line_name)s.",
+                            line_name=line.display_name,
+                        )
+                    )
+        return lines_with_consumed_values
+
+    def _revert_stock_valuation_at_draft(self):
+        """
+        If products having valuation layers linked to this account move line
+        haven't been consumed, revert them
+        in order to be regenerated at account move post.
+        """
+        for line in self:
+            origin_svls = line.stock_valuation_layer_ids.stock_valuation_layer_id
+            revert_stock_valuation_layers = self.env["stock.valuation.layer"].browse()
+            for origin_svl in origin_svls:
+                svls = origin_svl.stock_valuation_layer_ids.filtered(
+                    "account_move_line_id"
+                )
+                value = sum(svls.mapped("value"))
+                if not float_is_zero(
+                    value, precision_rounding=line.currency_id.rounding
+                ):
+                    origin_svl.remaining_value -= value
+                    revert_stock_valuation_layers |= svls[0].copy({"value": -value})
+            if revert_stock_valuation_layers:
+                revert_stock_valuation_layers._validate_accounting_entries()
+            product = line.product_id.with_company(line.move_id.company_id.id)
+            if product.cost_method == "average":
+                product.sudo().with_context(disable_auto_svl=True).write(
+                    {"standard_price": product.value_svl / product.quantity_svl}
+                )

--- a/stock_account_move_reset_to_draft/readme/CONFIGURE.rst
+++ b/stock_account_move_reset_to_draft/readme/CONFIGURE.rst
@@ -1,0 +1,2 @@
+- Add advanced accounting users to the `Allowed to Force Account Moves to Draft (without stock valuations updates)`
+  user group in order to force the vendor bills with modified stock valuations.

--- a/stock_account_move_reset_to_draft/readme/CONTRIBUTORS.rst
+++ b/stock_account_move_reset_to_draft/readme/CONTRIBUTORS.rst
@@ -7,3 +7,7 @@
 
   * Yoshi Tashiro
   * Aung Ko Ko Lin
+
+* `Acsone <https://acsone.eu>`_:
+
+  * Denis Roussel <denis.roussel@acsone.eu>

--- a/stock_account_move_reset_to_draft/readme/DESCRIPTION.rst
+++ b/stock_account_move_reset_to_draft/readme/DESCRIPTION.rst
@@ -2,3 +2,7 @@ This module allows a vendor bill to be reverted to draft status even
 when an SVL (Stock Valuation Layer) record is created due to a price difference between the receipt and the vendor bill,
 when inventory from the receipt has yet to be consumed.
 When a vendor bill is reset to draft, as applicable, a new SVL record is generated to offset the valuation difference that was generated upon the bill's confirmation.
+
+This module allows advanced accounting users to reset the vendor bill to draft
+even if the products have been consumed as they often need it to correct other information
+than prices or quantities.

--- a/stock_account_move_reset_to_draft/readme/USAGE.rst
+++ b/stock_account_move_reset_to_draft/readme/USAGE.rst
@@ -9,3 +9,9 @@
 When attempting to reset an invoice to draft for a product that has been partially or fully consumed, 
 the system will display the following error message: "The inventory has already been (partially) consumed."
 In that case, consider using landed costs to adjust the valuation of the product as necessary.
+
+When advanced user in the `Allowed to Force Account Moves to Draft (without stock valuations updates)`
+user group try to reset the vendro bill to draft that has already modified stock valuations,
+it will display a popup with the concerned moves in order to pay attention to them and
+to be sure they want to do it. With that flow, no revert stock valuations are generated at
+reset to draft nor during the revalidation.

--- a/stock_account_move_reset_to_draft/security/security.xml
+++ b/stock_account_move_reset_to_draft/security/security.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- Copyright 2026 ACSONE SA/NV
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="group_stock_move_force_reset_to_draft" model="res.groups">
+        <field
+            name="name"
+        >Allowed to Force Account Moves to Draft (without stock valuations updates)</field>
+        <field name="category_id" ref="base.module_category_accounting_accounting" />
+    </record>
+
+    <record id="stock_move_force_reset_to_draft_wizard_access" model="ir.model.access">
+        <field name="name">stock_move_force_reset_to_draft_wizard_access</field>
+        <field name="model_id" ref="model_stock_account_move_reset_to_draft" />
+        <field
+            name="group_id"
+            ref="stock_account_move_reset_to_draft.group_stock_move_force_reset_to_draft"
+        />
+        <field name="perm_read" eval="1" />
+        <field name="perm_create" eval="1" />
+        <field name="perm_write" eval="1" />
+        <field name="perm_unlink" eval="1" />
+    </record>
+
+</odoo>

--- a/stock_account_move_reset_to_draft/static/description/index.html
+++ b/stock_account_move_reset_to_draft/static/description/index.html
@@ -379,16 +379,20 @@ ul.auto-toc {
 when an SVL (Stock Valuation Layer) record is created due to a price difference between the receipt and the vendor bill,
 when inventory from the receipt has yet to be consumed.
 When a vendor bill is reset to draft, as applicable, a new SVL record is generated to offset the valuation difference that was generated upon the bill’s confirmation.</p>
+<p>This module allows advanced accounting users to reset the vendor bill to draft
+even if the products have been consumed as they often need it to correct other information
+than prices or quantities.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
 <li><a class="reference internal" href="#use-cases-context" id="toc-entry-1">Use Cases / Context</a></li>
-<li><a class="reference internal" href="#usage" id="toc-entry-2">Usage</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-3">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-4">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-5">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-6">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-7">Maintainers</a></li>
+<li><a class="reference internal" href="#configuration" id="toc-entry-2">Configuration</a></li>
+<li><a class="reference internal" href="#usage" id="toc-entry-3">Usage</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-4">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-5">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-6">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-7">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-8">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -406,8 +410,15 @@ an SVL record is generated, locking the vendor bill. If a user then realizes a
 mistake, such as processing the bill for the incorrect purchase order, they are
 unable to cancel it.</p>
 </div>
+<div class="section" id="configuration">
+<h2><a class="toc-backref" href="#toc-entry-2">Configuration</a></h2>
+<ul class="simple">
+<li>Add advanced accounting users to the <cite>Allowed to Force Account Moves to Draft (without stock valuations updates)</cite>
+user group in order to force the vendor bills with modified stock valuations.</li>
+</ul>
+</div>
 <div class="section" id="usage">
-<h2><a class="toc-backref" href="#toc-entry-2">Usage</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-3">Usage</a></h2>
 <ol class="arabic simple">
 <li>Create a product category with Costing Method: Average Cost (AVCO) or First In First Out (FIFO).</li>
 <li>Create a product linked to the category created before.</li>
@@ -420,9 +431,14 @@ unable to cancel it.</p>
 <p>When attempting to reset an invoice to draft for a product that has been partially or fully consumed,
 the system will display the following error message: “The inventory has already been (partially) consumed.”
 In that case, consider using landed costs to adjust the valuation of the product as necessary.</p>
+<p>When advanced user in the <cite>Allowed to Force Account Moves to Draft (without stock valuations updates)</cite>
+user group try to reset the vendro bill to draft that has already modified stock valuations,
+it will display a popup with the concerned moves in order to pay attention to them and
+to be sure they want to do it. With that flow, no revert stock valuations are generated at
+reset to draft nor during the revalidation.</p>
 </div>
 <div class="section" id="bug-tracker">
-<h2><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-4">Bug Tracker</a></h2>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/account-invoicing/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -430,15 +446,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h2><a class="toc-backref" href="#toc-entry-4">Credits</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-5">Credits</a></h2>
 <div class="section" id="authors">
-<h3><a class="toc-backref" href="#toc-entry-5">Authors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-6">Authors</a></h3>
 <ul class="simple">
 <li>Tecnativa</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h3><a class="toc-backref" href="#toc-entry-6">Contributors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-7">Contributors</a></h3>
 <ul class="simple">
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
 <li>Víctor Martínez</li>
@@ -450,10 +466,14 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Aung Ko Ko Lin</li>
 </ul>
 </li>
+<li><a class="reference external" href="https://acsone.eu">Acsone</a>:<ul>
+<li>Denis Roussel &lt;<a class="reference external" href="mailto:denis.roussel&#64;acsone.eu">denis.roussel&#64;acsone.eu</a>&gt;</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h3><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h3>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />

--- a/stock_account_move_reset_to_draft/tests/test_stock_account_move_reset_to_draft.py
+++ b/stock_account_move_reset_to_draft/tests/test_stock_account_move_reset_to_draft.py
@@ -240,6 +240,42 @@ class TestStockAccountMoveResetToDraft(BaseCommon):
         self.assertFalse(invoice.dont_regenerate_valuation)
 
     @mute_logger("odoo.models.unlink")
+    def test_purchase_order_consume_error(self):
+        order = self.create_and_confirm_order(price=10, qty=1)
+        self.process_picking(order.picking_ids)
+        invoice = self.create_and_post_invoice(order, price=12, qty=1)
+        self.assertEqual(
+            sum(invoice.invoice_line_ids.mapped("stock_valuation_layer_ids.value")), 2
+        )
+        # Create an outgoing move
+        move = self.env["stock.move"].create(
+            {
+                "name": self.product.name,
+                "product_id": self.product.id,
+                "product_uom": self.product.uom_id.id,
+                "location_id": order.picking_ids.location_dest_id.id,
+                "location_dest_id": self.env.ref("stock.stock_location_customers").id,
+                "product_uom_qty": 1.0,
+            }
+        )
+        move._action_confirm()
+        move._action_assign()
+        self.assertEqual(
+            "assigned",
+            move.state,
+        )
+        move.move_line_ids.qty_done = 1.0
+        move._action_done()
+
+        with self.assertRaises(UserError) as error:
+            invoice.button_draft()
+        invoice_name = invoice.invoice_line_ids.display_name
+        self.assertEqual(
+            error.exception.args[0],
+            f"The inventory has already been (partially) consumed for {invoice_name}.",
+        )
+
+    @mute_logger("odoo.models.unlink")
     def test_purchase_order_flow_wizard_intertwined(self):
         self.env.user.groups_id |= self.group
         # PO for a product: 2 pcs at EUR10

--- a/stock_account_move_reset_to_draft/tests/test_stock_account_move_reset_to_draft.py
+++ b/stock_account_move_reset_to_draft/tests/test_stock_account_move_reset_to_draft.py
@@ -37,6 +37,9 @@ class TestStockAccountMoveResetToDraft(BaseCommon):
             }
         )
         cls.partner = cls.env["res.partner"].create({"name": "Test partner"})
+        cls.group = cls.env.ref(
+            "stock_account_move_reset_to_draft.group_stock_move_force_reset_to_draft"
+        )
 
     def create_and_confirm_order(self, price=10, qty=1):
         order_form = Form(self.env["purchase.order"])
@@ -183,4 +186,120 @@ class TestStockAccountMoveResetToDraft(BaseCommon):
         self.assertEqual(invoice.state, "draft")
         self.assertEqual(
             sum(invoice.invoice_line_ids.mapped("stock_valuation_layer_ids.value")), 0
+        )
+
+    @mute_logger("odoo.models.unlink")
+    def test_purchase_order_flow_wizard(self):
+        self.env.user.groups_id |= self.group
+        order = self.create_and_confirm_order(price=10, qty=1)
+        self.process_picking(order.picking_ids)
+        invoice = self.create_and_post_invoice(order, price=12, qty=1)
+        self.assertEqual(
+            sum(invoice.invoice_line_ids.mapped("stock_valuation_layer_ids.value")), 2
+        )
+        # Create an outgoing move
+        move = self.env["stock.move"].create(
+            {
+                "name": self.product.name,
+                "product_id": self.product.id,
+                "product_uom": self.product.uom_id.id,
+                "location_id": order.picking_ids.location_dest_id.id,
+                "location_dest_id": self.env.ref("stock.stock_location_customers").id,
+                "product_uom_qty": 1.0,
+            }
+        )
+        move._action_confirm()
+        move._action_assign()
+        self.assertEqual(
+            "assigned",
+            move.state,
+        )
+        move.move_line_ids.qty_done = 1.0
+        move._action_done()
+
+        result = invoice.button_draft()
+        wizard_model = "stock.account.move.reset.to.draft"
+        self.assertEqual(wizard_model, result.get("res_model"))
+        context = result.get("context")
+        wizard = self.env[wizard_model].with_context(**context).create({})
+
+        wizard.doit()
+
+        # Valuations haven't changed
+        self.assertEqual(invoice.state, "draft")
+        self.assertEqual(
+            sum(invoice.invoice_line_ids.mapped("stock_valuation_layer_ids.value")), 2.0
+        )
+
+        # Revalidate invoice
+        invoice._post()
+        self.assertEqual(invoice.state, "posted")
+        self.assertEqual(
+            sum(invoice.invoice_line_ids.mapped("stock_valuation_layer_ids.value")), 2.0
+        )
+        self.assertFalse(invoice.dont_regenerate_valuation)
+
+    @mute_logger("odoo.models.unlink")
+    def test_purchase_order_flow_wizard_intertwined(self):
+        self.env.user.groups_id |= self.group
+        # PO for a product: 2 pcs at EUR10
+        order = self.create_and_confirm_order(price=10, qty=2)
+        # Receive 1 pc and create a backorder
+        picking = order.picking_ids
+        self.process_picking(picking, qty_done=1)
+        extra_picking = order.picking_ids - picking
+        self.process_picking(extra_picking)
+        invoice = self.create_and_post_invoice(order, price=12, qty=2)
+        self.assertEqual(len(invoice.invoice_line_ids.stock_valuation_layer_ids), 2)
+        svls_1 = invoice.invoice_line_ids.stock_valuation_layer_ids
+        self.assertEqual(sum(svls_1.mapped("value")), 4)
+        self.assertTrue(invoice.show_reset_to_draft_button)
+        # Reset the bill to draft
+        invoice.button_draft()
+        self.assertEqual(invoice.state, "draft")
+        # We should have done nothing
+        self.assertEqual(len(invoice.invoice_line_ids.stock_valuation_layer_ids), 4)
+        svls_1_negative = invoice.invoice_line_ids.stock_valuation_layer_ids - svls_1
+        self.assertEqual(sum(svls_1.mapped("value")), 4)
+        self.assertEqual(sum(svls_1_negative.mapped("value")), -4)
+        # Change the bill content to 1 pc at EUR15 and post
+        invoice.invoice_line_ids.write({"quantity": 1, "price_unit": 15})
+        invoice.action_post()
+        self.assertEqual(invoice.state, "posted")
+        self.assertEqual(len(invoice.invoice_line_ids.stock_valuation_layer_ids), 4)
+        # Create another bill for 1 pc at EUR8 and post
+        invoice_extra = self.create_and_post_invoice(order, price=8, qty=1)
+        self.assertEqual(
+            len(invoice_extra.invoice_line_ids.stock_valuation_layer_ids), 1
+        )
+        self.assertEqual(
+            invoice_extra.invoice_line_ids.stock_valuation_layer_ids.value, -2
+        )
+        self.assertTrue(invoice.show_reset_to_draft_button)
+        # Reset the first bill to draft -> User error to prevent valuation inconsistencies
+        result = invoice.button_draft()
+        wizard_model = "stock.account.move.reset.to.draft"
+        self.assertEqual(wizard_model, result.get("res_model"))
+        context = result.get("context")
+        wizard = self.env[wizard_model].with_context(**context).create({})
+
+        self.assertTrue(wizard.intertwined_move_line_ids)
+
+        self.assertEqual(
+            sum(invoice.invoice_line_ids.mapped("stock_valuation_layer_ids.value")), 0.0
+        )
+
+        wizard.doit()
+
+        # Valuations haven't changed
+        self.assertEqual(invoice.state, "draft")
+        self.assertEqual(
+            sum(invoice.invoice_line_ids.mapped("stock_valuation_layer_ids.value")), 0.0
+        )
+
+        # Revalidate invoice
+        invoice._post()
+        self.assertEqual(invoice.state, "posted")
+        self.assertEqual(
+            sum(invoice.invoice_line_ids.mapped("stock_valuation_layer_ids.value")), 0.0
         )

--- a/stock_account_move_reset_to_draft/views/account_move.xml
+++ b/stock_account_move_reset_to_draft/views/account_move.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 ACSONE SA/NV
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="view_move_form" model="ir.ui.view">
+        <field name="name">account.move.form</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form" />
+        <field name="arch" type="xml">
+            <header position="after">
+                <div
+                    groups="account.group_account_invoice,account.group_account_readonly"
+                    class="alert alert-warning mb-0"
+                    role="alert"
+                    attrs="{'invisible': [('dont_regenerate_valuation', '=', False)]}"
+                >
+                    <b>Stock valuations</b><br />
+                    This invoice should be validated as it has been reset to draft
+                    with existing stock valuations.
+                    <field name="dont_regenerate_valuation" invisible="1" />
+                </div>
+            </header>
+        </field>
+    </record>
+</odoo>

--- a/stock_account_move_reset_to_draft/wizards/__init__.py
+++ b/stock_account_move_reset_to_draft/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_account_move_reset_to_draft

--- a/stock_account_move_reset_to_draft/wizards/stock_account_move_reset_to_draft.py
+++ b/stock_account_move_reset_to_draft/wizards/stock_account_move_reset_to_draft.py
@@ -1,0 +1,45 @@
+# Copyright 2026 ACSONE SA/NV
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class StockAccountMoveResetToDraft(models.TransientModel):
+
+    _name = "stock.account.move.reset.to.draft"
+    _description = "Reset account move to draft"
+
+    move_ids = fields.Many2many(
+        comodel_name="account.move",
+        compute="_compute_move_ids",
+    )
+    intertwined_move_line_ids = fields.Many2many(
+        comodel_name="account.move.line",
+        column1="wizard_id",
+        column2="intertwined_move_id",
+        relation="stock_account_move_reset_to_draft_intertwined_move_line_rel",
+        ondelete="cascade",
+        required=True,
+        readonly=True,
+    )
+    consumed_move_line_ids = fields.Many2many(
+        comodel_name="account.move.line",
+        column1="wizard_id",
+        column2="consumed_line_id",
+        relation="stock_account_move_reset_to_draft_consumed_move_line_rel",
+        ondelete="cascade",
+        required=True,
+        readonly=True,
+    )
+
+    @api.depends("intertwined_move_line_ids", "consumed_move_line_ids")
+    def _compute_move_ids(self):
+        for wizard in self:
+            wizard.move_ids = (
+                wizard.consumed_move_line_ids.move_id
+                | wizard.intertwined_move_line_ids.move_id
+            )
+
+    def doit(self):
+        for wizard in self:
+            return wizard.move_ids._force_reset_to_draft()

--- a/stock_account_move_reset_to_draft/wizards/stock_account_move_reset_to_draft.py
+++ b/stock_account_move_reset_to_draft/wizards/stock_account_move_reset_to_draft.py
@@ -1,0 +1,44 @@
+# Copyright 2026 ACSONE SA/NV
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class StockAccountMoveResetToDraft(models.TransientModel):
+
+    _name = "stock.account.move.reset.to.draft"
+
+    move_ids = fields.Many2many(
+        comodel_name="account.move",
+        compute="_compute_move_ids",
+    )
+    intertwined_move_line_ids = fields.Many2many(
+        comodel_name="account.move.line",
+        column1="wizard_id",
+        column2="intertwined_move_id",
+        relation="stock_account_move_reset_to_draft_intertwined_move_line_rel",
+        ondelete="cascade",
+        required=True,
+        readonly=True,
+    )
+    consumed_move_line_ids = fields.Many2many(
+        comodel_name="account.move.line",
+        column1="wizard_id",
+        column2="consumed_line_id",
+        relation="stock_account_move_reset_to_draft_consumed_move_line_rel",
+        ondelete="cascade",
+        required=True,
+        readonly=True,
+    )
+
+    @api.depends("intertwined_move_line_ids", "consumed_move_line_ids")
+    def _compute_move_ids(self):
+        for wizard in self:
+            wizard.move_ids = (
+                wizard.consumed_move_line_ids.move_id
+                | wizard.intertwined_move_line_ids.move_id
+            )
+
+    def doit(self):
+        for wizard in self:
+            return wizard.move_ids._force_reset_to_draft()

--- a/stock_account_move_reset_to_draft/wizards/stock_account_move_reset_to_draft.xml
+++ b/stock_account_move_reset_to_draft/wizards/stock_account_move_reset_to_draft.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 ACSONE SA/NV
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record model="ir.ui.view" id="stock_account_move_reset_to_draft_form_view">
+        <field name="model">stock.account.move.reset.to.draft</field>
+        <field name="arch" type="xml">
+            <form string="Stock Account Move Reset To Draft">
+
+                    <p>
+                        The selected account moves have already stock valuations and will be reset to draft.
+                        The next validation won't regenerate those valuations.
+                    </p>
+
+                <group>
+                    <field name="intertwined_move_line_ids">
+                        <tree>
+                            <field name="move_id" />
+                            <field name="name" />
+                        </tree>
+                    </field>
+                    <field name="consumed_move_line_ids">
+                        <tree>
+                            <field name="move_id" />
+                            <field name="name" />
+                        </tree>
+                    </field>
+                </group>
+                <footer>
+                    <button
+                        name="doit"
+                        string="Reset to Draft"
+                        class="btn-primary"
+                        type="object"
+                    />
+                    <button string="Cancel" class="btn-default" special="cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record
+        model="ir.actions.act_window"
+        id="stock_account_move_reset_to_draft_act_window"
+    >
+        <field name="name">Stock Account Move Reset To Draft</field>
+        <field name="res_model">stock.account.move.reset.to.draft</field>
+        <field name="view_mode">form</field>
+        <field name="context">{}</field>
+        <field name="target">new</field>
+    </record>
+
+</odoo>


### PR DESCRIPTION


Even if there are stock valuations with modifications, some advanced accounting users may want to modify other information that do not have influence on stock valuations.

The user will be warned with a wizard about moves that are already consumed or intertwined and the vendor bill will be reset to draft without reversing stock valuations. Then, at revalidation, no stock valuations will be generated as well. This is maintained with a flag on stock move.

A warning is displayed on stock moves that have stock valuations and should be revalidated.