### PR TITLE
[IMP] account_invoice_transmit_method: disable forcecreate

### DIFF
--- a/account_invoice_transmit_method/data/transmit_method.xml
+++ b/account_invoice_transmit_method/data/transmit_method.xml
@@ -5,15 +5,15 @@
   License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 -->
 <odoo noupdate="1">
-    <record id="mail" model="transmit.method">
+    <record id="mail" model="transmit.method" forcecreate="0">
         <field name="code">mail</field>
         <field name="name">E-Mail</field>
     </record>
-    <record id="post" model="transmit.method">
+    <record id="post" model="transmit.method" forcecreate="0">
         <field name="code">post</field>
         <field name="name">Post</field>
     </record>
-    <record id="portal" model="transmit.method">
+    <record id="portal" model="transmit.method" forcecreate="0">
         <field name="code">portal</field>
         <field name="name">Customer Portal</field>
     </record>


### PR DESCRIPTION
If the default transmit method records are deleted, prevent recreating them by disabling the forcecreate