### PR TITLE
[FIX] purchase_create_bill_button: exclude zero qty lines from bill

### DIFF
--- a/purchase_create_bill_button/__manifest__.py
+++ b/purchase_create_bill_button/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Purchase Create Bill Button",
     "summary": "Add a direct button to create bills from purchase orders",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.1.0",
     "development_status": "Production/Stable",
     "category": "Accounting",
     "website": "https://github.com/OCA/account-invoicing",

--- a/purchase_create_bill_button/models/__init__.py
+++ b/purchase_create_bill_button/models/__init__.py
@@ -1,3 +1,3 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from . import models
+from . import purchase_order

--- a/purchase_create_bill_button/models/purchase_order.py
+++ b/purchase_create_bill_button/models/purchase_order.py
@@ -1,0 +1,90 @@
+# Copyright 2026 Juan Arcos MTS <j.arcos@madetosoft.com>
+# Copyright 2026 Oriol Gracia MTS <o.gracia@madetosoft.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+from odoo.exceptions import ValidationError
+from odoo.tools import groupby
+from odoo.tools.float_utils import float_is_zero
+
+
+class PurchaseOrder(models.Model):
+    _inherit = "purchase.order"
+
+    def action_create_invoice(self, attachment_ids=False):
+        precision = self.env["decimal.precision"].precision_get("Product Unit")
+
+        invoice_vals_list = []
+        sequence = 10
+        for order in self:
+            order = order.with_company(order.company_id)
+            pending_section = None
+            invoice_vals = order._prepare_invoice()
+            for line in order.order_line:
+                if line.display_type in ("line_section", "line_subsection"):
+                    pending_section = line
+                    continue
+                if not float_is_zero(line.qty_to_invoice, precision_digits=precision):
+                    if pending_section:
+                        line_vals = pending_section._prepare_account_move_line()
+                        line_vals.update({"sequence": sequence})
+                        invoice_vals["invoice_line_ids"].append((0, 0, line_vals))
+                        sequence += 1
+                        pending_section = None
+                    line_vals = line._prepare_account_move_line()
+                    line_vals.update({"sequence": sequence})
+                    invoice_vals["invoice_line_ids"].append((0, 0, line_vals))
+                    sequence += 1
+            invoice_vals_list.append(invoice_vals)
+
+        new_invoice_vals_list = []
+        for _grouping_keys, invoices in groupby(
+            invoice_vals_list,
+            key=lambda x: (
+                x.get("company_id"),
+                x.get("partner_id"),
+                x.get("currency_id"),
+            ),
+        ):
+            origins = set()
+            ref_invoice_vals = None
+            for invoice_vals in invoices:
+                if not ref_invoice_vals:
+                    ref_invoice_vals = invoice_vals
+                else:
+                    ref_invoice_vals["invoice_line_ids"] += invoice_vals[
+                        "invoice_line_ids"
+                    ]
+                origins.add(invoice_vals["invoice_origin"])
+            ref_invoice_vals.update({"invoice_origin": ", ".join(origins)})
+            new_invoice_vals_list.append(ref_invoice_vals)
+        invoice_vals_list = new_invoice_vals_list
+
+        invoices = self.env["account.move"]
+        AccountMove = self.env["account.move"].with_context(
+            default_move_type="in_invoice"
+        )
+        for vals in invoice_vals_list:
+            invoices |= AccountMove.with_company(vals["company_id"]).create(vals)
+
+        invoices.filtered(
+            lambda m: m.currency_id.round(m.amount_total) < 0
+        ).action_switch_move_type()
+
+        attachments = self.env["ir.attachment"].browse(attachment_ids)
+        if not attachments:
+            return self.action_view_invoice(invoices)
+
+        if len(invoices) != 1:
+            raise ValidationError(
+                self.env._("You can only upload a bill for a single vendor at a time.")
+            )
+        invoices.with_context(skip_is_manually_modified=True)._extend_with_attachments(
+            invoices._to_files_data(attachments),
+            new=True,
+        )
+
+        invoices.message_post(attachment_ids=attachments.ids)
+
+        attachments.write({"res_model": "account.move", "res_id": invoices.id})
+        return self.action_view_invoice(invoices)

--- a/purchase_create_bill_button/tests/__init__.py
+++ b/purchase_create_bill_button/tests/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import test_purchase_order

