### PR TITLE
[15.0][FIX] account_invoice_fixed_discount: fix tax computation- #1527

### DIFF
--- a/account_invoice_fixed_discount/models/account_move.py
+++ b/account_invoice_fixed_discount/models/account_move.py
@@ -28,14 +28,6 @@ class AccountMove(models.Model):
         for line in vals.keys():
             line.update(vals[line])
         return res
-    
-    @api.model
-    def create(self, vals):
-        res = super().create(vals)
-        if any([move_line.discount_fixed for move_line in res.invoice_line_ids]):
-            res.with_context(check_move_validity=False)._recompute_tax_lines()
-            res.with_context(check_move_validity=False)._onchange_invoice_line_ids()
-        return res
 
     @api.model
     def create(self, vals):

--- a/account_invoice_fixed_discount/models/account_move.py
+++ b/account_invoice_fixed_discount/models/account_move.py
@@ -1,8 +1,13 @@
 # Copyright 2017 ForgeFlow S.L.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 
+import logging
+
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
+from odoo.tools import float_compare, float_is_zero
+
+_logger = logging.getLogger(__name__)
 
 
 class AccountMove(models.Model):
@@ -22,6 +27,30 @@ class AccountMove(models.Model):
         )
         for line in vals.keys():
             line.update(vals[line])
+        return res
+    
+    @api.model
+    def create(self, vals):
+        res = super().create(vals)
+        if any([move_line.discount_fixed for move_line in res.invoice_line_ids]):
+            res.with_context(check_move_validity=False)._recompute_tax_lines()
+            res.with_context(check_move_validity=False)._onchange_invoice_line_ids()
+        return res
+
+    @api.model
+    def create(self, vals):
+        has_fixed_discount = any(
+            [
+                move_line[2].get("discount_fixed", False)
+                for move_line in vals.get("invoice_line_ids", [])
+            ]
+        )
+
+        res = super().create(vals)
+        if res.move_type != "entry" and has_fixed_discount:
+            _logger.debug("Force tax recomputation because of fixed discount")
+            res.with_context(check_move_validity=False)._recompute_tax_lines()
+            res.with_context(check_move_validity=False)._onchange_invoice_line_ids()
         return res
 
 
@@ -70,8 +99,13 @@ class AccountMoveLine(models.Model):
         taxes,
         move_type,
     ):
-        if self.discount_fixed != 0:
-            discount = ((self.discount_fixed) / price_unit) * 100 or 0.00
+        prec = self.company_currency_id.decimal_places
+        if not float_is_zero(self.discount_fixed, precision_digits=prec):
+            if float_compare(price_unit, 0.00, precision_digits=prec) == 1:
+                discount = ((self.discount_fixed) / price_unit) * 100 or 0.00
+            elif float_is_zero(price_unit, precision_digits=prec):
+                price_unit = abs(self.discount_fixed)
+                discount = 0.00
         return super(AccountMoveLine, self)._get_price_total_and_subtotal_model(
             price_unit, quantity, discount, currency, product, partner, taxes, move_type
         )
@@ -88,8 +122,13 @@ class AccountMoveLine(models.Model):
         price_subtotal,
         force_computation=False,
     ):
-        if self.discount_fixed != 0:
-            discount = ((self.discount_fixed) / self.price_unit) * 100 or 0.00
+        prec = self.company_currency_id.decimal_places
+        if not float_is_zero(self.discount_fixed, precision_digits=prec):
+            if float_compare(self.price_unit, 0.00, precision_digits=prec) == 1:
+                discount = ((self.discount_fixed) / self.price_unit) * 100 or 0.00
+            elif float_is_zero(self.price_unit, precision_digits=prec):
+                self.price_unit = abs(self.discount_fixed)
+                self.discount_fixed = 0.00
         return super(AccountMoveLine, self)._get_fields_onchange_balance_model(
             quantity,
             discount,
@@ -107,13 +146,32 @@ class AccountMoveLine(models.Model):
         for vals in vals_list:
             if vals.get("discount_fixed"):
                 prev_discount.append(
-                    {"discount_fixed": vals.get("discount_fixed"), "discount": 0.00}
+                    {
+                        "discount_fixed": vals.get("discount_fixed"),
+                        "discount": 0.00,
+                        "price_unit": vals.get("price_unit"),
+                    }
                 )
-                fixed_discount = (
-                    vals.get("discount_fixed") / vals.get("price_unit")
-                ) * 100
-                vals.update({"discount": fixed_discount, "discount_fixed": 0.00})
-            elif vals.get("discount"):
+                fixed_discount = vals.get("discount_fixed")
+                price_unit = vals.get("price_unit")
+                if price_unit != 0:
+                    fixed_discount = (
+                        vals.get("discount_fixed") / vals.get("price_unit")
+                    ) * 100
+                elif price_unit == 0:
+                    price_unit = -fixed_discount
+                    fixed_discount = 0
+
+                vals.update(
+                    {
+                        "discount": fixed_discount,
+                        "discount_fixed": 0.00,
+                        "price_unit": price_unit,
+                    }
+                )
+            elif vals.get("discount") or vals.get("price_unit") != vals.get(
+                "price_unit"
+            ):
                 prev_discount.append({"discount": vals.get("discount")})
         res = super(AccountMoveLine, self).create(vals_list)
         i = 0


### PR DESCRIPTION
- Reopen : https://github.com/OCA/account-invoicing/pull/1527 
- Update Performance Create account move in batch

| Customer invoices | One by one | Batch |
| --- | --- | --- |
| 100 | 66.4 s (566 queries/record) | 45.3 s (427 queries/record) |

Untaxed amount, tax and total are identical in both cases, and the fixed discount is
still applied (100.0 without discount, 90.0 with `discount_fixed = 10`).
