### PR TITLE
[19.0][FIX] account_invoice_pricelist: don't reset price_unit on vendor bills when quantity changes

### DIFF
--- a/account_invoice_pricelist/models/account_move.py
+++ b/account_invoice_pricelist/models/account_move.py
@@ -134,14 +134,20 @@ class AccountMoveLine(models.Model):
         # Reschedule price_unit on sale lines when quantity changes
         # post-create. We skip `create` so explicit `price_unit` in
         # create vals isn't clobbered by the pricelist.
+        # Also skip lines whose price_unit is protected (same write also
+        # set an explicit price) — otherwise the deferred recompute
+        # overwrites the user's price with the pricelist result (often
+        # 0 for products without a matching rule) after the write ends.
         res = super().modified(fnames, create=create, before=before)
         if "quantity" in fnames and not create:
+            price_unit_field = self._fields["price_unit"]
             sale_lines = self.filtered(
                 lambda line: line.move_id.move_type
                 in ("out_invoice", "out_refund", "out_receipt")
+                and not self.env.is_protected(price_unit_field, line)
             )
             if sale_lines:
-                self.env.add_to_compute(self._fields["price_unit"], sale_lines)
+                self.env.add_to_compute(price_unit_field, sale_lines)
         return res
 
     def _apply_pricelist_to_price_unit(self):

--- a/account_invoice_pricelist/models/account_move.py
+++ b/account_invoice_pricelist/models/account_move.py
@@ -121,10 +121,37 @@ class AccountMoveLine(models.Model):
                     # to the customer
                     line.discount = discount
 
-    @api.depends("quantity")
     def _compute_price_unit(self):
+        # `quantity` is intentionally NOT in the depends: merging it
+        # would re-fire super() on vendor bills and overwrite their
+        # PO-supplied price with `standard_price`. Quantity-driven
+        # recomputes are scheduled for sale lines only in `modified()`.
         res = super()._compute_price_unit()
+        self._apply_pricelist_to_price_unit()
+        return res
+
+    def modified(self, fnames, create=False, before=False):
+        # Reschedule price_unit on sale lines when quantity changes
+        # post-create. We skip `create` so explicit `price_unit` in
+        # create vals isn't clobbered by the pricelist.
+        res = super().modified(fnames, create=create, before=before)
+        if "quantity" in fnames and not create:
+            sale_lines = self.filtered(
+                lambda line: line.move_id.move_type
+                in ("out_invoice", "out_refund", "out_receipt")
+            )
+            if sale_lines:
+                self.env.add_to_compute(self._fields["price_unit"], sale_lines)
+        return res
+
+    def _apply_pricelist_to_price_unit(self):
         for line in self:
+            if line.move_id.move_type not in (
+                "out_invoice",
+                "out_refund",
+                "out_receipt",
+            ):
+                continue
             line = line.with_company(line.company_id)
             if not line.move_id.pricelist_id:
                 continue
@@ -142,7 +169,6 @@ class AccountMoveLine(models.Model):
                 line.with_context(
                     check_move_validity=False
                 ).price_unit = line.currency_id.round(price_unit)
