### PR TITLE
[19.0][REF] account_billing: rename _compute_tax_totals to _compute_amount

### DIFF
--- a/account_billing/models/account_billing.py
+++ b/account_billing/models/account_billing.py
@@ -102,17 +102,17 @@ class AccountBilling(models.Model):
     )
     amount_untaxed = fields.Monetary(
         string="Untaxed Amount",
-        compute="_compute_tax_totals",
+        compute="_compute_amount",
         store=True,
     )
     amount_tax = fields.Monetary(
         string="Tax Amount",
-        compute="_compute_tax_totals",
+        compute="_compute_amount",
         store=True,
     )
     amount_total = fields.Monetary(
         string="Total Amount",
-        compute="_compute_tax_totals",
+        compute="_compute_amount",
         store=True,
     )
     amount_due = fields.Monetary(
@@ -162,7 +162,7 @@ class AccountBilling(models.Model):
     @api.depends(
         "billing_line_ids.move_id.amount_untaxed", "billing_line_ids.move_id.amount_tax"
     )
-    def _compute_tax_totals(self):
+    def _compute_amount(self):
         for bill in self:
             bill.amount_untaxed = 0.0
             bill.amount_tax = 0.0


### PR DESCRIPTION
Forward port of https://github.com/OCA/account-invoicing/pull/2439/changes/2f745bea4a589e94e0aa3aebacd4d12fab3259f0

The method computes `amount_untaxed`, `amount_tax` and `amount_total`, and the model has no `tax_totals` field at all, so the name is misleading: everywhere else in Odoo (`account.move`, `sale.order`, `purchase.order`) `_compute_tax_totals` is the compute of a `tax_totals` field, and `_compute_amount` is the one computing the amounts.

Beyond the naming, it also squats the name a module adding an actual `tax_totals` field needs. `l10n_jp_summary_invoice` does exactly that, and currently has to redeclare the three amount fields only to move them off the compute it needs to override.

Assisted-by: Claude Opus 5

@qrtl QT7203