--- a/purchase_create_bill_button/tests/test_purchase_order.py
+++ b/purchase_create_bill_button/tests/test_purchase_order.py
@@ -18,7 +18,7 @@ class TestPurchaseOrderCreateBill(TransactionCase):
                 "name": "Product A",
                 "type": "consu",
                 "is_storable": True,
-                "purchase_method": "received",
+                "purchase_method": "receive",
             }
         )
         cls.product_b = cls.env["product.product"].create(
@@ -26,7 +26,7 @@ class TestPurchaseOrderCreateBill(TransactionCase):
                 "name": "Product B",
                 "type": "consu",
                 "is_storable": True,
-                "purchase_method": "received",
+                "purchase_method": "receive",
             }
         )
 

--- a/purchase_create_bill_button/tests/test_purchase_order.py
+++ b/purchase_create_bill_button/tests/test_purchase_order.py
@@ -59,18 +59,29 @@ class TestPurchaseOrderCreateBill(TransactionCase):
         order.button_confirm()
         return order
 
-    def _receive_move(self, move, qty):
-        move_line_vals = move._prepare_move_line_vals()
-        move_line_vals["quantity"] = qty
-        self.env["stock.move.line"].create(move_line_vals)
+    def _validate_picking(self, picking):
+        result = picking.button_validate()
+        if isinstance(result, dict) and result.get("res_model") == (
+            "stock.backorder.confirmation"
+        ):
+            ctx = result["context"]
+            wizard = (
+                self.env["stock.backorder.confirmation"]
+                .with_context(**ctx)
+                .create({"pick_ids": ctx["default_pick_ids"]})
+            )
+            wizard.process_cancel_backorder()
 
     def test_bill_excludes_zero_qty_lines(self):
         """Lines with qty_to_invoice=0 must not appear in the bill."""
         order = self._create_po()
         picking = order.picking_ids
-        move_a = picking.move_ids.filtered(lambda m: m.product_id == self.product_a)
-        self._receive_move(move_a, 5)
-        picking.button_validate()
+        for move in picking.move_ids:
+            if move.product_id == self.product_a:
+                move.move_line_ids.write({"quantity": 5})
+            else:
+                move.move_line_ids.write({"quantity": 0})
+        self._validate_picking(picking)
 
         line_a = order.order_line.filtered(
             lambda line: line.product_id == self.product_a
@@ -93,8 +104,8 @@ class TestPurchaseOrderCreateBill(TransactionCase):
         order = self._create_po()
         picking = order.picking_ids
         for move in picking.move_ids:
-            self._receive_move(move, 10)
-        picking.button_validate()
+            move.move_line_ids.write({"quantity": 10})
+        self._validate_picking(picking)
 
         action = order.action_create_invoice()
         invoice = self.env["account.move"].browse(action["res_id"])

--- a/purchase_create_bill_button/tests/test_purchase_order.py
+++ b/purchase_create_bill_button/tests/test_purchase_order.py
@@ -30,7 +30,7 @@ class TestPurchaseOrderCreateBill(TransactionCase):
             }
         )
 