-        return res
 
     def _get_display_price(self):
         """Compute the displayed unit price for a given line.

--- a/account_invoice_pricelist/tests/test_account_move_pricelist.py
+++ b/account_invoice_pricelist/tests/test_account_move_pricelist.py
@@ -475,6 +475,68 @@ class TestAccountMovePricelist(common.TransactionCase):
         bill.invoice_line_ids[:1].quantity = 1.0
         self.assertEqual(bill.invoice_line_ids[:1].price_unit, 42.00)
 
+    def test_write_quantity_and_price_unit_preserves_explicit_price(self):
+        """Saving quantity + price_unit together must keep the user's price.
+
+        Oncharging invoices often need both qty and a manual price (products
+        with no / $0 pricelist rule). Writing both in one go used to reschedule
+        price_unit from quantity via modified(), and the deferred recompute
+        then overwrote the explicit price with the pricelist result (0).
+        """
+        # sale_pricelist3 prices this product at a fixed $0 — same shape as
+        # SMS Contract/Usage products that aren't priced via the pricelist.
+        product = self.product.product_variant_ids[:1]
+        invoice = self.AccountMove.create(
+            {
+                "partner_id": self.partner.id,
+                "move_type": "out_invoice",
+                "pricelist_id": self.sale_pricelist3.id,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": product.id,
+                            "name": "SMS Contract",
+                            "quantity": 1.0,
+                            "price_unit": 5.0,
+                        },
+                    ),
+                    Command.create(
+                        {
+                            "product_id": product.id,
+                            "name": "SMS Usage",
+                            "quantity": 0.0,
+                            "price_unit": 0.0,
+                        },
+                    ),
+                ],
+            }
+        )
+        line_contract, line_usage = invoice.invoice_line_ids
+        invoice.write(
+            {
+                "invoice_line_ids": [
+                    Command.update(
+                        line_contract.id, {"quantity": 2.0, "price_unit": 5.0}
+                    ),
+                    Command.update(
+                        line_usage.id, {"quantity": 2.0, "price_unit": 0.11}
+                    ),
+                ]
+            }
+        )
+        self.assertEqual(line_contract.quantity, 2.0)
+        self.assertEqual(line_contract.price_unit, 5.0)
+        self.assertEqual(line_usage.quantity, 2.0)
+        self.assertEqual(line_usage.price_unit, 0.11)
+
+    def test_quantity_only_write_still_applies_pricelist(self):
+        """Quantity-only edits on sale invoices should still refresh price."""
+        line = self.invoice.invoice_line_ids[:1]
+        self.invoice.pricelist_id = self.sale_pricelist.id
+        line.write({"quantity": 2.0})
+        self.assertEqual(line.quantity, 2.0)
+        self.assertEqual(line.price_unit, 60.00)
+
     def test_14_calculate_discount(self):
         self.env.user.write({"group_ids": [(4, self.group_discount.id)]})
         self.product.write({"list_price": 0.00})

--- a/account_invoice_pricelist/tests/test_account_move_pricelist.py
+++ b/account_invoice_pricelist/tests/test_account_move_pricelist.py
@@ -447,6 +447,34 @@ class TestAccountMovePricelist(common.TransactionCase):
         self.assertEqual(invoice_line.price_unit, 100.00)
         self.assertEqual(invoice_line.discount, 0.00)
 
+    def test_vendor_bill_pricelist_does_not_overwrite_price_unit(self):
+        """Vendor bills must never have a sale pricelist applied: even if a
+        pricelist_id is set on an in_invoice (e.g. by a third-party module
+        or by user error), the supplied price_unit must be preserved so the
+        price brought in from the PO autocomplete or supplierinfo isn't
+        replaced by the product's list_price / standard_price.
+        """
+        bill = self.AccountMove.create(
+            {
+                "partner_id": self.partner.id,
+                "move_type": "in_invoice",
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.product.product_variant_ids[:1].id,
+                            "name": "Vendor line",
+                            "quantity": 1.0,
+                            "price_unit": 42.00,
+                        },
+                    ),
+                ],
+            }
+        )
+        bill.pricelist_id = self.sale_pricelist.id
+        bill.invoice_line_ids[:1].quantity = 0.0
+        bill.invoice_line_ids[:1].quantity = 1.0
+        self.assertEqual(bill.invoice_line_ids[:1].price_unit, 42.00)
+
     def test_14_calculate_discount(self):
         self.env.user.write({"group_ids": [(4, self.group_discount.id)]})
         self.product.write({"list_price": 0.00})


### PR DESCRIPTION
Supersedes #2329

### Problem
`account_invoice_pricelist` added `quantity` to `_compute_price_unit`'s
`@api.depends`. Depends merge across the inheritance chain, so quantity
changes re-fired `super()._compute_price_unit()` on **all** move types,
including vendor bills — overwriting the PO-supplied `price_unit` with
`standard_price`. Full write-up and reproducer: #2329.

### Fix
Drop `quantity` from the compute depends. For sale lines only, schedule a
`price_unit` recompute from `modified()` when quantity changes (so volume
pricelist rules still apply). Scope `_apply_pricelist_to_price_unit` to
sale moves.
Also skip that reschedule while `price_unit` is protected (same write set
an explicit price), so a user-entered unit price is not overwritten by the
deferred pricelist recompute.

### Tests
- `test_vendor_bill_pricelist_does_not_overwrite_price_unit`
- `test_write_quantity_and_price_unit_preserves_explicit_price`
- `test_quantity_only_write_still_applies_pricelist`