-    def _create_po_with_two_products(self):
+    def _create_po(self):
         order = self.env["purchase.order"].create(
             {
                 "partner_id": self.vendor.id,
@@ -59,29 +59,27 @@ class TestPurchaseOrderCreateBill(TransactionCase):
         order.button_confirm()
         return order
 
+    def _receive_move(self, move, qty):
+        move_line_vals = move._prepare_move_line_vals()
+        move_line_vals["quantity"] = qty
+        self.env["stock.move.line"].create(move_line_vals)
+
     def test_bill_excludes_zero_qty_lines(self):
         """Lines with qty_to_invoice=0 must not appear in the bill."""
-        order = self._create_po_with_two_products()
+        order = self._create_po()
         picking = order.picking_ids
-        # Receive only Product A (5 units), leave Product B at 0
-        for move in picking.move_ids:
-            if move.product_id == self.product_a:
-                move.quantity = 5
-            else:
-                move.quantity = 0
+        move_a = picking.move_ids.filtered(lambda m: m.product_id == self.product_a)
+        self._receive_move(move_a, 5)
         picking.button_validate()
 
-        self.assertEqual(order.invoice_status, "to invoice")
-        self.assertTrue(
-            order.order_line.filtered(
-                lambda line: line.product_id == self.product_a
-            ).qty_to_invoice,
+        line_a = order.order_line.filtered(
+            lambda line: line.product_id == self.product_a
         )
-        self.assertFalse(
-            order.order_line.filtered(
-                lambda line: line.product_id == self.product_b
-            ).qty_to_invoice,
+        line_b = order.order_line.filtered(
+            lambda line: line.product_id == self.product_b
         )
+        self.assertEqual(line_a.qty_to_invoice, 5)
+        self.assertEqual(line_b.qty_to_invoice, 0)
 
         action = order.action_create_invoice()
         invoice = self.env["account.move"].browse(action["res_id"])
@@ -92,13 +90,11 @@ class TestPurchaseOrderCreateBill(TransactionCase):
 
     def test_bill_includes_all_qty_to_invoice_lines(self):
         """When both products are received, both must appear in the bill."""
-        order = self._create_po_with_two_products()
+        order = self._create_po()
         picking = order.picking_ids
         for move in picking.move_ids:
-            move.quantity = 10
+            self._receive_move(move, 10)
         picking.button_validate()
-
-        self.assertEqual(order.invoice_status, "to invoice")
 
         action = order.action_create_invoice()
         invoice = self.env["account.move"].browse(action["res_id"])

--- a/purchase_create_bill_button/tests/test_purchase_order.py
+++ b/purchase_create_bill_button/tests/test_purchase_order.py
@@ -1,0 +1,106 @@
+# Copyright 2026 Juan Arcos MTS <j.arcos@madetosoft.com>
+# Copyright 2026 Oriol Gracia MTS <o.gracia@madetosoft.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("-at_install", "post_install")
+class TestPurchaseOrderCreateBill(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.vendor = cls.env["res.partner"].create(
+            {"name": "Test Vendor", "supplier_rank": 1}
+        )
+        cls.product_a = cls.env["product.product"].create(
+            {
+                "name": "Product A",
+                "type": "consu",
+                "is_storable": True,
+                "purchase_method": "received",
+            }
+        )
+        cls.product_b = cls.env["product.product"].create(
+            {
+                "name": "Product B",
+                "type": "consu",
+                "is_storable": True,
+                "purchase_method": "received",
+            }
+        )
+
+    def _create_po_with_two_products(self):
+        order = self.env["purchase.order"].create(
+            {
+                "partner_id": self.vendor.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product_a.id,
+                            "product_qty": 10,
+                            "price_unit": 100,
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product_b.id,
+                            "product_qty": 10,
+                            "price_unit": 200,
+                        },
+                    ),
+                ],
+            }
+        )
+        order.button_confirm()
+        return order
+
+    def test_bill_excludes_zero_qty_lines(self):
+        """Lines with qty_to_invoice=0 must not appear in the bill."""
+        order = self._create_po_with_two_products()
+        picking = order.picking_ids
+        # Receive only Product A (5 units), leave Product B at 0
+        for move in picking.move_ids:
+            if move.product_id == self.product_a:
+                move.quantity = 5
+            else:
+                move.quantity = 0
+        picking.button_validate()
+
+        self.assertEqual(order.invoice_status, "to invoice")
+        self.assertTrue(
+            order.order_line.filtered(
+                lambda line: line.product_id == self.product_a
+            ).qty_to_invoice,
+        )
+        self.assertFalse(
+            order.order_line.filtered(
+                lambda line: line.product_id == self.product_b
+            ).qty_to_invoice,
+        )
+
+        action = order.action_create_invoice()
+        invoice = self.env["account.move"].browse(action["res_id"])
+
+        invoice_product_ids = invoice.invoice_line_ids.mapped("product_id")
+        self.assertIn(self.product_a, invoice_product_ids)
+        self.assertNotIn(self.product_b, invoice_product_ids)
+
+    def test_bill_includes_all_qty_to_invoice_lines(self):
+        """When both products are received, both must appear in the bill."""
+        order = self._create_po_with_two_products()
+        picking = order.picking_ids
+        for move in picking.move_ids:
+            move.quantity = 10
+        picking.button_validate()
+
+        self.assertEqual(order.invoice_status, "to invoice")
+
+        action = order.action_create_invoice()
+        invoice = self.env["account.move"].browse(action["res_id"])
+
+        self.assertEqual(len(invoice.invoice_line_ids), 2)


### PR DESCRIPTION
When using 'Received Quantities' billing policy, clicking 'Create Bill' added all purchase order lines to the bill, including those with qty_to_invoice = 0. This is a regression in Odoo v19 core's action_create_invoice method that removed the float_is_zero check present in v18.

Override action_create_invoice to restore the v18 filtering behavior, ensuring only lines with pending quantities are included in the bill.